### PR TITLE
feat: export a reusable HTTP conformance harness runner

### DIFF
--- a/sdks/ts/memory/README.md
+++ b/sdks/ts/memory/README.md
@@ -31,6 +31,28 @@ The published `memory` binary runs on Node 20+ (its shebang is `#!/usr/bin/env n
 - Cross-SDK daemon scenarios: `ask-basic`, `ask-augmented`, `search-retrieve-only`.
 - CLI: `memory init|ingest|search|extract|reflect|consolidate|eval|serve|acl|git`.
 
+## Conformance runner
+
+```ts
+import { runConformanceSuite } from '@jeffs-brain/memory/conformance'
+
+const result = await runConformanceSuite({
+  baseUrl: 'http://127.0.0.1:18844/v1',
+  authToken: process.env.JB_AUTH_TOKEN,
+})
+
+if (result.failed > 0) {
+  throw new Error(
+    result.cases
+      .filter((testCase) => !testCase.ok)
+      .map((testCase) => `${testCase.name}: ${testCase.error}`)
+      .join('\n'),
+  )
+}
+```
+
+The runner packages the shared `spec/conformance/http-contract.json` fixture, provisions an isolated brain per case, replays the full HTTP store contract, and deletes every test brain afterwards.
+
 ## Embedded usage
 
 ```ts

--- a/sdks/ts/memory/package.json
+++ b/sdks/ts/memory/package.json
@@ -38,6 +38,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./conformance": {
+      "import": "./dist/conformance/index.js",
+      "types": "./dist/conformance/index.d.ts"
+    },
     "./store": {
       "import": "./dist/store/index.js",
       "types": "./dist/store/index.d.ts"
@@ -98,7 +102,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node ./scripts/copy-conformance-fixture.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "prepublishOnly": "bun run typecheck && bun run test && bun run build"

--- a/sdks/ts/memory/scripts/copy-conformance-fixture.mjs
+++ b/sdks/ts/memory/scripts/copy-conformance-fixture.mjs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { copyFile, mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const packageDir = resolve(here, '..')
+const source = resolve(packageDir, '../../../spec/conformance/http-contract.json')
+const target = resolve(packageDir, 'dist/conformance/http-contract.json')
+
+await mkdir(dirname(target), { recursive: true })
+await copyFile(source, target)

--- a/sdks/ts/memory/src/conformance/index.test.ts
+++ b/sdks/ts/memory/src/conformance/index.test.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { type Server, createServer as createNodeServer } from 'node:http'
+import {
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+  createServer as createNodeServer,
+} from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -18,9 +23,8 @@ type CustomFixtureDocument = {
 
 type Fixture = {
   readonly server: Server
-  readonly daemon: Daemon
-  readonly tempDir: string
   readonly baseUrl: string
+  cleanup(): Promise<void>
 }
 
 let fixtures: Fixture[] = []
@@ -53,9 +57,188 @@ const startFixture = async (authToken?: string): Promise<Fixture> => {
 
   const fixture: Fixture = {
     server,
-    daemon,
-    tempDir,
     baseUrl: `http://${hostname}:${address.port}`,
+    cleanup: async (): Promise<void> => {
+      await new Promise<void>((resolve) => {
+        fixture.server.close(() => resolve())
+        fixture.server.closeAllConnections?.()
+      })
+      await daemon.close()
+      await rm(tempDir, { recursive: true, force: true })
+    },
+  }
+  fixtures.push(fixture)
+  return fixture
+}
+
+type CustomServerOptions = {
+  readonly connectDelayMs?: number
+  readonly readyEventDelayMs?: number
+}
+
+const startCustomFixture = async (options: CustomServerOptions = {}): Promise<Fixture> => {
+  const hostname = '127.0.0.1'
+  const brains = new Set<string>()
+  const subscribers = new Map<string, Set<ServerResponse<IncomingMessage>>>()
+  const timers = new Set<ReturnType<typeof setTimeout>>()
+
+  const removeSubscriber = (brainId: string, response: ServerResponse<IncomingMessage>): void => {
+    const brainSubscribers = subscribers.get(brainId)
+    if (brainSubscribers === undefined) return
+    brainSubscribers.delete(response)
+    if (brainSubscribers.size === 0) {
+      subscribers.delete(brainId)
+    }
+  }
+
+  const sendJson = (
+    response: ServerResponse<IncomingMessage>,
+    status: number,
+    body: unknown,
+  ): void => {
+    response.writeHead(status, { 'content-type': 'application/json' })
+    response.end(JSON.stringify(body))
+  }
+
+  const server = createNodeServer(async (request, response) => {
+    const url = new URL(request.url ?? '/', `http://${hostname}`)
+    const pathname = url.pathname
+
+    if (request.method === 'GET' && pathname === '/v1/brains') {
+      sendJson(response, 200, {
+        items: [...brains].sort().map((brainId) => ({ brainId })),
+      })
+      return
+    }
+
+    if (request.method === 'POST' && pathname === '/v1/brains') {
+      const chunks: Uint8Array[] = []
+      for await (const chunk of request) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+      }
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { brainId?: string }
+      if (typeof body.brainId !== 'string' || body.brainId === '') {
+        response.writeHead(400)
+        response.end()
+        return
+      }
+      brains.add(body.brainId)
+      response.writeHead(201)
+      response.end()
+      return
+    }
+
+    const brainMatch = pathname.match(/^\/v1\/brains\/([^/]+)(?:\/(.*))?$/)
+    if (brainMatch === null) {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+
+    const brainId = decodeURIComponent(brainMatch[1] ?? '')
+    const suffix = brainMatch[2] ?? ''
+
+    if (request.method === 'DELETE' && suffix === '') {
+      brains.delete(brainId)
+      for (const subscriber of subscribers.get(brainId) ?? []) {
+        subscriber.end()
+      }
+      subscribers.delete(brainId)
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    if (!brains.has(brainId)) {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+
+    if (request.method === 'PUT' && suffix === 'documents') {
+      const path = url.searchParams.get('path') ?? ''
+      response.writeHead(204)
+      response.end()
+
+      if (path !== '') {
+        for (const subscriber of subscribers.get(brainId) ?? []) {
+          subscriber.write(`event: change\ndata: ${JSON.stringify({ kind: 'created', path })}\n\n`)
+        }
+      }
+      return
+    }
+
+    if (request.method === 'GET' && suffix === 'events') {
+      const connectTimer = setTimeout(() => {
+        timers.delete(connectTimer)
+        if (response.writableEnded) return
+
+        response.writeHead(200, {
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+          'content-type': 'text/event-stream',
+        })
+        response.flushHeaders()
+        const brainSubscribers = subscribers.get(brainId) ?? new Set()
+        brainSubscribers.add(response)
+        subscribers.set(brainId, brainSubscribers)
+
+        if (options.readyEventDelayMs !== undefined) {
+          const readyTimer = setTimeout(() => {
+            timers.delete(readyTimer)
+            if (!response.writableEnded) {
+              response.write('event: ready\ndata: {}\n\n')
+            }
+          }, options.readyEventDelayMs)
+          timers.add(readyTimer)
+        }
+      }, options.connectDelayMs ?? 0)
+      timers.add(connectTimer)
+
+      const close = (): void => {
+        clearTimeout(connectTimer)
+        timers.delete(connectTimer)
+        removeSubscriber(brainId, response)
+      }
+      response.on('close', close)
+      return
+    }
+
+    response.writeHead(404)
+    response.end()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, hostname, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address()
+  if (address === null || typeof address === 'string') {
+    throw new Error('conformance test: custom server.address() returned no port')
+  }
+
+  const fixture: Fixture = {
+    server,
+    baseUrl: `http://${hostname}:${address.port}`,
+    cleanup: async (): Promise<void> => {
+      for (const timer of timers) {
+        clearTimeout(timer)
+      }
+      timers.clear()
+      for (const brainSubscribers of subscribers.values()) {
+        for (const subscriber of brainSubscribers) {
+          subscriber.end()
+        }
+      }
+      await new Promise<void>((resolve) => {
+        fixture.server.close(() => resolve())
+        fixture.server.closeAllConnections?.()
+      })
+    },
   }
   fixtures.push(fixture)
   return fixture
@@ -98,9 +281,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   for (const fixture of fixtures) {
-    await new Promise<void>((resolve) => fixture.server.close(() => resolve()))
-    await fixture.daemon.close()
-    await rm(fixture.tempDir, { recursive: true, force: true })
+    await fixture.cleanup()
   }
   fixtures = []
 })
@@ -184,6 +365,100 @@ describe('runConformanceSuite', () => {
       expect(result.failed).toBe(1)
       expect(result.cases[0]?.ok).toBe(false)
       expect(result.cases[0]?.error).toContain('field "items"')
+      expect(await listBrains(fixture.baseUrl)).toEqual([])
+    } finally {
+      await rm(dirname(fixturePath), { recursive: true, force: true })
+    }
+  })
+
+  it('observes delayed SSE events without dropping chunks while polling', async () => {
+    const fixture = await startCustomFixture({ readyEventDelayMs: 350 })
+    const fixturePath = await writeCustomFixture({
+      placeholders: {},
+      cases: [
+        {
+          name: 'delayed ready event',
+          request: {
+            method: 'GET',
+            path: '/v1/brains/BRAIN_ID/events',
+            headers: {
+              accept: 'text/event-stream',
+            },
+          },
+          expectedResponse: {
+            status: 200,
+            streamAssertions: [{ kind: 'expect-event', event: 'ready' }],
+          },
+        },
+      ],
+    })
+
+    try {
+      const result = await runConformanceSuite({
+        baseUrl: fixture.baseUrl,
+        fixturePath,
+        sseTimeoutMs: 1_000,
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.passed).toBe(1)
+      expect(result.failed).toBe(0)
+      assertSuitePassed(result)
+      expect(await listBrains(fixture.baseUrl)).toEqual([])
+    } finally {
+      await rm(dirname(fixturePath), { recursive: true, force: true })
+    }
+  })
+
+  it('waits for the SSE subscription handshake before follow-up steps run', async () => {
+    const fixture = await startCustomFixture({ connectDelayMs: 150 })
+    const fixturePath = await writeCustomFixture({
+      placeholders: {},
+      cases: [
+        {
+          name: 'open-sse waits for handshake',
+          setup: [
+            {
+              kind: 'open-sse',
+              name: 'watcher',
+              path: '/v1/brains/BRAIN_ID/events',
+            },
+          ],
+          request: {
+            method: 'PUT',
+            path: '/v1/brains/BRAIN_ID/documents?path=memory%2Fa.md',
+            bodyBase64: 'YQ==',
+          },
+          expectedResponse: {
+            status: 204,
+          },
+          followUp: [
+            {
+              kind: 'await-sse-event',
+              name: 'watcher',
+              event: 'change',
+            },
+          ],
+          teardown: [
+            {
+              kind: 'close-sse',
+              name: 'watcher',
+            },
+          ],
+        },
+      ],
+    })
+
+    try {
+      const result = await runConformanceSuite({
+        baseUrl: fixture.baseUrl,
+        fixturePath,
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.passed).toBe(1)
+      expect(result.failed).toBe(0)
+      assertSuitePassed(result)
       expect(await listBrains(fixture.baseUrl)).toEqual([])
     } finally {
       await rm(dirname(fixturePath), { recursive: true, force: true })

--- a/sdks/ts/memory/src/conformance/index.test.ts
+++ b/sdks/ts/memory/src/conformance/index.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { type Server, createServer as createNodeServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { handleNodeRequest } from '../cli/commands/serve.js'
+import { Daemon, createRouter } from '../http/index.js'
+
+import { runConformanceSuite } from './index.js'
+
+type CustomFixtureDocument = {
+  readonly placeholders: Readonly<Record<string, string>>
+  readonly cases: ReadonlyArray<Record<string, unknown>>
+}
+
+type Fixture = {
+  readonly server: Server
+  readonly daemon: Daemon
+  readonly tempDir: string
+  readonly baseUrl: string
+}
+
+let fixtures: Fixture[] = []
+
+const startFixture = async (authToken?: string): Promise<Fixture> => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'memory-conformance-'))
+  const hostname = '127.0.0.1'
+  const daemon = new Daemon({
+    root: tempDir,
+    ...(authToken !== undefined ? { authToken } : {}),
+  })
+  await daemon.start()
+  const router = createRouter(daemon)
+
+  const server = createNodeServer((request, response) => {
+    void handleNodeRequest(router, hostname, 0, request, response)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, hostname, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  const address = server.address()
+  if (address === null || typeof address === 'string') {
+    throw new Error('conformance test: server.address() returned no port')
+  }
+
+  const fixture: Fixture = {
+    server,
+    daemon,
+    tempDir,
+    baseUrl: `http://${hostname}:${address.port}`,
+  }
+  fixtures.push(fixture)
+  return fixture
+}
+
+const writeCustomFixture = async (document: CustomFixtureDocument): Promise<string> => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'memory-conformance-fixture-'))
+  const path = join(tempDir, 'http-contract.json')
+  await writeFile(path, JSON.stringify(document), 'utf8')
+  return path
+}
+
+const listBrains = async (baseUrl: string, authToken?: string): Promise<readonly string[]> => {
+  const response = await fetch(`${baseUrl}/v1/brains`, {
+    headers:
+      authToken === undefined
+        ? undefined
+        : {
+            authorization: `Bearer ${authToken}`,
+          },
+  })
+  expect(response.status).toBe(200)
+  const body = (await response.json()) as { items: Array<{ brainId: string }> }
+  return body.items.map((item) => item.brainId)
+}
+
+const assertSuitePassed = (result: Awaited<ReturnType<typeof runConformanceSuite>>): void => {
+  if (result.failed > 0) {
+    const details = result.cases
+      .filter((testCase) => !testCase.ok)
+      .map((testCase) => `${testCase.name}: ${testCase.error ?? 'unknown error'}`)
+      .join('\n')
+    throw new Error(`conformance suite failed:\n${details}`)
+  }
+}
+
+beforeEach(() => {
+  fixtures = []
+})
+
+afterEach(async () => {
+  for (const fixture of fixtures) {
+    await new Promise<void>((resolve) => fixture.server.close(() => resolve()))
+    await fixture.daemon.close()
+    await rm(fixture.tempDir, { recursive: true, force: true })
+  }
+  fixtures = []
+})
+
+describe('runConformanceSuite', () => {
+  it('replays the shared fixture against an unauthenticated daemon and cleans up every brain', async () => {
+    const fixture = await startFixture()
+
+    const result = await runConformanceSuite({
+      baseUrl: fixture.baseUrl,
+    })
+
+    expect(result.total).toBeGreaterThanOrEqual(29)
+    expect(result.passed).toBe(result.total)
+    expect(result.failed).toBe(0)
+    assertSuitePassed(result)
+    expect(await listBrains(fixture.baseUrl)).toEqual([])
+  })
+
+  it('replays the shared fixture against an authenticated daemon when baseUrl includes /v1', async () => {
+    const authToken = 'test-token'
+    const fixture = await startFixture(authToken)
+
+    const result = await runConformanceSuite({
+      baseUrl: `${fixture.baseUrl}/v1`,
+      authToken,
+    })
+
+    expect(result.total).toBeGreaterThanOrEqual(29)
+    expect(result.passed).toBe(result.total)
+    expect(result.failed).toBe(0)
+    expect(
+      result.cases.find((testCase) => testCase.name === 'auth header forwarded when apiKey is set')
+        ?.ok,
+    ).toBe(true)
+    assertSuitePassed(result)
+    expect(await listBrains(fixture.baseUrl, authToken)).toEqual([])
+  })
+
+  it('treats json-field-equals as exact equality for the selected field value', async () => {
+    const fixture = await startFixture()
+    const fixturePath = await writeCustomFixture({
+      placeholders: {},
+      cases: [
+        {
+          name: 'json-field-equals exact field match',
+          setup: [
+            {
+              method: 'PUT',
+              path: '/v1/brains/BRAIN_ID/documents?path=memory%2Fa.md',
+              bodyBase64: 'YQ==',
+              expectedStatus: 204,
+            },
+          ],
+          request: {
+            method: 'GET',
+            path: '/v1/brains/BRAIN_ID/documents?dir=memory&recursive=true&include_generated=false',
+          },
+          expectedResponse: {
+            status: 200,
+            bodyAssertions: [
+              {
+                kind: 'json-field-equals',
+                field: 'items',
+                value: [{ path: 'memory/a.md' }],
+              },
+            ],
+          },
+        },
+      ],
+    })
+
+    try {
+      const result = await runConformanceSuite({
+        baseUrl: fixture.baseUrl,
+        fixturePath,
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.passed).toBe(0)
+      expect(result.failed).toBe(1)
+      expect(result.cases[0]?.ok).toBe(false)
+      expect(result.cases[0]?.error).toContain('field "items"')
+      expect(await listBrains(fixture.baseUrl)).toEqual([])
+    } finally {
+      await rm(dirname(fixturePath), { recursive: true, force: true })
+    }
+  })
+})

--- a/sdks/ts/memory/src/conformance/index.ts
+++ b/sdks/ts/memory/src/conformance/index.ts
@@ -96,6 +96,7 @@ type SseWaiter = {
 }
 
 type SseSubscriber = {
+  readonly ready: Promise<void>
   waitFor(event: string, timeoutMs?: number): Promise<string>
   close(): Promise<void>
 }
@@ -453,16 +454,22 @@ const assertStreamAssertions = async (
   const decoder = new TextDecoder('utf-8')
   const parser = new SSEParser()
   const deadline = Date.now() + timeoutMs
+  let readPromise: ReturnType<typeof reader.read> | undefined = reader.read()
   try {
     while (seen.size < wanted.size && Date.now() < deadline) {
       const remaining = Math.max(1, deadline - Date.now())
+      if (readPromise === undefined) {
+        readPromise = reader.read()
+      }
+      const pendingRead = readPromise
       const outcome = await Promise.race([
-        reader.read(),
+        pendingRead,
         new Promise<{ readonly timedOut: true }>((resolve) => {
           setTimeout(() => resolve({ timedOut: true }), Math.min(remaining, 200))
         }),
       ])
       if ('timedOut' in outcome) continue
+      readPromise = undefined
       if (outcome.done) {
         for (const event of parser.flush()) {
           if (wanted.has(event.event)) {
@@ -481,6 +488,7 @@ const assertStreamAssertions = async (
     }
   } finally {
     await reader.cancel().catch(() => undefined)
+    await readPromise?.catch(() => undefined)
     reader.releaseLock()
   }
 
@@ -540,11 +548,36 @@ const assertEventPayload = (rawExpected: ConformanceExpectedResponse, payload: s
   }
 }
 
-const createSseSubscriber = (url: string, headers: Headers): SseSubscriber => {
+const createSseSubscriber = (
+  url: string,
+  headers: Headers,
+  readyTimeoutMs: number,
+): SseSubscriber => {
   const controller = new AbortController()
   const events: SSEEvent[] = []
   const waiters = new Map<string, SseWaiter[]>()
   let terminalError: Error | undefined
+  let readySettled = false
+  let resolveReady = (): void => undefined
+  let rejectReady = (_error: Error): void => undefined
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = (): void => {
+      if (readySettled) return
+      readySettled = true
+      resolve()
+    }
+    rejectReady = (error: Error): void => {
+      if (readySettled) return
+      readySettled = true
+      reject(error)
+    }
+  })
+
+  const settleTerminalError = (error: Error): void => {
+    terminalError = error
+    rejectReady(error)
+    rejectWaiters(error)
+  }
 
   const rejectWaiters = (error: Error): void => {
     for (const [event, pending] of waiters.entries()) {
@@ -567,6 +600,10 @@ const createSseSubscriber = (url: string, headers: Headers): SseSubscriber => {
   }
 
   const run = (async (): Promise<void> => {
+    const readyTimer = setTimeout(() => {
+      controller.abort()
+      settleTerminalError(new Error(`SSE subscribe timed out after ${readyTimeoutMs} ms`))
+    }, readyTimeoutMs)
     try {
       const response = await fetch(url, {
         method: 'GET',
@@ -579,22 +616,24 @@ const createSseSubscriber = (url: string, headers: Headers): SseSubscriber => {
       if (response.body === null) {
         throw new Error('SSE subscribe failed: response body missing')
       }
+      clearTimeout(readyTimer)
+      resolveReady()
       for await (const event of iterateSSE(response.body)) {
         events.push(event)
         resolveWaiters(event)
       }
       if (!controller.signal.aborted) {
-        terminalError = new Error('SSE stream closed before the case finished')
-        rejectWaiters(terminalError)
+        settleTerminalError(new Error('SSE stream closed before the case finished'))
       }
     } catch (error) {
+      clearTimeout(readyTimer)
       if (controller.signal.aborted) return
-      terminalError = asError(error)
-      rejectWaiters(terminalError)
+      settleTerminalError(asError(error))
     }
   })()
 
   return {
+    ready,
     waitFor: async (eventName: string, timeoutMs = DEFAULT_SSE_TIMEOUT_MS): Promise<string> => {
       const existing = events.find((event) => event.event === eventName)
       if (existing !== undefined) return existing.data
@@ -621,6 +660,7 @@ const createSseSubscriber = (url: string, headers: Headers): SseSubscriber => {
     },
     close: async (): Promise<void> => {
       controller.abort()
+      rejectReady(new Error('SSE subscriber closed'))
       rejectWaiters(new Error('SSE subscriber closed'))
       await run.catch(() => undefined)
     },
@@ -680,10 +720,18 @@ const runStep = async (rawStep: ConformanceStep, context: RunCaseContext): Promi
         context.substitute,
         context.authToken,
       )
-      context.ssePool.set(
-        name,
-        createSseSubscriber(resolveRequestUrl(context.baseUrl, path), headers),
+      const subscriber = createSseSubscriber(
+        resolveRequestUrl(context.baseUrl, path),
+        headers,
+        context.requestTimeoutMs,
       )
+      try {
+        await subscriber.ready
+      } catch (error) {
+        await subscriber.close().catch(() => undefined)
+        throw error
+      }
+      context.ssePool.set(name, subscriber)
       return
     }
     case 'await-sse-event': {

--- a/sdks/ts/memory/src/conformance/index.ts
+++ b/sdks/ts/memory/src/conformance/index.ts
@@ -1,0 +1,988 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reusable HTTP conformance runner for `memory serve`.
+ *
+ * Loads the shared `spec/conformance/http-contract.json` fixture,
+ * provisions an isolated brain per case, replays every documented
+ * request against a remote daemon, and returns a pass/fail report.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { access, readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { isDeepStrictEqual } from 'node:util'
+
+import { type SSEEvent, SSEParser, iterateSSE } from '../llm/sse.js'
+
+export type ConformanceBodyAssertion =
+  | { readonly kind: 'items-include-path'; readonly path: string }
+  | { readonly kind: 'items-exclude-path'; readonly path: string }
+  | { readonly kind: 'items-files-equal'; readonly paths: readonly string[] }
+  | { readonly kind: 'items-dirs-equal'; readonly paths: readonly string[] }
+  | { readonly kind: 'json-field-equals'; readonly field: string; readonly value: unknown }
+  | ({ readonly kind: string } & Readonly<Record<string, unknown>>)
+
+export type ConformanceStreamAssertion =
+  | { readonly kind: 'expect-event'; readonly event: string }
+  | ({ readonly kind: string } & Readonly<Record<string, unknown>>)
+
+export type ConformanceStep = {
+  readonly kind?: string
+  readonly name?: string
+  readonly method?: string
+  readonly path?: string
+  readonly headers?: Readonly<Record<string, string>>
+  readonly bodyBase64?: string
+  readonly bodyJson?: unknown
+  readonly event?: string
+  readonly expectedStatus?: number
+  readonly expectedBodyBase64?: string
+}
+
+export type ConformanceExpectedResponse = {
+  readonly status?: number
+  readonly contentType?: string
+  readonly bodyBase64?: string
+  readonly body?: unknown
+  readonly bodyAssertions?: readonly ConformanceBodyAssertion[]
+  readonly streamAssertions?: readonly ConformanceStreamAssertion[]
+}
+
+export type ConformanceCase = {
+  readonly name: string
+  readonly notes?: string
+  readonly setup?: readonly ConformanceStep[]
+  readonly request: ConformanceStep
+  readonly expectedResponse: ConformanceExpectedResponse
+  readonly followUp?: readonly ConformanceStep[]
+  readonly teardown?: readonly ConformanceStep[]
+}
+
+export type ConformanceDocument = {
+  readonly description?: string
+  readonly placeholders: Readonly<Record<string, string>>
+  readonly cases: readonly ConformanceCase[]
+}
+
+export type RunConformanceSuiteOptions = {
+  readonly baseUrl: string
+  readonly authToken?: string
+  readonly fixturePath?: string
+  readonly brainIdPrefix?: string
+  readonly requestTimeoutMs?: number
+  readonly sseTimeoutMs?: number
+}
+
+export type ConformanceCaseResult = {
+  readonly name: string
+  readonly brainId: string
+  readonly ok: boolean
+  readonly error?: string
+}
+
+export type ConformanceSuiteResult = {
+  readonly total: number
+  readonly passed: number
+  readonly failed: number
+  readonly cases: readonly ConformanceCaseResult[]
+}
+
+type SseWaiter = {
+  readonly resolve: (value: string) => void
+  readonly reject: (error: Error) => void
+  readonly timer: ReturnType<typeof setTimeout>
+}
+
+type SseSubscriber = {
+  waitFor(event: string, timeoutMs?: number): Promise<string>
+  close(): Promise<void>
+}
+
+type FetchResponse = Awaited<ReturnType<typeof fetch>>
+type ResponseLike = {
+  readonly status: number
+  readonly headers: { get(name: string): string | null }
+  readonly body: ReadableStream<Uint8Array> | null
+  clone(): ResponseLike
+  text(): Promise<string>
+  arrayBuffer(): Promise<ArrayBuffer>
+}
+
+type RunCaseContext = {
+  readonly baseUrl: URL
+  readonly authToken: string | undefined
+  readonly requestTimeoutMs: number
+  readonly sseTimeoutMs: number
+  readonly substitute: (value: string) => string
+  readonly ssePool: Map<string, SseSubscriber>
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000
+const DEFAULT_SSE_TIMEOUT_MS = 3_000
+const DEFAULT_BRAIN_ID_PREFIX = 'jb-conformance'
+const DIST_FIXTURE_FILENAME = 'http-contract.json'
+const REPO_FIXTURE_RELATIVE_PATH = ['spec', 'conformance', 'http-contract.json'] as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined
+
+const formatValue = (value: unknown): string => {
+  if (value === undefined) return 'undefined'
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+const normaliseBaseUrl = (raw: string): URL => {
+  const url = new URL(raw)
+  if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+    url.pathname = url.pathname.slice(0, -1)
+  }
+  return url
+}
+
+const resolveRequestUrl = (baseUrl: URL, requestPath: string): string => {
+  const requestUrl = new URL(requestPath, baseUrl.origin)
+  const basePath = baseUrl.pathname === '/' ? '' : baseUrl.pathname
+  const alreadyPrefixed =
+    basePath !== '' &&
+    (requestUrl.pathname === basePath || requestUrl.pathname.startsWith(`${basePath}/`))
+
+  const url = new URL(baseUrl.toString())
+  url.pathname = alreadyPrefixed ? requestUrl.pathname : `${basePath}${requestUrl.pathname}`
+  url.search = requestUrl.search
+  url.hash = requestUrl.hash
+  return url.toString()
+}
+
+const substituteFactory = (
+  placeholders: Readonly<Record<string, string>>,
+  brainId: string,
+): ((value: string) => string) => {
+  const pairs = Object.entries({ ...placeholders, BRAIN_ID: brainId })
+  pairs.sort(([left], [right]) => right.length - left.length)
+  return (value: string) => {
+    let resolved = value
+    for (const [key, replacement] of pairs) {
+      resolved = resolved.split(key).join(replacement)
+    }
+    return resolved
+  }
+}
+
+const substituteJson = (value: unknown, substitute: (input: string) => string): unknown => {
+  if (typeof value === 'string') return substitute(value)
+  if (Array.isArray(value)) return value.map((item) => substituteJson(item, substitute))
+  if (isRecord(value)) {
+    const next: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      next[key] = substituteJson(child, substitute)
+    }
+    return next
+  }
+  return value
+}
+
+const buildHeaders = (
+  headers: Readonly<Record<string, string>> | undefined,
+  substitute: (value: string) => string,
+  authToken: string | undefined,
+): Headers => {
+  const out = new Headers()
+  if (headers !== undefined) {
+    for (const [key, value] of Object.entries(headers)) {
+      out.set(key, substitute(value))
+    }
+  }
+  if (authToken !== undefined) {
+    out.set('authorization', `Bearer ${authToken}`)
+  }
+  return out
+}
+
+const readResponseText = async (response: ResponseLike): Promise<string> => {
+  try {
+    return await response.text()
+  } catch (error) {
+    return `<failed to read response body: ${formatError(error)}>`
+  }
+}
+
+const fetchWithTimeout = async (
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<FetchResponse> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`request timed out after ${timeoutMs} ms`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+const makeBrainId = (prefix: string, index: number): string =>
+  `${prefix}-${index + 1}-${randomUUID().slice(0, 8)}`
+
+const sameStringMultiset = (left: readonly string[], right: readonly string[]): boolean => {
+  if (left.length !== right.length) return false
+  const counts = new Map<string, number>()
+  for (const value of left) {
+    counts.set(value, (counts.get(value) ?? 0) + 1)
+  }
+  for (const value of right) {
+    const count = counts.get(value)
+    if (count === undefined) return false
+    if (count === 1) counts.delete(value)
+    else counts.set(value, count - 1)
+  }
+  return counts.size === 0
+}
+
+const extractItems = (parsed: unknown): readonly Record<string, unknown>[] => {
+  if (!isRecord(parsed)) {
+    throw new Error(`expected JSON object with items array, got ${typeof parsed}`)
+  }
+  const items = parsed.items
+  if (!Array.isArray(items)) {
+    throw new Error('expected JSON object with items array')
+  }
+  return items.filter(isRecord)
+}
+
+const compareJson = (expected: unknown, actual: unknown, path = 'root'): void => {
+  if (expected === null || expected === undefined) {
+    if (actual !== expected) {
+      throw new Error(`${path}: want ${String(expected)} got ${String(actual)}`)
+    }
+    return
+  }
+
+  if (typeof expected === 'string') {
+    if (expected === '<ISO-8601>') {
+      if (typeof actual !== 'string') {
+        throw new Error(`${path}: want ISO-8601 string got ${typeof actual}`)
+      }
+      const parsed = new Date(actual)
+      if (!Number.isFinite(parsed.getTime())) {
+        throw new Error(`${path}: ${actual} is not ISO-8601`)
+      }
+      return
+    }
+    if (actual !== expected) {
+      throw new Error(`${path}: want ${JSON.stringify(expected)} got ${JSON.stringify(actual)}`)
+    }
+    return
+  }
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      throw new Error(`${path}: want array got ${typeof actual}`)
+    }
+    if (actual.length < expected.length) {
+      throw new Error(`${path}: array length ${actual.length} < expected ${expected.length}`)
+    }
+    for (let index = 0; index < expected.length; index += 1) {
+      compareJson(expected[index], actual[index], `${path}[${index}]`)
+    }
+    return
+  }
+
+  if (typeof expected === 'object') {
+    if (!isRecord(actual)) {
+      throw new Error(`${path}: want object got ${typeof actual}`)
+    }
+    for (const [key, value] of Object.entries(expected)) {
+      if (!(key in actual)) {
+        throw new Error(`${path}: missing key ${JSON.stringify(key)}`)
+      }
+      compareJson(value, actual[key], `${path}.${key}`)
+    }
+    return
+  }
+
+  if (actual !== expected) {
+    throw new Error(`${path}: want ${String(expected)} got ${String(actual)}`)
+  }
+}
+
+const runBodyAssertion = (assertion: ConformanceBodyAssertion, parsed: unknown): void => {
+  switch (assertion.kind) {
+    case 'items-include-path': {
+      const items = extractItems(parsed)
+      if (!items.some((item) => item.path === assertion.path)) {
+        throw new Error(`items do not include ${JSON.stringify(assertion.path)}`)
+      }
+      return
+    }
+    case 'items-exclude-path': {
+      const items = extractItems(parsed)
+      if (items.some((item) => item.path === assertion.path)) {
+        throw new Error(`items unexpectedly include ${JSON.stringify(assertion.path)}`)
+      }
+      return
+    }
+    case 'items-files-equal': {
+      const expectedPaths = Array.isArray(assertion.paths)
+        ? assertion.paths.filter((path): path is string => typeof path === 'string')
+        : []
+      const items = extractItems(parsed)
+      const actual = items
+        .filter((item) => item.is_dir !== true)
+        .flatMap((item) => (typeof item.path === 'string' ? [item.path] : []))
+      if (!sameStringMultiset(actual, expectedPaths)) {
+        throw new Error(
+          `items-files-equal: want ${JSON.stringify(expectedPaths)} got ${JSON.stringify(actual)}`,
+        )
+      }
+      return
+    }
+    case 'items-dirs-equal': {
+      const expectedPaths = Array.isArray(assertion.paths)
+        ? assertion.paths.filter((path): path is string => typeof path === 'string')
+        : []
+      const items = extractItems(parsed)
+      const actual = items
+        .filter((item) => item.is_dir === true)
+        .flatMap((item) => (typeof item.path === 'string' ? [item.path] : []))
+      if (!sameStringMultiset(actual, expectedPaths)) {
+        throw new Error(
+          `items-dirs-equal: want ${JSON.stringify(expectedPaths)} got ${JSON.stringify(actual)}`,
+        )
+      }
+      return
+    }
+    case 'json-field-equals': {
+      if (!isRecord(parsed)) {
+        throw new Error(`json-field-equals: expected JSON object got ${typeof parsed}`)
+      }
+      const field = typeof assertion.field === 'string' ? assertion.field : ''
+      if (field === '') {
+        throw new Error('json-field-equals: missing field name')
+      }
+      const actual = parsed[field]
+      if (!isDeepStrictEqual(actual, assertion.value)) {
+        throw new Error(
+          `field ${JSON.stringify(field)}: want ${formatValue(assertion.value)} got ${formatValue(actual)}`,
+        )
+      }
+      return
+    }
+    default:
+      throw new Error(`unknown body assertion kind ${JSON.stringify(assertion.kind)}`)
+  }
+}
+
+const assertExpectedBody = async (
+  expected: ConformanceExpectedResponse,
+  response: ResponseLike,
+): Promise<void> => {
+  if (expected.bodyBase64 !== undefined) {
+    const wanted = Buffer.from(expected.bodyBase64, 'base64')
+    const actual = Buffer.from(new Uint8Array(await response.clone().arrayBuffer()))
+    if (!actual.equals(wanted)) {
+      throw new Error(
+        `body mismatch: want ${wanted.toString('base64')} got ${actual.toString('base64')}`,
+      )
+    }
+  }
+
+  if (expected.body !== undefined) {
+    const text = await response.clone().text()
+    let parsed: unknown
+    try {
+      parsed = text === '' ? null : JSON.parse(text)
+    } catch (error) {
+      throw new Error(`decode response JSON: ${formatError(error)} body=${text}`)
+    }
+    compareJson(expected.body, parsed)
+  }
+
+  if (expected.bodyAssertions !== undefined && expected.bodyAssertions.length > 0) {
+    const text = await response.clone().text()
+    let parsed: unknown
+    try {
+      parsed = text === '' ? {} : JSON.parse(text)
+    } catch (error) {
+      throw new Error(`decode response JSON: ${formatError(error)} body=${text}`)
+    }
+    for (const assertion of expected.bodyAssertions) {
+      runBodyAssertion(assertion, parsed)
+    }
+  }
+}
+
+const assertStreamAssertions = async (
+  expected: ConformanceExpectedResponse,
+  response: ResponseLike,
+  timeoutMs: number,
+): Promise<void> => {
+  const assertions = expected.streamAssertions
+  if (assertions === undefined || assertions.length === 0) return
+  if (response.body === null) {
+    throw new Error('expected SSE response body, got none')
+  }
+
+  const wanted = new Set<string>()
+  for (const assertion of assertions) {
+    if (assertion.kind !== 'expect-event') {
+      throw new Error(`unknown stream assertion kind ${JSON.stringify(assertion.kind)}`)
+    }
+    const eventName = typeof assertion.event === 'string' ? assertion.event : ''
+    if (eventName === '') {
+      throw new Error('expect-event assertion missing event name')
+    }
+    wanted.add(eventName)
+  }
+
+  const seen = new Set<string>()
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder('utf-8')
+  const parser = new SSEParser()
+  const deadline = Date.now() + timeoutMs
+  try {
+    while (seen.size < wanted.size && Date.now() < deadline) {
+      const remaining = Math.max(1, deadline - Date.now())
+      const outcome = await Promise.race([
+        reader.read(),
+        new Promise<{ readonly timedOut: true }>((resolve) => {
+          setTimeout(() => resolve({ timedOut: true }), Math.min(remaining, 200))
+        }),
+      ])
+      if ('timedOut' in outcome) continue
+      if (outcome.done) {
+        for (const event of parser.flush()) {
+          if (wanted.has(event.event)) {
+            seen.add(event.event)
+          }
+        }
+        break
+      }
+      const chunk = decoder.decode(outcome.value, { stream: true })
+      for (const event of parser.feed(chunk)) {
+        if (wanted.has(event.event)) {
+          seen.add(event.event)
+          if (seen.size === wanted.size) break
+        }
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
+  }
+
+  const missing = [...wanted].filter((event) => !seen.has(event))
+  if (missing.length > 0) {
+    throw new Error(`expected SSE events ${JSON.stringify(missing)} never arrived`)
+  }
+}
+
+const assertExpectedResponse = async (
+  rawExpected: ConformanceExpectedResponse,
+  response: ResponseLike,
+  timeoutMs: number,
+): Promise<void> => {
+  if (rawExpected.status !== undefined && response.status !== rawExpected.status) {
+    const body = await readResponseText(response.clone())
+    throw new Error(`want status ${rawExpected.status} got ${response.status} body=${body}`)
+  }
+
+  if (rawExpected.contentType !== undefined) {
+    const actual = response.headers.get('content-type') ?? ''
+    if (!actual.includes(rawExpected.contentType)) {
+      throw new Error(
+        `want content-type containing ${JSON.stringify(rawExpected.contentType)} got ${JSON.stringify(actual)}`,
+      )
+    }
+  }
+
+  await assertExpectedBody(rawExpected, response)
+  await assertStreamAssertions(rawExpected, response, timeoutMs)
+}
+
+const assertEventPayload = (rawExpected: ConformanceExpectedResponse, payload: string): void => {
+  if (rawExpected.bodyBase64 !== undefined) {
+    const wanted = Buffer.from(rawExpected.bodyBase64, 'base64')
+    const actual = Buffer.from(payload, 'utf8')
+    if (!actual.equals(wanted)) {
+      throw new Error(
+        `event body mismatch: want ${wanted.toString('base64')} got ${actual.toString('base64')}`,
+      )
+    }
+  }
+
+  if (rawExpected.body !== undefined || rawExpected.bodyAssertions !== undefined) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(payload)
+    } catch (error) {
+      throw new Error(`decode event JSON: ${formatError(error)} payload=${payload}`)
+    }
+    if (rawExpected.body !== undefined) compareJson(rawExpected.body, parsed)
+    if (rawExpected.bodyAssertions !== undefined) {
+      for (const assertion of rawExpected.bodyAssertions) {
+        runBodyAssertion(assertion, parsed)
+      }
+    }
+  }
+}
+
+const createSseSubscriber = (url: string, headers: Headers): SseSubscriber => {
+  const controller = new AbortController()
+  const events: SSEEvent[] = []
+  const waiters = new Map<string, SseWaiter[]>()
+  let terminalError: Error | undefined
+
+  const rejectWaiters = (error: Error): void => {
+    for (const [event, pending] of waiters.entries()) {
+      waiters.delete(event)
+      for (const waiter of pending) {
+        clearTimeout(waiter.timer)
+        waiter.reject(error)
+      }
+    }
+  }
+
+  const resolveWaiters = (event: SSEEvent): void => {
+    const pending = waiters.get(event.event)
+    if (pending === undefined) return
+    waiters.delete(event.event)
+    for (const waiter of pending) {
+      clearTimeout(waiter.timer)
+      waiter.resolve(event.data)
+    }
+  }
+
+  const run = (async (): Promise<void> => {
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+      })
+      if (!response.ok) {
+        throw new Error(`SSE subscribe failed: ${response.status} ${response.statusText}`)
+      }
+      if (response.body === null) {
+        throw new Error('SSE subscribe failed: response body missing')
+      }
+      for await (const event of iterateSSE(response.body)) {
+        events.push(event)
+        resolveWaiters(event)
+      }
+      if (!controller.signal.aborted) {
+        terminalError = new Error('SSE stream closed before the case finished')
+        rejectWaiters(terminalError)
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      terminalError = asError(error)
+      rejectWaiters(terminalError)
+    }
+  })()
+
+  return {
+    waitFor: async (eventName: string, timeoutMs = DEFAULT_SSE_TIMEOUT_MS): Promise<string> => {
+      const existing = events.find((event) => event.event === eventName)
+      if (existing !== undefined) return existing.data
+      if (terminalError !== undefined) throw terminalError
+
+      return new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const pending = waiters.get(eventName)
+          if (pending === undefined) {
+            reject(new Error(`timeout waiting for SSE event ${JSON.stringify(eventName)}`))
+            return
+          }
+          waiters.set(
+            eventName,
+            pending.filter((candidate) => candidate.timer !== timer),
+          )
+          reject(new Error(`timeout waiting for SSE event ${JSON.stringify(eventName)}`))
+        }, timeoutMs)
+
+        const pending = waiters.get(eventName) ?? []
+        pending.push({ resolve, reject, timer })
+        waiters.set(eventName, pending)
+      })
+    },
+    close: async (): Promise<void> => {
+      controller.abort()
+      rejectWaiters(new Error('SSE subscriber closed'))
+      await run.catch(() => undefined)
+    },
+  }
+}
+
+const executeStepRequest = async (
+  step: ConformanceStep,
+  context: RunCaseContext,
+): Promise<FetchResponse> => {
+  const method = (step.method ?? 'GET').toUpperCase()
+  const path = context.substitute(step.path ?? '')
+  const url = resolveRequestUrl(context.baseUrl, path)
+  const headers = buildHeaders(step.headers, context.substitute, context.authToken)
+
+  let body: RequestInit['body'] | undefined
+  if (step.bodyBase64 !== undefined && step.bodyBase64 !== '') {
+    body = new Uint8Array(Buffer.from(context.substitute(step.bodyBase64), 'base64'))
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/octet-stream')
+    }
+  } else if (step.bodyJson !== undefined) {
+    body = JSON.stringify(substituteJson(step.bodyJson, context.substitute))
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/json')
+    }
+  }
+
+  return await fetchWithTimeout(
+    url,
+    {
+      method,
+      headers,
+      ...(body !== undefined ? { body } : {}),
+    },
+    context.requestTimeoutMs,
+  )
+}
+
+const runStep = async (rawStep: ConformanceStep, context: RunCaseContext): Promise<void> => {
+  const resolvedStep = substituteJson(rawStep, context.substitute) as ConformanceStep
+
+  switch (resolvedStep.kind) {
+    case 'open-sse': {
+      const name = resolvedStep.name ?? ''
+      if (name === '') throw new Error('open-sse step missing name')
+      const path = resolvedStep.path ?? ''
+      if (path === '') throw new Error('open-sse step missing path')
+
+      const existing = context.ssePool.get(name)
+      if (existing !== undefined) {
+        await existing.close()
+      }
+
+      const headers = buildHeaders(
+        { accept: 'text/event-stream', ...(resolvedStep.headers ?? {}) },
+        context.substitute,
+        context.authToken,
+      )
+      context.ssePool.set(
+        name,
+        createSseSubscriber(resolveRequestUrl(context.baseUrl, path), headers),
+      )
+      return
+    }
+    case 'await-sse-event': {
+      const name = resolvedStep.name ?? ''
+      const event = resolvedStep.event ?? ''
+      if (name === '' || event === '') {
+        throw new Error('await-sse-event step missing name or event')
+      }
+      const subscriber = context.ssePool.get(name)
+      if (subscriber === undefined) {
+        throw new Error(`SSE subscriber ${JSON.stringify(name)} not opened`)
+      }
+      await subscriber.waitFor(event, context.sseTimeoutMs)
+      return
+    }
+    case 'close-sse': {
+      const name = resolvedStep.name ?? ''
+      if (name === '') throw new Error('close-sse step missing name')
+      const subscriber = context.ssePool.get(name)
+      if (subscriber !== undefined) {
+        await subscriber.close()
+        context.ssePool.delete(name)
+      }
+      return
+    }
+    case undefined:
+      break
+    default:
+      throw new Error(`unknown step kind ${JSON.stringify(resolvedStep.kind)}`)
+  }
+
+  const response = await executeStepRequest(resolvedStep, context)
+  if (
+    resolvedStep.expectedStatus !== undefined &&
+    response.status !== resolvedStep.expectedStatus
+  ) {
+    const body = await readResponseText(response.clone())
+    throw new Error(
+      `setup step ${resolvedStep.method ?? 'GET'} ${resolvedStep.path ?? ''}: want status ${resolvedStep.expectedStatus} got ${response.status} body=${body}`,
+    )
+  }
+  if (resolvedStep.expectedBodyBase64 !== undefined && resolvedStep.expectedBodyBase64 !== '') {
+    const wanted = Buffer.from(resolvedStep.expectedBodyBase64, 'base64')
+    const actual = Buffer.from(new Uint8Array(await response.arrayBuffer()))
+    if (!actual.equals(wanted)) {
+      throw new Error(
+        `setup step body mismatch: want ${wanted.toString('base64')} got ${actual.toString('base64')}`,
+      )
+    }
+  }
+}
+
+const createBrain = async (
+  baseUrl: URL,
+  authToken: string | undefined,
+  requestTimeoutMs: number,
+  brainId: string,
+): Promise<void> => {
+  const response = await fetchWithTimeout(
+    resolveRequestUrl(baseUrl, '/v1/brains'),
+    {
+      method: 'POST',
+      headers: buildHeaders({ 'content-type': 'application/json' }, (value) => value, authToken),
+      body: JSON.stringify({ brainId }),
+    },
+    requestTimeoutMs,
+  )
+  if (response.status !== 201) {
+    const body = await readResponseText(response)
+    throw new Error(`create brain ${brainId}: want 201 got ${response.status} body=${body}`)
+  }
+}
+
+const deleteBrain = async (
+  baseUrl: URL,
+  authToken: string | undefined,
+  requestTimeoutMs: number,
+  brainId: string,
+): Promise<void> => {
+  const response = await fetchWithTimeout(
+    resolveRequestUrl(baseUrl, `/v1/brains/${encodeURIComponent(brainId)}`),
+    {
+      method: 'DELETE',
+      headers: buildHeaders({ 'x-confirm-delete': 'yes' }, (value) => value, authToken),
+    },
+    requestTimeoutMs,
+  )
+  if (response.status !== 204) {
+    const body = await readResponseText(response)
+    throw new Error(`delete brain ${brainId}: want 204 got ${response.status} body=${body}`)
+  }
+}
+
+const closeSubscribers = async (pool: Map<string, SseSubscriber>): Promise<void> => {
+  for (const [name, subscriber] of pool.entries()) {
+    await subscriber.close()
+    pool.delete(name)
+  }
+}
+
+const formatError = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error))
+
+const combineErrors = (
+  main: string | undefined,
+  cleanup: string | undefined,
+): string | undefined => {
+  if (main === undefined) return cleanup
+  if (cleanup === undefined) return main
+  return `${main}; cleanup failed: ${cleanup}`
+}
+
+const runCase = async (
+  testCase: ConformanceCase,
+  index: number,
+  options: {
+    readonly baseUrl: URL
+    readonly authToken: string | undefined
+    readonly requestTimeoutMs: number
+    readonly sseTimeoutMs: number
+    readonly brainIdPrefix: string
+    readonly placeholders: Readonly<Record<string, string>>
+  },
+): Promise<ConformanceCaseResult> => {
+  const brainId = makeBrainId(options.brainIdPrefix, index)
+  const substitute = substituteFactory(options.placeholders, brainId)
+  const context: RunCaseContext = {
+    baseUrl: options.baseUrl,
+    authToken: options.authToken,
+    requestTimeoutMs: options.requestTimeoutMs,
+    sseTimeoutMs: options.sseTimeoutMs,
+    substitute,
+    ssePool: new Map(),
+  }
+
+  let createdBrain = false
+  let mainError: string | undefined
+  try {
+    await createBrain(options.baseUrl, options.authToken, options.requestTimeoutMs, brainId)
+    createdBrain = true
+
+    for (const step of testCase.setup ?? []) {
+      await runStep(step, context)
+    }
+
+    const resolvedExpected = substituteJson(
+      testCase.expectedResponse,
+      substitute,
+    ) as ConformanceExpectedResponse
+
+    if (testCase.request.kind === 'await-sse-event') {
+      const name = testCase.request.name ?? ''
+      const event = testCase.request.event ?? ''
+      if (name === '' || event === '') {
+        throw new Error('await-sse-event request missing name or event')
+      }
+      const subscriber = context.ssePool.get(name)
+      if (subscriber === undefined) {
+        throw new Error(`SSE subscriber ${JSON.stringify(name)} not opened`)
+      }
+      const payload = await subscriber.waitFor(event, options.sseTimeoutMs)
+      assertEventPayload(resolvedExpected, payload)
+    } else {
+      const response = await executeStepRequest(testCase.request, context)
+      await assertExpectedResponse(resolvedExpected, response, options.sseTimeoutMs)
+    }
+
+    for (const step of testCase.followUp ?? []) {
+      await runStep(step, context)
+    }
+    for (const step of testCase.teardown ?? []) {
+      await runStep(step, context)
+    }
+  } catch (error) {
+    mainError = formatError(error)
+  }
+
+  let cleanupError: string | undefined
+  try {
+    await closeSubscribers(context.ssePool)
+    if (createdBrain) {
+      await deleteBrain(options.baseUrl, options.authToken, options.requestTimeoutMs, brainId)
+    }
+  } catch (error) {
+    cleanupError = formatError(error)
+  }
+
+  const error = combineErrors(mainError, cleanupError)
+  if (error === undefined) {
+    return { name: testCase.name, brainId, ok: true }
+  }
+  return { name: testCase.name, brainId, ok: false, error }
+}
+
+const assertDocument = (value: unknown, source: string): ConformanceDocument => {
+  if (!isRecord(value)) {
+    throw new Error(`conformance fixture ${source} must be an object`)
+  }
+
+  const cases = value.cases
+  if (!Array.isArray(cases)) {
+    throw new Error(`conformance fixture ${source} missing cases array`)
+  }
+
+  const placeholders = value.placeholders
+  if (!isRecord(placeholders)) {
+    throw new Error(`conformance fixture ${source} missing placeholders object`)
+  }
+
+  for (let index = 0; index < cases.length; index += 1) {
+    const testCase = cases[index]
+    if (!isRecord(testCase)) {
+      throw new Error(`conformance fixture ${source} case ${index} must be an object`)
+    }
+    if (asString(testCase.name) === undefined) {
+      throw new Error(`conformance fixture ${source} case ${index} missing name`)
+    }
+    if (!isRecord(testCase.request)) {
+      throw new Error(`conformance fixture ${source} case ${index} missing request object`)
+    }
+    if (!isRecord(testCase.expectedResponse)) {
+      throw new Error(`conformance fixture ${source} case ${index} missing expectedResponse object`)
+    }
+  }
+
+  return value as ConformanceDocument
+}
+
+export const resolveConformanceFixturePath = async (): Promise<string> => {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  for (;;) {
+    for (const candidate of [
+      join(dir, DIST_FIXTURE_FILENAME),
+      join(dir, ...REPO_FIXTURE_RELATIVE_PATH),
+    ]) {
+      try {
+        await access(candidate)
+        return candidate
+      } catch {
+        /* keep walking */
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  throw new Error(
+    `could not find ${DIST_FIXTURE_FILENAME} or ${REPO_FIXTURE_RELATIVE_PATH.join('/')} from ${fileURLToPath(import.meta.url)}`,
+  )
+}
+
+export const loadConformanceDocument = async (
+  fixturePath?: string,
+): Promise<ConformanceDocument> => {
+  const resolvedPath = fixturePath ?? (await resolveConformanceFixturePath())
+  const raw = await readFile(resolvedPath, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`parse conformance fixture ${resolvedPath}: ${formatError(error)}`)
+  }
+  return assertDocument(parsed, resolvedPath)
+}
+
+export const runConformanceSuite = async (
+  options: RunConformanceSuiteOptions,
+): Promise<ConformanceSuiteResult> => {
+  const document = await loadConformanceDocument(options.fixturePath)
+  const baseUrl = normaliseBaseUrl(options.baseUrl)
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+  const sseTimeoutMs = options.sseTimeoutMs ?? DEFAULT_SSE_TIMEOUT_MS
+  const brainIdPrefix = options.brainIdPrefix ?? DEFAULT_BRAIN_ID_PREFIX
+
+  const cases: ConformanceCaseResult[] = []
+  for (let index = 0; index < document.cases.length; index += 1) {
+    const testCase = document.cases[index]
+    if (testCase === undefined) continue
+    cases.push(
+      await runCase(testCase, index, {
+        baseUrl,
+        authToken: options.authToken,
+        requestTimeoutMs,
+        sseTimeoutMs,
+        brainIdPrefix,
+        placeholders: document.placeholders,
+      }),
+    )
+  }
+
+  const passed = cases.filter((testCase) => testCase.ok).length
+  const failed = cases.length - passed
+  return {
+    total: cases.length,
+    passed,
+    failed,
+    cases,
+  }
+}


### PR DESCRIPTION
## Summary
- export `@jeffs-brain/memory/conformance` with a reusable `runConformanceSuite` runner for the shared HTTP contract fixture
- package `spec/conformance/http-contract.json` into the published tarball and document the new runner in the TypeScript SDK README
- add end-to-end conformance runner tests, including auth and `/v1` base URL coverage, plus a regression test for exact `json-field-equals` semantics

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `npm pack --dry-run --json`
- `node -e "import('@jeffs-brain/memory/conformance')..."`

Closes #2
