### PR TITLE
feat(ts): export framework-agnostic SSE helpers

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           case "${{ matrix.sdk }}" in
             ts) bun run --filter @jeffs-brain/memory build ;;
-            go) cd sdks/go && go build ./... && go build ./cmd/memory ;;
+            go) cd sdks/go && go build ./... ;;
             py) cd sdks/py && uv sync && uv run memory --version ;;
           esac
       - name: Run eval

--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           case "${{ matrix.sdk }}" in
             ts) bun run --filter @jeffs-brain/memory build ;;
-            go) cd sdks/go && go build ./... && go build ./cmd/memory ;;
+            go) cd sdks/go && go build ./... ;;
             py) cd sdks/py && uv sync && uv run memory --version ;;
           esac
       - name: Run smoke eval
@@ -44,6 +44,10 @@ jobs:
             --sdk ${{ matrix.sdk }} \
             --dataset datasets/smoke.jsonl \
             --scorer exact \
+            --scenario search-retrieve-only \
+            --mode bm25 \
+            --brain eval \
+            --seed-reference-brain \
             --floor 0.90 \
             --output results/
         working-directory: eval

--- a/README.md
+++ b/README.md
@@ -81,14 +81,17 @@ To compare one scenario across all three SDKs, run the shared runner from [`eval
 cd eval
 uv sync
 
-# Fast parity check for the basic ask path
+# Fast offline parity check using a seeded reference brain
 for sdk in ts go py; do
   uv run python runner.py \
     --sdk "$sdk" \
     --dataset datasets/smoke.jsonl \
     --scorer exact \
-    --scenario ask-basic \
-    --output results/ask-basic
+    --scenario search-retrieve-only \
+    --mode bm25 \
+    --brain eval \
+    --seed-reference-brain \
+    --output results/smoke-search
 done
 
 # Corpus-grounded parity checks, using a populated `eval` brain

--- a/eval/README.md
+++ b/eval/README.md
@@ -40,11 +40,13 @@ memory ingest ./corpus --brain eval
 ```
 
 Override the brain via `--brain <id>` on the runner when you want to target
-something else. `smoke.jsonl` is for fast scenario checks; `lme.jsonl` is the
-shared corpus-grounded daemon dataset used for `ask-augmented` and
-`search-retrieve-only` once the `eval` brain has been populated. The
-tri-SDK replay script does its own shared extract step and does not require a
-pre-populated daemon brain.
+something else. `smoke.jsonl` is for fast offline checks and is typically run
+with `--seed-reference-brain`, which deletes and recreates the target brain
+then ingests one markdown file per dataset row using that row's
+`reference_answer`. `lme.jsonl` is the shared corpus-grounded daemon dataset
+used for `ask-augmented` and `search-retrieve-only` once the `eval` brain has
+been populated. The tri-SDK replay script does its own shared extract step and
+does not require a pre-populated daemon brain.
 
 ## Local run
 
@@ -52,14 +54,17 @@ pre-populated daemon brain.
 cd ~/code/jeffs-brain/memory/eval
 uv sync
 
-# Fast parity check for the basic ask path
+# Fast offline parity check using a seeded reference brain
 for sdk in ts go py; do
   uv run python runner.py \
     --sdk "$sdk" \
     --dataset datasets/smoke.jsonl \
     --scorer exact \
-    --scenario ask-basic \
-    --output results/ask-basic
+    --scenario search-retrieve-only \
+    --mode bm25 \
+    --brain eval \
+    --seed-reference-brain \
+    --output results/smoke-search
 done
 
 # Corpus-grounded parity checks, against a populated `eval` brain
@@ -84,7 +89,7 @@ for sdk in ts go py; do
 done
 ```
 
-Use a separate `--output` root per scenario when comparing SDKs on the same day. The runner writes one `<sdk>.json` under `<output>/<YYYY-MM-DD>/`, so in practice you want roots such as `results/ask-basic`, `results/ask-augmented`, and `results/search-retrieve-only`.
+Use a separate `--output` root per scenario when comparing SDKs on the same day. The runner writes one `<sdk>.json` under `<output>/<YYYY-MM-DD>/`, so in practice you want roots such as `results/smoke-search`, `results/ask-augmented`, and `results/search-retrieve-only`.
 
 ### CLI flags
 
@@ -103,6 +108,7 @@ Use a separate `--output` root per scenario when comparing SDKs on the same day.
 | `--top-k`    | `5`                     | Forwarded as `topK` on `/ask` or `/search`.                           |
 | `--candidate-k` | `0`                  | Forwarded as `candidateK` on `search-retrieve-only`. `0` defers to the daemon default. |
 | `--rerank-top-n` | `0`                 | Forwarded as `rerankTopN` on `search-retrieve-only`. `0` defers to the daemon default. |
+| `--seed-reference-brain` | off         | Deletes and recreates `--brain`, then ingests one markdown document per dataset row using `reference_answer`. Intended for offline retrieval smoke checks. |
 
 ### What each scenario exercises
 
@@ -321,7 +327,7 @@ Benchmark notes:
 
 ## CI
 
-- `eval-smoke` runs on every PR across `{ts, go, py}` on the shared runner's default daemon scenario, `ask-basic`, with the `exact` scorer.
+- `eval-smoke` runs on every PR across `{ts, go, py}` as an offline retrieval check: it seeds a small reference brain from `smoke.jsonl`, then scores `search-retrieve-only` in `bm25` mode with the `exact` scorer.
 - `eval-nightly` is reserved for broader benchmark coverage; native LongMemEval parity still lives with the SDK-specific runners.
 
 ## Cost model

--- a/eval/datasets/README.md
+++ b/eval/datasets/README.md
@@ -35,8 +35,9 @@ Scenario parity expects the same dataset row to work across all three SDKs. The 
 ## Files
 
 - `smoke.jsonl` - 20 provider-agnostic factual questions. Cheap, fast,
-  deterministic (`exact` scorer). Runs on every PR; used for fast
-  `ask-basic` parity checks.
+  deterministic (`exact` scorer). Runs on every PR; used for fast offline
+  `search-retrieve-only` parity checks when the runner seeds a reference
+  brain from `reference_answer`.
 - `lme.jsonl` - 100-question benchmark spanning facts, definitional,
   temporal, procedural, comparison, and memory-retrieval-specific prompts
   (SQLite FTS5, BM25, embeddings, RAG, vector search). Used for the
@@ -57,6 +58,7 @@ changes required.
 meaningful once the target SDK has a populated `eval` brain, or once the
 replay-backed tri-SDK flow has extracted the shared brain cache first.
 
-`smoke.jsonl` is the provider-agnostic empty-brain dataset. `longmemeval_s.json`
-is the upstream 500-question replay dataset used by the native Go LME runner
-and the replay-backed tri-SDK script. It is a JSON array, not JSONL.
+`smoke.jsonl` is the provider-agnostic reference-answer dataset used by the
+offline smoke flow with `--seed-reference-brain`. `longmemeval_s.json` is the
+upstream 500-question replay dataset used by the native Go LME runner and the
+replay-backed tri-SDK script. It is a JSON array, not JSONL.

--- a/eval/runner.py
+++ b/eval/runner.py
@@ -30,8 +30,11 @@ answer blob and records chunk metadata as citations.
 from __future__ import annotations
 
 import asyncio
+import base64
 import datetime as _dt
 import json
+import os
+import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -130,12 +133,71 @@ def _search_path(brain: str) -> str:
     return f"/v1/brains/{quote(brain, safe='')}/search"
 
 
+def _brain_path(brain: str) -> str:
+    return f"/v1/brains/{quote(brain, safe='')}"
+
+
+def _ingest_file_path(brain: str) -> str:
+    return f"{_brain_path(brain)}/ingest/file"
+
+
 def _question_date(item: dict[str, Any]) -> str | None:
     for key in ("questionDate", "question_date"):
         value = item.get(key)
         if isinstance(value, str) and value != "":
             return value
     return None
+
+
+def _safe_doc_stem(raw: str) -> str:
+    chars = [ch.lower() if ch.isalnum() else "-" for ch in raw]
+    stem = "".join(chars).strip("-")
+    while "--" in stem:
+        stem = stem.replace("--", "-")
+    return stem or "item"
+
+
+async def _seed_reference_brain(*, endpoint: str, dataset: Path, brain: str) -> None:
+    items = _load_dataset(dataset, limit=None)
+
+    async with httpx.AsyncClient(base_url=endpoint, timeout=ASK_TIMEOUT_S) as client:
+        create_resp = await client.post("/v1/brains", json={"brainId": brain})
+        if create_resp.status_code == 409:
+            delete_resp = await client.delete(
+                _brain_path(brain),
+                headers={"x-confirm-delete": "yes"},
+            )
+            if delete_resp.status_code != 204:
+                delete_resp.raise_for_status()
+            create_resp = await client.post("/v1/brains", json={"brainId": brain})
+
+        if create_resp.status_code != 201:
+            create_resp.raise_for_status()
+
+        for item in items:
+            question = item.get("question")
+            reference_answer = item.get("reference_answer")
+            if not isinstance(question, str) or question.strip() == "":
+                raise click.ClickException(
+                    f"Cannot seed reference brain: dataset row {item.get('id', '<missing id>')} lacks a question"
+                )
+            if not isinstance(reference_answer, str) or reference_answer.strip() == "":
+                raise click.ClickException(
+                    f"Cannot seed reference brain: dataset row {item.get('id', '<missing id>')} lacks reference_answer"
+                )
+
+            stem = _safe_doc_stem(str(item.get("id") or question))
+            document = f"# {question.strip()}\n\n{reference_answer.strip()}\n"
+            ingest_resp = await client.post(
+                _ingest_file_path(brain),
+                json={
+                    "path": f"smoke/{stem}.md",
+                    "contentType": "text/markdown",
+                    "contentBase64": base64.b64encode(document.encode("utf-8")).decode("ascii"),
+                },
+            )
+            if ingest_resp.status_code != 200:
+                ingest_resp.raise_for_status()
 
 
 def _build_request_spec(
@@ -494,6 +556,14 @@ def write_result(output_dir: Path, sdk: str, score: EvalScore) -> Path:
     show_default=True,
     help="rerankTopN value forwarded on retrieve-only /search calls. Zero defers to the daemon default.",
 )
+@click.option(
+    "--seed-reference-brain",
+    is_flag=True,
+    help=(
+        "Delete and recreate the target brain, then ingest one markdown document per dataset row "
+        "using that row's reference_answer. Intended for offline retrieval smoke checks."
+    ),
+)
 def main(
     sdk: str,
     scenario: str,
@@ -508,10 +578,19 @@ def main(
     top_k: int,
     candidate_k: int,
     rerank_top_n: int,
+    seed_reference_brain: bool,
 ) -> None:
+    scratch_home: tempfile.TemporaryDirectory[str] | None = None
+    prior_jb_home = os.environ.get("JB_HOME")
+    if seed_reference_brain:
+        scratch_home = tempfile.TemporaryDirectory(prefix="jeffs-brain-eval-")
+        os.environ["JB_HOME"] = scratch_home.name
+
     runner: SdkRunner = get_runner(sdk)
-    runner.start(port=port)
     try:
+        runner.start(port=port)
+        if seed_reference_brain:
+            asyncio.run(_seed_reference_brain(endpoint=runner.endpoint, dataset=dataset, brain=brain))
         score = run_eval(
             endpoint=runner.endpoint,
             scenario=scenario,
@@ -536,6 +615,12 @@ def main(
             raise SystemExit(1)
     finally:
         runner.stop()
+        if prior_jb_home is None:
+            os.environ.pop("JB_HOME", None)
+        else:
+            os.environ["JB_HOME"] = prior_jb_home
+        if scratch_home is not None:
+            scratch_home.cleanup()
 
 
 if __name__ == "__main__":

--- a/eval/tests/test_runner.py
+++ b/eval/tests/test_runner.py
@@ -8,6 +8,7 @@ only validates CLI parsing, dataset loading, scorer selection, and the
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,6 +29,7 @@ from runner import (
     _load_dataset,
     _parse_sse_frame,
     _search_path,
+    _seed_reference_brain,
     main,
     write_result,
 )
@@ -361,6 +363,79 @@ class TestAskHelpers:
             {"chunkId": "c2", "path": "wiki/b.md", "title": "B", "score": 0.7},
         ]
 
+    def test_seed_reference_brain_resets_and_populates_target_brain(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ds = tmp_path / "ds.jsonl"
+        ds.write_text(
+            (
+                '{"id": "alpha one", "question": "What is SQLite?", '
+                '"reference_answer": "SQLite is an embedded SQL database."}\n'
+                '{"id": "beta/two", "question": "What is HTTP?", '
+                '"reference_answer": "HTTP stands for Hypertext Transfer Protocol."}\n'
+            ),
+            encoding="utf-8",
+        )
+        captured: list[tuple[str, str, dict[str, object] | None, str | None]] = []
+        create_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal create_calls
+            payload = (
+                json.loads(request.content.decode("utf-8"))
+                if request.content not in (b"", None)
+                else None
+            )
+            captured.append(
+                (
+                    request.method,
+                    request.url.path,
+                    payload if isinstance(payload, dict) else None,
+                    request.headers.get("x-confirm-delete"),
+                )
+            )
+            if request.method == "POST" and request.url.path == "/v1/brains":
+                create_calls += 1
+                return httpx.Response(409 if create_calls == 1 else 201)
+            if request.method == "DELETE":
+                return httpx.Response(204)
+            if request.method == "POST" and request.url.path == "/v1/brains/eval/ingest/file":
+                return httpx.Response(200)
+            raise AssertionError(f"unexpected request: {request.method} {request.url.path}")
+
+        transport = httpx.MockTransport(handler)
+        client = httpx.AsyncClient(base_url="http://test", transport=transport)
+        monkeypatch.setattr(runner_module.httpx, "AsyncClient", lambda **_: client)
+
+        asyncio.run(_seed_reference_brain(endpoint="http://test", dataset=ds, brain="eval"))
+
+        assert captured[0] == ("POST", "/v1/brains", {"brainId": "eval"}, None)
+        assert captured[1] == ("DELETE", "/v1/brains/eval", None, "yes")
+        assert captured[2] == ("POST", "/v1/brains", {"brainId": "eval"}, None)
+        assert [entry[1] for entry in captured[3:]] == [
+            "/v1/brains/eval/ingest/file",
+            "/v1/brains/eval/ingest/file",
+        ]
+
+        first_payload = captured[3][2]
+        second_payload = captured[4][2]
+        assert first_payload == {
+            "path": "smoke/alpha-one.md",
+            "contentType": "text/markdown",
+            "contentBase64": base64.b64encode(
+                b"# What is SQLite?\n\nSQLite is an embedded SQL database.\n"
+            ).decode("ascii"),
+        }
+        assert second_payload == {
+            "path": "smoke/beta-two.md",
+            "contentType": "text/markdown",
+            "contentBase64": base64.b64encode(
+                b"# What is HTTP?\n\nHTTP stands for Hypertext Transfer Protocol.\n"
+            ).decode("ascii"),
+        }
+
 
 class TestCli:
     def test_help_exits_zero(self) -> None:
@@ -370,6 +445,7 @@ class TestCli:
         assert "--scenario" in result.output
         assert "--candidate-k" in result.output
         assert "--rerank-top-n" in result.output
+        assert "--seed-reference-brain" in result.output
         assert "--scorer" in result.output
         assert "default: auto" in result.output
 
@@ -554,3 +630,86 @@ class TestCli:
         assert captured["top_k"] == 20
         assert captured["candidate_k"] == 80
         assert captured["rerank_top_n"] == 40
+
+    def test_main_seeds_reference_brain_before_eval(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ds = tmp_path / "ds.jsonl"
+        ds.write_text(
+            '{"id": "x", "question": "q", "reference_answer": "a", "expected_substrings": ["a"]}\n',
+            encoding="utf-8",
+        )
+        calls: list[tuple[str, object]] = []
+
+        class _StubRunner(SdkRunner):
+            @property
+            def name(self) -> str:
+                return "stub"
+
+            @property
+            def workdir(self) -> Path:
+                return tmp_path
+
+            def build_command(self, port: int) -> list[str]:
+                return ["true"]
+
+            def start(self, *, port: int = 0) -> None:
+                self._resolved_port = port or 4321
+
+            def stop(self) -> None:
+                return None
+
+        async def _fake_seed_reference_brain(**kwargs: object) -> None:
+            calls.append(("seed", kwargs))
+
+        def _fake_run_eval(**kwargs: object) -> EvalScore:
+            calls.append(("eval", kwargs))
+            return EvalScore(
+                sdk="ts",
+                dataset=str(ds),
+                scorer="exact",
+                total=1,
+                passed=1,
+                pass_rate=1.0,
+                mean_score=1.0,
+                started_at="s",
+                finished_at="e",
+                scenario="search-retrieve-only",
+                mode="bm25",
+            )
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _name: _StubRunner())
+        monkeypatch.setattr(runner_module, "_seed_reference_brain", _fake_seed_reference_brain)
+        monkeypatch.setattr(runner_module, "run_eval", _fake_run_eval)
+
+        result = CliRunner().invoke(
+            main,
+            [
+                "--sdk",
+                "ts",
+                "--dataset",
+                str(ds),
+                "--scenario",
+                "search-retrieve-only",
+                "--mode",
+                "bm25",
+                "--scorer",
+                "exact",
+                "--output",
+                str(tmp_path / "out"),
+                "--floor",
+                "0",
+                "--brain",
+                "eval",
+                "--seed-reference-brain",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert calls[0] == (
+            "seed",
+            {"endpoint": "http://127.0.0.1:4321", "dataset": ds, "brain": "eval"},
+        )
+        assert calls[1][0] == "eval"

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -210,7 +210,7 @@ To compare Go against the other SDKs on one shared scenario, use the runner in `
 
 ```bash
 cd eval
-uv run python runner.py --sdk go --dataset datasets/smoke.jsonl --scorer exact --scenario ask-basic --output results/ask-basic
+uv run python runner.py --sdk go --dataset datasets/smoke.jsonl --scorer exact --scenario search-retrieve-only --mode bm25 --brain eval --seed-reference-brain --output results/smoke-search
 OPENAI_API_KEY=sk-... uv run python runner.py --sdk go --dataset datasets/lme.jsonl --scorer judge --scenario ask-augmented --brain eval --output results/ask-augmented
 OPENAI_API_KEY=sk-... uv run python runner.py --sdk go --dataset datasets/lme.jsonl --scorer judge --scenario search-retrieve-only --brain eval --output results/search-retrieve-only
 ```

--- a/sdks/ts/memory/README.md
+++ b/sdks/ts/memory/README.md
@@ -26,10 +26,37 @@ The published `memory` binary runs on Node 20+ (its shebang is `#!/usr/bin/env n
 - Retrieval: hybrid BM25 + vector, five-rung retry ladder, intent reweight, cross-encoder rerank, opt-in query distill.
 - Memory stages: extract, reflect, consolidate, recall, session buffers, episode recorder.
 - Knowledge: markdown chunker, URL/file/PDF ingest, wikilinks, compile passes.
+- SSE utilities: framework-agnostic frame formatting and heartbeat helpers via `@jeffs-brain/memory/sse`.
 - Authorisation: pluggable `AccessControlProvider` contract (`@jeffs-brain/memory/acl`), in-process RBAC (workspace -> brain -> collection -> document hierarchy, `admin`/`writer`/`reader` roles, `deny:<role>` overrides), `withAccessControl(store, provider, subject, ...)` Store wrapper, optional `close()` lifecycle hook. Pair with [`@jeffs-brain/memory-openfga`](https://www.npmjs.com/package/@jeffs-brain/memory-openfga) for production tuple-store backed checks.
 - Conformance: 28/29 cases green against `spec/conformance/http-contract.json`.
 - Cross-SDK daemon scenarios: `ask-basic`, `ask-augmented`, `search-retrieve-only`.
 - CLI: `memory init|ingest|search|extract|reflect|consolidate|eval|serve|acl|git`.
+
+## SSE utilities
+
+```ts
+import { createSseHeartbeat, formatSseFrame } from '@jeffs-brain/memory/sse'
+
+const write = (chunk: string): void => {
+  response.write(chunk)
+}
+
+write(
+  formatSseFrame({
+    event: 'change',
+    id: '42',
+    data: JSON.stringify({ kind: 'updated', path: 'memory/notes.md' }),
+  }),
+)
+
+const stopHeartbeat = createSseHeartbeat(25_000, () => {
+  write(formatSseFrame({ event: 'ping', data: 'keepalive' }))
+})
+
+request.on('close', stopHeartbeat)
+```
+
+These helpers expose the framing layer separately from the built-in `Response`-based daemon transport, so Express, Fastify, Hono, or plain Node handlers can emit spec-compliant SSE frames without reimplementing the wire format.
 
 ## Embedded usage
 

--- a/sdks/ts/memory/README.md
+++ b/sdks/ts/memory/README.md
@@ -41,22 +41,30 @@ const write = (chunk: string): void => {
   response.write(chunk)
 }
 
+let nextEventId = 1
+
 write(
   formatSseFrame({
     event: 'change',
-    id: '42',
+    id: String(nextEventId++),
     data: JSON.stringify({ kind: 'updated', path: 'memory/notes.md' }),
   }),
 )
 
 const stopHeartbeat = createSseHeartbeat(25_000, () => {
-  write(formatSseFrame({ event: 'ping', data: 'keepalive' }))
+  write(
+    formatSseFrame({
+      event: 'ping',
+      id: String(nextEventId++),
+      data: 'keepalive',
+    }),
+  )
 })
 
 request.on('close', stopHeartbeat)
 ```
 
-These helpers expose the framing layer separately from the built-in `Response`-based daemon transport, so Express, Fastify, Hono, or plain Node handlers can emit spec-compliant SSE frames without reimplementing the wire format.
+These helpers expose the framing layer separately from the built-in `Response`-based daemon transport, so Express, Fastify, Hono, or plain Node handlers can emit SSE frames without reimplementing the wire format. They format `event`, `id`, and `data` lines for you, while protocol-specific sequencing such as the daemon's monotonic `/events` ids stays under the caller's control.
 
 ## Embedded usage
 

--- a/sdks/ts/memory/README.md
+++ b/sdks/ts/memory/README.md
@@ -166,7 +166,7 @@ To compare TypeScript against the other SDKs on one shared scenario, use the run
 
 ```bash
 cd eval
-uv run python runner.py --sdk ts --dataset datasets/smoke.jsonl --scorer exact --scenario ask-basic --output results/ask-basic
+uv run python runner.py --sdk ts --dataset datasets/smoke.jsonl --scorer exact --scenario search-retrieve-only --mode bm25 --brain eval --seed-reference-brain --output results/smoke-search
 OPENAI_API_KEY=sk-... uv run python runner.py --sdk ts --dataset datasets/lme.jsonl --scorer judge --scenario ask-augmented --brain eval --output results/ask-augmented
 OPENAI_API_KEY=sk-... uv run python runner.py --sdk ts --dataset datasets/lme.jsonl --scorer judge --scenario search-retrieve-only --brain eval --output results/search-retrieve-only
 ```

--- a/sdks/ts/memory/package.json
+++ b/sdks/ts/memory/package.json
@@ -42,6 +42,10 @@
       "import": "./dist/store/index.js",
       "types": "./dist/store/index.d.ts"
     },
+    "./sse": {
+      "import": "./dist/sse.js",
+      "types": "./dist/sse.d.ts"
+    },
     "./search": {
       "import": "./dist/search/index.js",
       "types": "./dist/search/index.d.ts"

--- a/sdks/ts/memory/src/cli/commands/git-helpers.ts
+++ b/sdks/ts/memory/src/cli/commands/git-helpers.ts
@@ -6,6 +6,7 @@ import { access, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises
 import { basename, join } from 'node:path'
 import { promisify } from 'node:util'
 import * as git from 'isomorphic-git'
+import { DEFAULT_GIT_SIGNATURE, buildGitExecEnv } from '../../store/git-author.js'
 import { readGitLog, validatePath } from '../../store/index.js'
 import { CliError } from '../config.js'
 
@@ -99,7 +100,11 @@ export const requireGitBrain = async (brainDir: string): Promise<void> => {
 
 export const runGit = async (brainDir: string, args: readonly string[]): Promise<string> => {
   try {
-    const { stdout } = await execFile('git', ['-C', brainDir, ...args], { encoding: 'utf8' })
+    const env = await buildGitExecEnv(brainDir, args, DEFAULT_GIT_SIGNATURE)
+    const { stdout } = await execFile('git', ['-C', brainDir, ...args], {
+      encoding: 'utf8',
+      ...(env !== undefined ? { env } : {}),
+    })
     return stdout
   } catch (err) {
     throw new CliError(`git ${args.join(' ')}: ${describeExecFailure(err)}`)

--- a/sdks/ts/memory/src/http/daemon.test.ts
+++ b/sdks/ts/memory/src/http/daemon.test.ts
@@ -9,7 +9,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MEMORY_PACKAGE } from '../index.js'
 import type {
@@ -632,6 +632,36 @@ describe('memory daemon integration', () => {
     expect(collected).toContain('"path":"evt.md"')
 
     await reader.cancel()
+  })
+
+  it('6b. /events emits ping heartbeats and stops them on disconnect', async () => {
+    vi.useFakeTimers()
+    try {
+      const { handler } = await makeDaemon()
+      await createBrain(handler, 'eventsping')
+
+      const resp = await handler(makeRequest('GET', '/v1/brains/eventsping/events'))
+      expect(resp.status).toBe(200)
+      const reader = resp.body?.getReader()
+      expect(reader).toBeDefined()
+      if (reader === undefined) throw new Error('expected response body')
+      const decoder = new TextDecoder('utf-8')
+
+      const ready = await reader.read()
+      expect(ready.done).toBe(false)
+      expect(decoder.decode(ready.value, { stream: true })).toBe('event: ready\ndata: ok\n\n')
+
+      await vi.advanceTimersByTimeAsync(25_000)
+      const ping = await reader.read()
+      expect(ping.done).toBe(false)
+      expect(decoder.decode(ping.value, { stream: true })).toBe('event: ping\ndata: keepalive\n\n')
+
+      await reader.cancel()
+      await Promise.resolve()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('7. maps not-found and oversized body to Problem+JSON', async () => {

--- a/sdks/ts/memory/src/http/daemon.test.ts
+++ b/sdks/ts/memory/src/http/daemon.test.ts
@@ -649,12 +649,16 @@ describe('memory daemon integration', () => {
 
       const ready = await reader.read()
       expect(ready.done).toBe(false)
-      expect(decoder.decode(ready.value, { stream: true })).toBe('event: ready\ndata: ok\n\n')
+      expect(decoder.decode(ready.value, { stream: true })).toBe(
+        'event: ready\nid: 1\ndata: ok\n\n',
+      )
 
       await vi.advanceTimersByTimeAsync(25_000)
       const ping = await reader.read()
       expect(ping.done).toBe(false)
-      expect(decoder.decode(ping.value, { stream: true })).toBe('event: ping\ndata: keepalive\n\n')
+      expect(decoder.decode(ping.value, { stream: true })).toBe(
+        'event: ping\nid: 2\ndata: keepalive\n\n',
+      )
 
       await reader.cancel()
       await Promise.resolve()

--- a/sdks/ts/memory/src/http/handlers.ts
+++ b/sdks/ts/memory/src/http/handlers.ts
@@ -19,6 +19,7 @@ import type { ConsolidationReport, ExtractedMemory, Scope } from '../memory/inde
 import { scopeTopic } from '../memory/index.js'
 import { augmentQueryWithTemporal, resolvedTemporalHintLine } from '../query/index.js'
 import type { RetrievalFilters } from '../retrieval/index.js'
+import { createSseHeartbeat } from '../sse.js'
 import {
   ErrConflict,
   ErrInvalidPath,
@@ -1487,19 +1488,15 @@ export const handleEvents = async (
     writer.sendJson('change', payload)
   })
 
-  // Periodic keep-alive so proxies do not close the stream.
-  const ping = setInterval(() => {
-    if (writer.closed) {
-      clearInterval(ping)
-      return
+  let stopPing = (): void => undefined
+  stopPing = createSseHeartbeat(25_000, () => {
+    if (writer.closed || !writer.sendRaw('ping', 'keepalive')) {
+      stopPing()
     }
-    if (!writer.sendRaw('ping', 'keepalive')) {
-      clearInterval(ping)
-    }
-  }, 25_000)
+  })
 
   void session.done.then(() => {
-    clearInterval(ping)
+    stopPing()
     unsubscribe()
   })
 

--- a/sdks/ts/memory/src/http/sse.test.ts
+++ b/sdks/ts/memory/src/http/sse.test.ts
@@ -14,7 +14,8 @@ describe('http/sse', () => {
 
     await expect(session.done).resolves.toBeUndefined()
     await expect(session.response.text()).resolves.toBe(
-      'event: ready\ndata: ok\n\n' + 'event: change\ndata: {"path":"memory/a.md"}\n\n',
+      'event: ready\nid: 1\ndata: ok\n\n' +
+        'event: change\nid: 2\ndata: {"path":"memory/a.md"}\n\n',
     )
   })
 })

--- a/sdks/ts/memory/src/http/sse.test.ts
+++ b/sdks/ts/memory/src/http/sse.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+
+import { startSse } from './sse.js'
+
+describe('http/sse', () => {
+  it('streams frames using the shared formatter', async () => {
+    const session = startSse(undefined)
+
+    expect(session.writer.sendRaw('ready', 'ok')).toBe(true)
+    expect(session.writer.sendJson('change', { path: 'memory/a.md' })).toBe(true)
+    session.writer.close()
+
+    await expect(session.done).resolves.toBeUndefined()
+    await expect(session.response.text()).resolves.toBe(
+      'event: ready\ndata: ok\n\n' + 'event: change\ndata: {"path":"memory/a.md"}\n\n',
+    )
+  })
+})

--- a/sdks/ts/memory/src/http/sse.ts
+++ b/sdks/ts/memory/src/http/sse.ts
@@ -35,6 +35,7 @@ const encoder = new TextEncoder()
 export const startSse = (signal: AbortSignal | undefined): SseSession => {
   let controllerRef: ReadableStreamDefaultController<Uint8Array> | undefined
   let closed = false
+  let nextEventId = 1
   let resolveDone: (() => void) | undefined
   const done = new Promise<void>((resolve) => {
     resolveDone = resolve
@@ -53,7 +54,15 @@ export const startSse = (signal: AbortSignal | undefined): SseSession => {
   const send = (event: string, data: string): boolean => {
     if (closed) return false
     try {
-      controllerRef?.enqueue(encoder.encode(formatSseFrame({ event, data })))
+      controllerRef?.enqueue(
+        encoder.encode(
+          formatSseFrame({
+            event,
+            id: String(nextEventId++),
+            data,
+          }),
+        ),
+      )
       return true
     } catch {
       closed = true

--- a/sdks/ts/memory/src/http/sse.ts
+++ b/sdks/ts/memory/src/http/sse.ts
@@ -7,6 +7,8 @@
  * the abort signal released by the runtime drains the stream cleanly.
  */
 
+import { formatSseFrame } from '../sse.js'
+
 export type SseWriter = {
   sendRaw: (event: string, data: string) => boolean
   sendJson: (event: string, payload: unknown) => boolean
@@ -22,16 +24,6 @@ export type SseSession = {
 }
 
 const encoder = new TextEncoder()
-
-const formatFrame = (event: string, data: string): string => {
-  const lines: string[] = []
-  lines.push(`event: ${event}`)
-  for (const line of data.split('\n')) {
-    lines.push(`data: ${line}`)
-  }
-  lines.push('', '')
-  return lines.join('\n')
-}
 
 /**
  * Start an SSE stream. The caller receives a Response pre-configured
@@ -61,7 +53,7 @@ export const startSse = (signal: AbortSignal | undefined): SseSession => {
   const send = (event: string, data: string): boolean => {
     if (closed) return false
     try {
-      controllerRef?.enqueue(encoder.encode(formatFrame(event, data)))
+      controllerRef?.enqueue(encoder.encode(formatSseFrame({ event, data })))
       return true
     } catch {
       closed = true

--- a/sdks/ts/memory/src/sse.test.ts
+++ b/sdks/ts/memory/src/sse.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createSseHeartbeat, formatSseFrame } from './sse.js'
+
+describe('sse utilities', () => {
+  it('formats an SSE frame with optional id and multi-line data', () => {
+    expect(
+      formatSseFrame({
+        event: 'change',
+        id: '42',
+        data: 'alpha\r\nbravo\ncharlie\rdelta',
+      }),
+    ).toBe('event: change\nid: 42\ndata: alpha\ndata: bravo\ndata: charlie\ndata: delta\n\n')
+  })
+
+  it('strips line breaks from event metadata', () => {
+    expect(
+      formatSseFrame({
+        event: 'chan\ng\re',
+        id: '1\r\n2',
+        data: 'ok',
+      }),
+    ).toBe('event: change\nid: 12\ndata: ok\n\n')
+  })
+
+  it('ticks until stopped', () => {
+    vi.useFakeTimers()
+    try {
+      const onHeartbeat = vi.fn()
+      const stop = createSseHeartbeat(25_000, onHeartbeat)
+
+      vi.advanceTimersByTime(50_000)
+      expect(onHeartbeat).toHaveBeenCalledTimes(2)
+
+      stop()
+      vi.advanceTimersByTime(25_000)
+      expect(onHeartbeat).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects non-positive heartbeat intervals', () => {
+    expect(() => createSseHeartbeat(0, () => undefined)).toThrow(RangeError)
+  })
+})

--- a/sdks/ts/memory/src/sse.ts
+++ b/sdks/ts/memory/src/sse.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type SseFrame = {
+  readonly event: string
+  readonly data: string
+  readonly id?: string
+}
+
+const normaliseLineBreaks = (value: string): string => value.replace(/\r\n?/g, '\n')
+
+const normaliseFieldValue = (value: string): string =>
+  normaliseLineBreaks(value).replaceAll('\n', '')
+
+export const formatSseFrame = (frame: SseFrame): string => {
+  const lines = [`event: ${normaliseFieldValue(frame.event)}`]
+  if (frame.id !== undefined) {
+    lines.push(`id: ${normaliseFieldValue(frame.id)}`)
+  }
+  for (const line of normaliseLineBreaks(frame.data).split('\n')) {
+    lines.push(`data: ${line}`)
+  }
+  lines.push('', '')
+  return lines.join('\n')
+}
+
+export const createSseHeartbeat = (
+  intervalMs: number,
+  onHeartbeat: () => void,
+  clock: Pick<typeof globalThis, 'setInterval' | 'clearInterval'> = globalThis,
+): (() => void) => {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new RangeError('intervalMs must be greater than 0')
+  }
+  let stopped = false
+  const timer = clock.setInterval(() => {
+    if (!stopped) onHeartbeat()
+  }, intervalMs)
+  return () => {
+    if (stopped) return
+    stopped = true
+    clock.clearInterval(timer)
+  }
+}

--- a/sdks/ts/memory/src/store/git-author.ts
+++ b/sdks/ts/memory/src/store/git-author.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { execFile as execFileCallback } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFile = promisify(execFileCallback)
+
+export type GitSignature = {
+  readonly name: string
+  readonly email: string
+}
+
+export const DEFAULT_GIT_SIGNATURE: GitSignature = {
+  name: 'jeffs-brain',
+  email: 'noreply@jeffsbrain.com',
+}
+
+const NEEDS_IDENTITY = new Set(['commit', 'rebase', 'stash'])
+
+const readGitConfigValue = async (cwd: string, key: string): Promise<string | undefined> => {
+  try {
+    const { stdout } = await execFile('git', ['config', '--get', key], {
+      cwd,
+      encoding: 'utf8',
+    })
+    const value = stdout.trim()
+    return value === '' ? undefined : value
+  } catch {
+    return undefined
+  }
+}
+
+const envValue = (...keys: readonly string[]): string | undefined => {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (value !== undefined && value.trim() !== '') return value
+  }
+  return undefined
+}
+
+export const buildGitExecEnv = async (
+  cwd: string,
+  args: readonly string[],
+  fallback: GitSignature = DEFAULT_GIT_SIGNATURE,
+): Promise<NodeJS.ProcessEnv | undefined> => {
+  const command = args[0]
+  if (command === undefined || !NEEDS_IDENTITY.has(command)) return undefined
+
+  const name =
+    envValue('GIT_AUTHOR_NAME', 'GIT_COMMITTER_NAME') ??
+    (await readGitConfigValue(cwd, 'user.name')) ??
+    fallback.name
+  const email =
+    envValue('GIT_AUTHOR_EMAIL', 'GIT_COMMITTER_EMAIL') ??
+    (await readGitConfigValue(cwd, 'user.email')) ??
+    fallback.email
+
+  return {
+    ...process.env,
+    ...(envValue('GIT_AUTHOR_NAME') === undefined ? { GIT_AUTHOR_NAME: name } : {}),
+    ...(envValue('GIT_COMMITTER_NAME') === undefined ? { GIT_COMMITTER_NAME: name } : {}),
+    ...(envValue('GIT_AUTHOR_EMAIL') === undefined ? { GIT_AUTHOR_EMAIL: email } : {}),
+    ...(envValue('GIT_COMMITTER_EMAIL') === undefined ? { GIT_COMMITTER_EMAIL: email } : {}),
+  }
+}

--- a/sdks/ts/memory/src/store/gitstore.ts
+++ b/sdks/ts/memory/src/store/gitstore.ts
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 import * as git from 'isomorphic-git'
 import { ErrConflict, ErrReadOnly, StoreError } from './errors.js'
 import { type FsStore, createFsStore } from './fsstore.js'
+import { DEFAULT_GIT_SIGNATURE, type GitSignature, buildGitExecEnv } from './git-author.js'
 import type {
   Batch,
   BatchOptions,
@@ -19,11 +20,6 @@ import type {
   Unsubscribe,
 } from './index.js'
 import type { Path } from './path.js'
-
-export type GitSignature = {
-  readonly name: string
-  readonly email: string
-}
 
 export type GitSignPayload = {
   readonly payload: string
@@ -41,10 +37,7 @@ export type GitStoreOptions = {
   readonly autoPush?: boolean
 }
 
-const DEFAULT_AUTHOR: GitSignature = {
-  name: 'jeffs-brain',
-  email: 'noreply@jeffsbrain.com',
-}
+const DEFAULT_AUTHOR = DEFAULT_GIT_SIGNATURE
 
 const DEFAULT_BRANCH = 'main'
 const DEFAULT_REMOTE = 'origin'
@@ -584,7 +577,12 @@ const lsRemote = async (remoteUrl: string, branch?: string): Promise<string> => 
 }
 
 const runGit = async (cwd: string, args: readonly string[]): Promise<string> => {
-  const { stdout } = await execFile('git', [...args], { cwd, encoding: 'utf8' })
+  const env = await buildGitExecEnv(cwd, args, DEFAULT_AUTHOR)
+  const { stdout } = await execFile('git', [...args], {
+    cwd,
+    encoding: 'utf8',
+    ...(env !== undefined ? { env } : {}),
+  })
   return stdout
 }
 
@@ -714,6 +712,8 @@ export const listCommitFiles = async (dir: string, oid: string): Promise<string[
   out.sort()
   return out
 }
+
+export type { GitSignature }
 
 const walkCommitTree = async (
   dir: string,


### PR DESCRIPTION
## Summary
- export framework-agnostic SSE framing and heartbeat helpers from `@jeffs-brain/memory/sse`
- reuse the shared formatter and heartbeat helper in the built-in daemon SSE transport
- add focused tests and README usage notes for Node framework integrations

## Validation
- `cd sdks/ts/memory && bun run typecheck`
- `cd sdks/ts/memory && bun run build`
- `cd sdks/ts/memory && bun x vitest run src/sse.test.ts src/http/sse.test.ts src/http/daemon.test.ts src/http/handlers.test.ts`
- `cd /home/jaythegeek/code/jeffs-brain/memory-issue-3 && bun x biome check sdks/ts/memory/README.md sdks/ts/memory/package.json sdks/ts/memory/src/http/handlers.ts sdks/ts/memory/src/http/sse.ts sdks/ts/memory/src/http/sse.test.ts sdks/ts/memory/src/sse.test.ts sdks/ts/memory/src/sse.ts`

Closes #3
