### PR TITLE
Fix timing-unsafe bearer token comparison

### DIFF
--- a/go/internal/httpd/middleware.go
+++ b/go/internal/httpd/middleware.go
@@ -3,6 +3,7 @@
 package httpd
 
 import (
+	"crypto/subtle"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -32,7 +33,6 @@ func AuthMiddleware(token string, next http.Handler) http.Handler {
 	if token == "" {
 		return next
 	}
-	expected := "Bearer " + token
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" {
 			next.ServeHTTP(w, r)
@@ -43,12 +43,31 @@ func AuthMiddleware(token string, next http.Handler) http.Handler {
 			Unauthorized(w, "missing Authorization header")
 			return
 		}
-		if !strings.EqualFold(got, expected) {
+		if !validBearerToken(got, token) {
 			Forbidden(w, "invalid bearer token")
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+const bearerPrefix = "bearer "
+
+// validBearerToken checks that header is a Bearer token matching expected.
+// The scheme prefix comparison is case-insensitive (RFC 7235); the token
+// comparison uses constant-time equality to prevent timing side-channels.
+func validBearerToken(header, expected string) bool {
+	if len(header) < len(bearerPrefix) {
+		return false
+	}
+	if !strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+		return false
+	}
+	actual := header[len(bearerPrefix):]
+	if len(actual) == 0 {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(actual), []byte(expected)) == 1
 }
 
 // Implements http.ResponseWriter / http.Flusher passthrough so SSE

--- a/go/internal/httpd/middleware.go
+++ b/go/internal/httpd/middleware.go
@@ -3,6 +3,7 @@
 package httpd
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"log/slog"
 	"net/http"
@@ -51,23 +52,31 @@ func AuthMiddleware(token string, next http.Handler) http.Handler {
 	})
 }
 
-const bearerPrefix = "bearer "
+const bearerScheme = "bearer"
 
 // validBearerToken checks that header is a Bearer token matching expected.
-// The scheme prefix comparison is case-insensitive (RFC 7235); the token
-// comparison uses constant-time equality to prevent timing side-channels.
+// The scheme comparison is case-insensitive per RFC 7235 and accepts
+// one-or-more spaces between scheme and token per the RFC grammar.
+// Token comparison hashes both sides with SHA-256 before calling
+// ConstantTimeCompare so that differing lengths do not leak timing.
 func validBearerToken(header, expected string) bool {
-	if len(header) < len(bearerPrefix) {
+	if len(header) < len(bearerScheme)+1 {
 		return false
 	}
-	if !strings.EqualFold(header[:len(bearerPrefix)], bearerPrefix) {
+	if !strings.EqualFold(header[:len(bearerScheme)], bearerScheme) {
 		return false
 	}
-	actual := header[len(bearerPrefix):]
+	rest := header[len(bearerScheme):]
+	if len(rest) == 0 || rest[0] != ' ' {
+		return false
+	}
+	actual := strings.TrimLeft(rest, " ")
 	if len(actual) == 0 {
 		return false
 	}
-	return subtle.ConstantTimeCompare([]byte(actual), []byte(expected)) == 1
+	actualHash := sha256.Sum256([]byte(actual))
+	expectedHash := sha256.Sum256([]byte(expected))
+	return subtle.ConstantTimeCompare(actualHash[:], expectedHash[:]) == 1
 }
 
 // Implements http.ResponseWriter / http.Flusher passthrough so SSE

--- a/go/internal/httpd/middleware_test.go
+++ b/go/internal/httpd/middleware_test.go
@@ -44,6 +44,16 @@ func TestValidBearerToken_valid(t *testing.T) {
 			header: "Bearer " + string(make([]byte, 4096)),
 			token:  string(make([]byte, 4096)),
 		},
+		{
+			name:   "multiple spaces between scheme and token",
+			header: "Bearer   my-secret-token",
+			token:  "my-secret-token",
+		},
+		{
+			name:   "two spaces between scheme and token",
+			header: "Bearer  my-secret-token",
+			token:  "my-secret-token",
+		},
 	}
 
 	for _, tt := range tests {
@@ -124,6 +134,7 @@ func TestAuthMiddleware_authorized(t *testing.T) {
 		{name: "standard bearer", header: "Bearer secret"},
 		{name: "lowercase bearer", header: "bearer secret"},
 		{name: "uppercase bearer", header: "BEARER secret"},
+		{name: "multiple spaces", header: "Bearer   secret"},
 	}
 
 	for _, tt := range tests {

--- a/go/internal/httpd/middleware_test.go
+++ b/go/internal/httpd/middleware_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValidBearerToken_valid(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		token  string
+	}{
+		{
+			name:   "standard bearer prefix",
+			header: "Bearer my-secret-token",
+			token:  "my-secret-token",
+		},
+		{
+			name:   "lowercase bearer prefix",
+			header: "bearer my-secret-token",
+			token:  "my-secret-token",
+		},
+		{
+			name:   "uppercase bearer prefix",
+			header: "BEARER my-secret-token",
+			token:  "my-secret-token",
+		},
+		{
+			name:   "mixed case bearer prefix",
+			header: "bEaReR my-secret-token",
+			token:  "my-secret-token",
+		},
+		{
+			name:   "token with special characters",
+			header: "Bearer abc!@#$%^&*()_+-=[]{}|;':\",./<>?",
+			token:  "abc!@#$%^&*()_+-=[]{}|;':\",./<>?",
+		},
+		{
+			name:   "very long token",
+			header: "Bearer " + string(make([]byte, 4096)),
+			token:  string(make([]byte, 4096)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !validBearerToken(tt.header, tt.token) {
+				t.Errorf("validBearerToken(%q, %q) = false, want true", tt.header, tt.token)
+			}
+		})
+	}
+}
+
+func TestValidBearerToken_invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		token  string
+	}{
+		{
+			name:   "wrong token",
+			header: "Bearer wrong-token",
+			token:  "correct-token",
+		},
+		{
+			name:   "empty header",
+			header: "",
+			token:  "my-token",
+		},
+		{
+			name:   "non-bearer scheme",
+			header: "Basic dXNlcjpwYXNz",
+			token:  "dXNlcjpwYXNz",
+		},
+		{
+			name:   "empty token after bearer prefix",
+			header: "Bearer ",
+			token:  "my-token",
+		},
+		{
+			name:   "bearer prefix only no space",
+			header: "Bearer",
+			token:  "my-token",
+		},
+		{
+			name:   "token case mismatch is rejected",
+			header: "Bearer MyToken",
+			token:  "mytoken",
+		},
+		{
+			name:   "partial prefix",
+			header: "Bear my-token",
+			token:  "my-token",
+		},
+		{
+			name:   "token with trailing space differs",
+			header: "Bearer my-token ",
+			token:  "my-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if validBearerToken(tt.header, tt.token) {
+				t.Errorf("validBearerToken(%q, %q) = true, want false", tt.header, tt.token)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_authorized(t *testing.T) {
+	handler := AuthMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{name: "standard bearer", header: "Bearer secret"},
+		{name: "lowercase bearer", header: "bearer secret"},
+		{name: "uppercase bearer", header: "BEARER secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Header.Set("Authorization", tt.header)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("got status %d, want %d", rec.Code, http.StatusOK)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_unauthorized(t *testing.T) {
+	handler := AuthMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	tests := []struct {
+		name       string
+		header     string
+		wantStatus int
+	}{
+		{
+			name:       "missing authorization header",
+			header:     "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "wrong token",
+			header:     "Bearer wrong",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "non-bearer scheme",
+			header:     "Basic c2VjcmV0",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "empty token value",
+			header:     "Bearer ",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_healthzBypass(t *testing.T) {
+	handler := AuthMiddleware("secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("got status %d, want %d for /healthz bypass", rec.Code, http.StatusOK)
+	}
+}
+
+func TestAuthMiddleware_emptyTokenPassthrough(t *testing.T) {
+	called := false
+	handler := AuthMiddleware("", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler was not called when token is empty (should be passthrough)")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("got status %d, want %d for empty-token passthrough", rec.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces `strings.EqualFold` token comparison in auth middleware with `crypto/subtle.ConstantTimeCompare` to prevent timing side-channel attacks.

## Problem

`strings.EqualFold` performs byte-by-byte comparison and returns early on first mismatch. An attacker can determine the correct token character-by-character by measuring response times. Additionally, case-insensitive comparison weakens the effective keyspace (RFC 6750 specifies tokens are case-sensitive).

## Changes

- `go/internal/httpd/middleware.go`: Extracted `validBearerToken()` function that parses "Bearer" prefix case-insensitively (RFC 7235) then compares the token value using `subtle.ConstantTimeCompare`
- `go/internal/httpd/middleware_test.go`: Added comprehensive table-driven tests covering valid tokens, prefix case variations, invalid tokens, missing headers, and edge cases

## Testing

- `go test -race ./internal/httpd/...` passes
- `go vet ./...` passes
- `go build ./...` passes

Resolves LLE-9642