### PR TITLE
Block SSRF in URL ingestion with DNS-level IP validation

### DIFF
--- a/go/knowledge/ingest.go
+++ b/go/knowledge/ingest.go
@@ -62,9 +62,14 @@ var (
 // when the caller does not supply an override.
 type defaultFetcher struct{}
 
-// Fetch implements [Fetcher].
+// Fetch implements [Fetcher]. Uses an SSRF-safe transport that
+// validates resolved IPs before connecting, preventing requests to
+// private networks regardless of DNS rebinding or redirects.
 func (defaultFetcher) Fetch(ctx context.Context, rawURL string) ([]byte, string, error) {
-	client := &http.Client{Timeout: defaultHTTPTimeout}
+	client := &http.Client{
+		Timeout:   defaultHTTPTimeout,
+		Transport: newSSRFSafeTransport(),
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("knowledge: building request: %w", err)
@@ -520,7 +525,9 @@ func collapseWhitespace(s string) string {
 	return strings.TrimSpace(joined)
 }
 
-// normaliseURL ensures a URL has a scheme and is well-formed.
+// normaliseURL ensures a URL has a scheme, is well-formed, and uses an
+// allowed scheme. Only http and https are permitted to prevent file://,
+// gopher://, and other protocol-based SSRF vectors.
 func normaliseURL(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -535,6 +542,9 @@ func normaliseURL(raw string) (string, error) {
 	}
 	if parsed.Host == "" {
 		return "", fmt.Errorf("knowledge: URL missing host")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("ingest: unsupported scheme %q (only http and https allowed)", parsed.Scheme)
 	}
 	return parsed.String(), nil
 }

--- a/go/knowledge/safefetch.go
+++ b/go/knowledge/safefetch.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package knowledge
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// newSSRFSafeTransport returns an [http.Transport] whose DialContext
+// resolves DNS then validates all returned IPs against a blocklist
+// before establishing a connection. This prevents SSRF attacks via
+// user-controlled URLs that resolve to internal infrastructure.
+func newSSRFSafeTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("ingest: invalid address: %w", err)
+			}
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("ingest: dns lookup failed: %w", err)
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("ingest: no addresses resolved for %s", host)
+			}
+			for _, ip := range ips {
+				if isBlockedIP(ip.IP) {
+					return nil, fmt.Errorf("ingest: request to private network blocked")
+				}
+			}
+			dialer := &net.Dialer{Timeout: 10 * time.Second}
+			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+}
+
+// isBlockedIP returns true when the IP belongs to a private, loopback,
+// link-local, or otherwise non-routable address range. Also blocks the
+// cloud metadata endpoint at 169.254.169.254.
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.Equal(net.IPv4(169, 254, 169, 254))
+}

--- a/go/knowledge/safefetch_test.go
+++ b/go/knowledge/safefetch_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package knowledge
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		{name: "ipv4 loopback", ip: "127.0.0.1", blocked: true},
+		{name: "ipv4 loopback alt", ip: "127.0.0.2", blocked: true},
+		{name: "rfc1918 10.x", ip: "10.0.0.1", blocked: true},
+		{name: "rfc1918 172.16.x", ip: "172.16.0.1", blocked: true},
+		{name: "rfc1918 172.31.x", ip: "172.31.255.255", blocked: true},
+		{name: "rfc1918 192.168.x", ip: "192.168.1.1", blocked: true},
+		{name: "link-local ipv4", ip: "169.254.1.1", blocked: true},
+		{name: "cloud metadata", ip: "169.254.169.254", blocked: true},
+		{name: "unspecified ipv4", ip: "0.0.0.0", blocked: true},
+		{name: "ipv6 loopback", ip: "::1", blocked: true},
+		{name: "ipv6 link-local", ip: "fe80::1", blocked: true},
+		{name: "ipv6 unspecified", ip: "::", blocked: true},
+		{name: "ipv6 unique local", ip: "fd00::1", blocked: true},
+		{name: "public ipv4", ip: "8.8.8.8", blocked: false},
+		{name: "public ipv4 alt", ip: "1.1.1.1", blocked: false},
+		{name: "public ipv4 93.x", ip: "93.184.216.34", blocked: false},
+		{name: "public ipv6", ip: "2607:f8b0:4004:800::200e", blocked: false},
+		{name: "nil ip", ip: "", blocked: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip net.IP
+			if tt.ip != "" {
+				ip = net.ParseIP(tt.ip)
+				if ip == nil {
+					t.Fatalf("failed to parse test IP %q", tt.ip)
+				}
+			}
+			got := isBlockedIP(ip)
+			if got != tt.blocked {
+				t.Errorf("isBlockedIP(%s) = %v, want %v", tt.ip, got, tt.blocked)
+			}
+		})
+	}
+}
+
+func TestNormaliseURL_BlocksUnsafeSchemes(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "https allowed", url: "https://example.com/page", wantErr: false},
+		{name: "http allowed", url: "http://example.com/page", wantErr: false},
+		{name: "no scheme defaults https", url: "example.com/page", wantErr: false},
+		{name: "file scheme blocked", url: "file:///etc/passwd", wantErr: true},
+		{name: "gopher scheme blocked", url: "gopher://evil.test:70/", wantErr: true},
+		{name: "ftp scheme blocked", url: "ftp://ftp.example.com/file", wantErr: true},
+		{name: "dict scheme blocked", url: "dict://evil.test:2628/", wantErr: true},
+		{name: "empty url", url: "", wantErr: true},
+		{name: "missing host", url: "https://", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := normaliseURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("normaliseURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSSRFSafeTransport_BlocksPrivateIPs(t *testing.T) {
+	transport := newSSRFSafeTransport()
+	if transport == nil {
+		t.Fatal("expected non-nil transport")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected DialContext to be set")
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		t.Fatal("expected TLSHandshakeTimeout to be set")
+	}
+}


### PR DESCRIPTION
## Summary

Adds SSRF protection to the URL ingestion endpoint by validating resolved IP addresses at the transport dial level, preventing requests to private networks, loopback, link-local, and cloud metadata endpoints.

## Problem

`defaultFetcher.Fetch()` in `go/knowledge/ingest.go` makes HTTP requests to user-provided URLs with zero IP validation. An authenticated attacker can probe internal services or exfiltrate cloud credentials via metadata endpoints (169.254.169.254).

## Changes

- `go/knowledge/safefetch.go`: New file with `newSSRFSafeTransport()` using custom `DialContext` that resolves DNS first, validates all IPs against blocklist, then connects to resolved IP (prevents DNS rebinding). Also adds `isBlockedIP()` covering loopback, RFC 1918, link-local, metadata, and IPv6 equivalents.
- `go/knowledge/ingest.go`: `defaultFetcher.Fetch()` now uses the safe transport. `normaliseURL()` rejects non-http/https schemes.
- `go/knowledge/safefetch_test.go`: Table-driven tests for IP blocklist and scheme validation.

## Design Decision

IP validation at `DialContext` level (not URL string level) because:
- Catches DNS rebinding attacks (IP checked after resolution)
- Catches redirect-to-private (DialContext runs on every TCP dial including redirects)
- Cannot be bypassed by URL encoding tricks

## Testing

- `go test -race ./knowledge/...` passes
- `go test -race ./...` all 20 packages pass
- `go vet ./...` passes

Resolves LLE-9643