### PR TITLE
Validate brainID to prevent path traversal in HTTP daemon

### DIFF
--- a/go/brain/validate.go
+++ b/go/brain/validate.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package brain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var validBrainIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$`)
+
+// ValidateBrainID returns an error if id is not a safe brain identifier.
+// A valid brain ID starts with an alphanumeric character, contains only
+// [a-zA-Z0-9._-], is between 1 and 128 characters long, and does not
+// contain path traversal sequences.
+func ValidateBrainID(id string) error {
+	if id == "" {
+		return fmt.Errorf("brain: ID must not be empty")
+	}
+	if strings.Contains(id, "..") {
+		return fmt.Errorf("brain: ID must not contain '..'")
+	}
+	if !validBrainIDPattern.MatchString(id) {
+		return fmt.Errorf("brain: ID must start with alphanumeric, contain only [a-zA-Z0-9._-], max 128 chars")
+	}
+	return nil
+}

--- a/go/brain/validate_test.go
+++ b/go/brain/validate_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package brain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBrainID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		// Positive cases.
+		{name: "simple lowercase", id: "my-brain", wantErr: false},
+		{name: "mixed case with dot", id: "Brain.v2", wantErr: false},
+		{name: "minimum length", id: "a", wantErr: false},
+		{name: "max length 128", id: strings.Repeat("a", 128), wantErr: false},
+		{name: "multiple dots no traversal", id: "a.b.c.d", wantErr: false},
+		{name: "all allowed special chars", id: "brain_v2-final.1", wantErr: false},
+		{name: "numeric start", id: "1brain", wantErr: false},
+
+		// Negative cases.
+		{name: "empty", id: "", wantErr: true},
+		{name: "path traversal passwd", id: "../../etc/passwd", wantErr: true},
+		{name: "path traversal prefix", id: "../attack", wantErr: true},
+		{name: "path separator slash", id: "brain/sub", wantErr: true},
+		{name: "starts with dot", id: ".hidden", wantErr: true},
+		{name: "starts with dash", id: "-dash", wantErr: true},
+		{name: "exceeds max length", id: strings.Repeat("a", 129), wantErr: true},
+		{name: "null byte", id: "brain\x00null", wantErr: true},
+		{name: "contains space", id: "brain name", wantErr: true},
+		{name: "backslash", id: "brain\\sub", wantErr: true},
+		{name: "unicode", id: "brainé", wantErr: true},
+		{name: "double dot traversal embedded", id: "foo..bar", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBrainID(tc.id)
+			if tc.wantErr && err == nil {
+				t.Fatalf("ValidateBrainID(%q) = nil, want error", tc.id)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateBrainID(%q) = %v, want nil", tc.id, err)
+			}
+		})
+	}
+}

--- a/go/cmd/memory-mcp/client.go
+++ b/go/cmd/memory-mcp/client.go
@@ -254,9 +254,15 @@ func (c *localClient) resolveBrainID(override string) string {
 	return defaultBrainID
 }
 
-// brainRoot returns the on-disk root for a brain.
+// brainRoot returns the on-disk root for a brain. When the ID passes
+// [brain.ValidateBrainID] it is used directly; otherwise the legacy
+// sanitiser normalises it to a safe filesystem component.
 func (c *localClient) brainRoot(id string) string {
-	return filepath.Join(c.cfg.BrainRoot, "brains", sanitiseBrainID(id))
+	safe := id
+	if brain.ValidateBrainID(id) != nil {
+		safe = sanitiseBrainID(id)
+	}
+	return filepath.Join(c.cfg.BrainRoot, "brains", safe)
 }
 
 // openBrain returns a cached [localBrain] for id, constructing one on

--- a/go/cmd/memory/daemon.go
+++ b/go/cmd/memory/daemon.go
@@ -104,12 +104,19 @@ func (d *Daemon) Close() error {
 	return nil
 }
 
-func (d *Daemon) brainRoot(brainID string) string {
-	return filepath.Join(d.Root, "brains", brainID)
+func (d *Daemon) brainRoot(brainID string) (string, error) {
+	if err := brain.ValidateBrainID(brainID); err != nil {
+		return "", err
+	}
+	return filepath.Join(d.Root, "brains", brainID), nil
 }
 
 func (d *Daemon) brainExists(brainID string) bool {
-	info, err := os.Stat(d.brainRoot(brainID))
+	root, err := d.brainRoot(brainID)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(root)
 	if err != nil {
 		return false
 	}
@@ -224,7 +231,10 @@ func (bm *BrainManager) Create(ctx context.Context, brainID string) (*BrainResou
 	if brainID == "" {
 		return nil, errors.New("brain manager: brainID required")
 	}
-	root := bm.d.brainRoot(brainID)
+	root, err := bm.d.brainRoot(brainID)
+	if err != nil {
+		return nil, fmt.Errorf("brain manager: %w", err)
+	}
 	if _, err := os.Stat(root); err == nil {
 		return nil, fmt.Errorf("brain manager: brain %s: %w", brainID, brain.ErrConflict)
 	}
@@ -271,7 +281,10 @@ func (bm *BrainManager) Delete(brainID string) error {
 		_ = entry.Close()
 		delete(bm.all, brainID)
 	}
-	root := bm.d.brainRoot(brainID)
+	root, err := bm.d.brainRoot(brainID)
+	if err != nil {
+		return fmt.Errorf("brain manager: %w", err)
+	}
 	info, err := os.Stat(root)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -300,7 +313,10 @@ func (bm *BrainManager) Close() error {
 // search is left nil and the retriever falls back to BM25-via-search
 // (or no-op when no index is present).
 func (bm *BrainManager) build(ctx context.Context, brainID string) (*BrainResources, error) {
-	root := bm.d.brainRoot(brainID)
+	root, err := bm.d.brainRoot(brainID)
+	if err != nil {
+		return nil, fmt.Errorf("brain manager: %w", err)
+	}
 	store, err := pt.New(root)
 	if err != nil {
 		return nil, fmt.Errorf("brain manager: store %s: %w", root, err)

--- a/go/cmd/memory/handler_brains.go
+++ b/go/cmd/memory/handler_brains.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jeffs-brain/memory/go/brain"
 	"github.com/jeffs-brain/memory/go/internal/httpd"
 )
 
@@ -43,6 +44,10 @@ func (d *Daemon) handleGetBrain(w http.ResponseWriter, r *http.Request) {
 		httpd.ValidationError(w, "missing brainId")
 		return
 	}
+	if err := brain.ValidateBrainID(id); err != nil {
+		httpd.ValidationError(w, err.Error())
+		return
+	}
 	if !d.brainExists(id) {
 		httpd.NotFound(w, "brain not found: "+id)
 		return
@@ -58,6 +63,10 @@ func (d *Daemon) handleCreateBrain(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.BrainID == "" {
 		httpd.ValidationError(w, "brainId required")
+		return
+	}
+	if err := brain.ValidateBrainID(req.BrainID); err != nil {
+		httpd.ValidationError(w, err.Error())
 		return
 	}
 	if _, err := d.Brains.Create(r.Context(), req.BrainID); err != nil {
@@ -78,6 +87,10 @@ func (d *Daemon) handleDeleteBrain(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("brainId")
 	if id == "" {
 		httpd.ValidationError(w, "missing brainId")
+		return
+	}
+	if err := brain.ValidateBrainID(id); err != nil {
+		httpd.ValidationError(w, err.Error())
 		return
 	}
 	if r.Header.Get("X-Confirm-Delete") != "yes" {

--- a/go/cmd/memory/handler_helpers.go
+++ b/go/cmd/memory/handler_helpers.go
@@ -57,11 +57,15 @@ func decodeJSONBody(r *http.Request, target any, limit int64) error {
 
 // resolveBrain pulls brainId from the path and looks it up via
 // BrainManager. Writes the appropriate Problem+JSON and returns nil
-// when the brain is missing.
+// when the brain is missing or invalid.
 func (d *Daemon) resolveBrain(w http.ResponseWriter, r *http.Request) *BrainResources {
 	id := r.PathValue("brainId")
 	if id == "" {
 		httpd.ValidationError(w, "missing brainId")
+		return nil
+	}
+	if err := brain.ValidateBrainID(id); err != nil {
+		httpd.ValidationError(w, err.Error())
 		return nil
 	}
 	br, err := d.Brains.Get(r.Context(), id)

--- a/go/cmd/memory/serve_integration_test.go
+++ b/go/cmd/memory/serve_integration_test.go
@@ -616,3 +616,38 @@ func TestServePreseededBrainScanOnOpen(t *testing.T) {
 		t.Fatalf("expected hedgehog.md in chunks, got: %+v", out.Chunks)
 	}
 }
+
+// TestServeCreateBrainPathTraversal verifies that POST /v1/brains
+// rejects a brainId containing path traversal sequences with 400.
+func TestServeCreateBrainPathTraversal(t *testing.T) {
+	_, srv := newTestDaemon(t)
+	c := srv.Client()
+
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"dotdot traversal", "../../etc/attack"},
+		{"relative prefix", "../attack"},
+		{"slash separator", "brain/sub"},
+		{"dot start", ".hidden"},
+		{"space in name", "brain name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, _ := json.Marshal(map[string]string{"brainId": tc.id})
+			resp, err := c.Post(srv.URL+"/v1/brains", "application/json", bytes.NewReader(payload))
+			if err != nil {
+				t.Fatalf("create %q: %v", tc.id, err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("create %q status = %d, want 400; body = %s", tc.id, resp.StatusCode, body)
+			}
+			if !strings.Contains(string(body), "validation_error") {
+				t.Fatalf("body missing validation_error code: %s", body)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds brainID validation to prevent path traversal attacks via the HTTP daemon. Extracts validation to a shared `brain.ValidateBrainID()` function used by both the HTTP daemon and MCP server.

## Problem

`POST /v1/brains` reads `brainId` from JSON body without validation. A payload like `{"brainId": "../../etc/attack"}` triggers `os.MkdirAll` outside the brains directory tree via `daemon.brainRoot()`. Go 1.22 ServeMux protects URL path params but not JSON body values.

## Changes

- `go/brain/validate.go`: New shared `ValidateBrainID()` — regex validation (alphanumeric start, `[a-zA-Z0-9._-]`, max 128 chars), `..` traversal rejection
- `go/brain/validate_test.go`: Table-driven tests (positive, negative, edge cases)
- `go/cmd/memory/daemon.go`: `brainRoot()` now validates and returns error
- `go/cmd/memory/handler_brains.go`: Guards in create/get/delete handlers
- `go/cmd/memory/handler_helpers.go`: Guard in shared `resolveBrain()` helper
- `go/cmd/memory-mcp/client.go`: Updated to use shared validation
- `go/cmd/memory/serve_integration_test.go`: Integration test for path traversal rejection

## Defence in Depth

Validation applied at two levels:
1. HTTP handler level (returns 400 before any filesystem operation)
2. `brainRoot()` level (defence-in-depth for any caller that bypasses handler validation)

## Testing

- `go test -race ./brain/... ./cmd/memory/...` passes
- `go test -race ./...` passes
- `go vet ./...` passes

Resolves LLE-9644