### PR TITLE
Fix OpenAI embedder to include dimensions in API request

### DIFF
--- a/go/llm/openai.go
+++ b/go/llm/openai.go
@@ -454,8 +454,9 @@ func (e *openAIEmbedder) Embed(ctx context.Context, texts []string) ([][]float32
 		return nil, nil
 	}
 	body, err := json.Marshal(openAIEmbedRequest{
-		Input: texts,
-		Model: e.cfg.Model,
+		Input:      texts,
+		Model:      e.cfg.Model,
+		Dimensions: e.cfg.Dimensions,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("llm: marshal openai embed request: %w", err)

--- a/go/llm/openai_test.go
+++ b/go/llm/openai_test.go
@@ -223,3 +223,89 @@ func TestOpenAIEmbedder(t *testing.T) {
 		t.Fatalf("dims %d", e.Dimensions())
 	}
 }
+
+func TestOpenAIEmbedder_DimensionsInRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dimensions int
+		wantInBody bool
+		wantValue  int
+	}{
+		{"configured 256 is sent", 256, true, 256},
+		{"configured 1536 is sent", 1536, true, 1536},
+		{"configured 3072 is sent", 3072, true, 3072},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"data":[{"index":0,"embedding":[0.1,0.2]}]}`)
+			}))
+			defer srv.Close()
+
+			e := llm.NewOpenAIEmbedder(llm.OpenAIEmbedConfig{
+				APIKey:     "k",
+				BaseURL:    srv.URL,
+				Dimensions: tt.dimensions,
+			})
+			defer func() { _ = e.Close() }()
+
+			vecs, err := e.Embed(context.Background(), []string{"test"})
+			if err != nil {
+				t.Fatalf("embed: %v", err)
+			}
+			if len(vecs) != 1 {
+				t.Fatalf("expected 1 vector, got %d", len(vecs))
+			}
+
+			dim, exists := gotBody["dimensions"]
+			if !exists {
+				t.Fatalf("dimensions field missing from request body")
+			}
+			if int(dim.(float64)) != tt.wantValue {
+				t.Fatalf("dimensions = %v, want %d", dim, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestOpenAIEmbedder_DefaultDimensionsSent(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"data":[{"index":0,"embedding":[0.1,0.2]}]}`)
+	}))
+	defer srv.Close()
+
+	e := llm.NewOpenAIEmbedder(llm.OpenAIEmbedConfig{
+		APIKey:  "k",
+		BaseURL: srv.URL,
+	})
+	defer func() { _ = e.Close() }()
+
+	_, err := e.Embed(context.Background(), []string{"test"})
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+
+	dim, exists := gotBody["dimensions"]
+	if !exists {
+		t.Fatalf("dimensions field missing when default should be applied")
+	}
+	if int(dim.(float64)) != 1536 {
+		t.Fatalf("default dimensions = %v, want 1536", dim)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the OpenAI embedder to include the configured `dimensions` field in embedding API requests. Previously, the field was stored in config but never sent, causing users to silently receive full-dimension vectors regardless of their configuration.

## Problem

`openAIEmbedRequest` struct has `Dimensions int` with `json:"dimensions,omitempty"` tag, but `Embed()` constructed requests with only `Input` and `Model`. Users configuring reduced dimensions (e.g., 256 for Matryoshka) received full-dimension vectors — wasting storage and degrading HNSW search performance.

## Changes

- `go/llm/openai.go`: Added `Dimensions: e.cfg.Dimensions` to the embed request construction
- `go/llm/openai_test.go`: Added tests verifying request body contains correct dimensions value

## Testing

- `go test -race ./llm/...` passes
- `go vet ./...` passes

Resolves LLE-9645