### PR TITLE
Handle tool_use content blocks in Anthropic streaming

### DIFF
--- a/go/llm/anthropic.go
+++ b/go/llm/anthropic.go
@@ -204,41 +204,7 @@ func (p *anthropicProvider) CompleteStream(ctx context.Context, req CompleteRequ
 	go func() {
 		defer resp.Body.Close()
 		defer close(out)
-		scanner := bufio.NewScanner(resp.Body)
-		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.HasPrefix(line, "data: ") {
-				continue
-			}
-			payload := strings.TrimPrefix(line, "data: ")
-			if payload == "" {
-				continue
-			}
-			var ev anthropicEvent
-			if err := json.Unmarshal([]byte(payload), &ev); err != nil {
-				continue
-			}
-			switch ev.Type {
-			case "content_block_delta":
-				if ev.Delta.Text != "" {
-					select {
-					case <-ctx.Done():
-						return
-					case out <- StreamChunk{DeltaText: ev.Delta.Text}:
-					}
-				}
-			case "message_delta":
-				if ev.Delta.StopReason != "" {
-					select {
-					case <-ctx.Done():
-					case out <- StreamChunk{Stop: mapAnthropicStop(ev.Delta.StopReason)}:
-					}
-				}
-			case "message_stop":
-				return
-			}
-		}
+		anthropicStreamLoop(ctx, resp.Body, out)
 	}()
 	return out, nil
 }
@@ -311,6 +277,121 @@ func mapAnthropicStop(s string) StopReason {
 		return StopStop
 	default:
 		return StopEndTurn
+	}
+}
+
+// streamToolState tracks the current content block during SSE streaming.
+// State transitions: idle -> text (content_block_start type=text) -> idle (content_block_stop)
+//                    idle -> tool_use (content_block_start type=tool_use) -> idle (content_block_stop)
+type streamToolState struct {
+	blockType string // "text" or "tool_use"; empty when idle
+	toolID    string
+	toolName  string
+	jsonBuf   strings.Builder
+}
+
+func (s *streamToolState) reset() {
+	s.blockType = ""
+	s.toolID = ""
+	s.toolName = ""
+	s.jsonBuf.Reset()
+}
+
+// anthropicStreamLoop processes SSE events from the Anthropic streaming API,
+// handling both text and tool_use content blocks.
+func anthropicStreamLoop(ctx context.Context, body io.Reader, out chan<- StreamChunk) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var state streamToolState
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		if payload == "" {
+			continue
+		}
+		var ev anthropicEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			continue
+		}
+		if done := anthropicHandleEvent(ctx, &ev, &state, out); done {
+			return
+		}
+	}
+}
+
+// anthropicHandleEvent dispatches a single parsed SSE event. Returns true when
+// streaming should terminate (message_stop or context cancelled).
+func anthropicHandleEvent(ctx context.Context, ev *anthropicEvent, state *streamToolState, out chan<- StreamChunk) bool {
+	switch ev.Type {
+	case "content_block_start":
+		state.reset()
+		state.blockType = ev.ContentBlock.Type
+		if ev.ContentBlock.Type == "tool_use" {
+			state.toolID = ev.ContentBlock.ID
+			state.toolName = ev.ContentBlock.Name
+		}
+	case "content_block_delta":
+		switch ev.Delta.Type {
+		case "text_delta":
+			if ev.Delta.Text != "" {
+				if !sendChunk(ctx, out, StreamChunk{DeltaText: ev.Delta.Text}) {
+					return true
+				}
+			}
+		case "input_json_delta":
+			state.jsonBuf.WriteString(ev.Delta.PartialJSON)
+		}
+	case "content_block_stop":
+		if state.blockType == "tool_use" {
+			tc := buildToolCallFromState(state)
+			if !sendChunk(ctx, out, StreamChunk{ToolCall: &tc}) {
+				return true
+			}
+		}
+		state.reset()
+	case "message_delta":
+		if ev.Delta.StopReason != "" {
+			if !sendChunk(ctx, out, StreamChunk{Stop: mapAnthropicStop(ev.Delta.StopReason)}) {
+				return true
+			}
+		}
+	case "message_stop":
+		return true
+	}
+	return false
+}
+
+// buildToolCallFromState constructs a ToolCall from accumulated streaming state.
+// If the accumulated JSON is malformed, Arguments will be the raw bytes as-is
+// to allow downstream error handling rather than silently dropping the call.
+func buildToolCallFromState(state *streamToolState) ToolCall {
+	raw := state.jsonBuf.String()
+	var args json.RawMessage
+	if raw == "" {
+		args = json.RawMessage("{}")
+	} else if json.Valid([]byte(raw)) {
+		args = json.RawMessage(raw)
+	} else {
+		args = json.RawMessage(raw)
+	}
+	return ToolCall{
+		ID:        state.toolID,
+		Name:      state.toolName,
+		Arguments: args,
+	}
+}
+
+// sendChunk sends a StreamChunk to the output channel, respecting context cancellation.
+// Returns false if context was cancelled (caller should stop processing).
+func sendChunk(ctx context.Context, out chan<- StreamChunk, chunk StreamChunk) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case out <- chunk:
+		return true
 	}
 }
 

--- a/go/llm/anthropic_test.go
+++ b/go/llm/anthropic_test.go
@@ -139,3 +139,402 @@ func TestAnthropicRejectsEmpty(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestAnthropicStream_SingleToolCall(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc123","name":"search"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"query\":"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"hello world\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "search for hello"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var tools []llm.ToolCall
+	var stop llm.StopReason
+	for chunk := range ch {
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+		if chunk.Stop != "" {
+			stop = chunk.Stop
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(tools))
+	}
+	if tools[0].ID != "toolu_abc123" {
+		t.Errorf("tool ID = %q, want %q", tools[0].ID, "toolu_abc123")
+	}
+	if tools[0].Name != "search" {
+		t.Errorf("tool name = %q, want %q", tools[0].Name, "search")
+	}
+	if string(tools[0].Arguments) != `{"query":"hello world"}` {
+		t.Errorf("tool args = %q, want %q", string(tools[0].Arguments), `{"query":"hello world"}`)
+	}
+	if stop != llm.StopToolUse {
+		t.Errorf("stop = %q, want %q", stop, llm.StopToolUse)
+	}
+}
+
+func TestAnthropicStream_TextAndToolInterleaved(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_2","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me search"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" for you."}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_xyz","name":"web_search"}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"url\":\"https://example.com\"}"}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "search"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var text strings.Builder
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		text.WriteString(chunk.DeltaText)
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	if text.String() != "Let me search for you." {
+		t.Errorf("text = %q, want %q", text.String(), "Let me search for you.")
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "web_search" {
+		t.Errorf("tool name = %q, want %q", tools[0].Name, "web_search")
+	}
+	if string(tools[0].Arguments) != `{"url":"https://example.com"}` {
+		t.Errorf("tool args = %q", string(tools[0].Arguments))
+	}
+}
+
+func TestAnthropicStream_MultipleTools(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_3","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/tmp/a.txt\"}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Reading files..."}}`,
+		`{"type":"content_block_stop","index":1}`,
+		`{"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_2","name":"write_file"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"/tmp/b"}}`,
+		`{"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":".txt\",\"content\":\"hello\"}"}}`,
+		`{"type":"content_block_stop","index":2}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "do stuff"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var text strings.Builder
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		text.WriteString(chunk.DeltaText)
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	if text.String() != "Reading files..." {
+		t.Errorf("text = %q, want %q", text.String(), "Reading files...")
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	if tools[0].ID != "toolu_1" || tools[0].Name != "read_file" {
+		t.Errorf("tool[0] = %+v", tools[0])
+	}
+	if string(tools[0].Arguments) != `{"path":"/tmp/a.txt"}` {
+		t.Errorf("tool[0].args = %q", string(tools[0].Arguments))
+	}
+	if tools[1].ID != "toolu_2" || tools[1].Name != "write_file" {
+		t.Errorf("tool[1] = %+v", tools[1])
+	}
+	if string(tools[1].Arguments) != `{"path":"/tmp/b.txt","content":"hello"}` {
+		t.Errorf("tool[1].args = %q", string(tools[1].Arguments))
+	}
+}
+
+func TestAnthropicStream_TextOnly_NoRegression(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_4","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello "}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world!"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "say hi"}},
+		MaxTokens: 32,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var text strings.Builder
+	var tools []llm.ToolCall
+	var stop llm.StopReason
+	for chunk := range ch {
+		text.WriteString(chunk.DeltaText)
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+		if chunk.Stop != "" {
+			stop = chunk.Stop
+		}
+	}
+	if text.String() != "Hello world!" {
+		t.Errorf("text = %q, want %q", text.String(), "Hello world!")
+	}
+	if len(tools) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(tools))
+	}
+	if stop != llm.StopEndTurn {
+		t.Errorf("stop = %q, want %q", stop, llm.StopEndTurn)
+	}
+}
+
+func TestAnthropicStream_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_5","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_bad","name":"broken"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"key\": "}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"INVALID"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "break"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	// Should still emit the tool call (with invalid JSON as raw bytes) rather than panic.
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(tools))
+	}
+	if tools[0].Name != "broken" {
+		t.Errorf("tool name = %q, want %q", tools[0].Name, "broken")
+	}
+	if tools[0].ID != "toolu_bad" {
+		t.Errorf("tool ID = %q, want %q", tools[0].ID, "toolu_bad")
+	}
+	// The raw malformed JSON is preserved as-is for downstream error handling.
+	if string(tools[0].Arguments) != `{"key": INVALID` {
+		t.Errorf("tool args = %q, want %q", string(tools[0].Arguments), `{"key": INVALID`)
+	}
+}
+
+func TestAnthropicStream_EmptyToolArguments(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_6","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_empty","name":"no_args"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "run"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(tools))
+	}
+	if tools[0].Name != "no_args" {
+		t.Errorf("tool name = %q", tools[0].Name)
+	}
+	// Empty arguments should default to empty JSON object.
+	if string(tools[0].Arguments) != "{}" {
+		t.Errorf("tool args = %q, want %q", string(tools[0].Arguments), "{}")
+	}
+}
+
+func TestAnthropicStream_LargeToolArguments(t *testing.T) {
+	t.Parallel()
+	// Simulate a large argument split across many delta events.
+	largeValue := strings.Repeat("x", 10000)
+	fullJSON := fmt.Sprintf(`{"data":"%s"}`, largeValue)
+
+	// Split JSON into 100-byte chunks to simulate many deltas.
+	var events []string
+	events = append(events, `{"type":"message_start","message":{"id":"msg_7","type":"message","role":"assistant"}}`)
+	events = append(events, `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_big","name":"large_tool"}}`)
+	for i := 0; i < len(fullJSON); i += 100 {
+		end := i + 100
+		if end > len(fullJSON) {
+			end = len(fullJSON)
+		}
+		chunk := fullJSON[i:end]
+		// Escape the chunk for embedding in JSON.
+		escaped := strings.ReplaceAll(chunk, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		events = append(events, fmt.Sprintf(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"%s"}}`, escaped))
+	}
+	events = append(events, `{"type":"content_block_stop","index":0}`)
+	events = append(events, `{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`)
+	events = append(events, `{"type":"message_stop"}`)
+
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "big request"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(tools))
+	}
+	if tools[0].Name != "large_tool" {
+		t.Errorf("tool name = %q", tools[0].Name)
+	}
+	if string(tools[0].Arguments) != fullJSON {
+		t.Errorf("tool args length = %d, want %d", len(tools[0].Arguments), len(fullJSON))
+	}
+}
+
+func TestAnthropicStream_ToolWithEmptyObject(t *testing.T) {
+	t.Parallel()
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_8","type":"message","role":"assistant"}}`,
+		`{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_obj","name":"ping"}}`,
+		`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		`{"type":"content_block_stop","index":0}`,
+		`{"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		`{"type":"message_stop"}`,
+	}
+	srv := anthropicStreamServer(t, events)
+	defer srv.Close()
+
+	p := llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: srv.URL})
+	ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+		Model:     "claude-test",
+		Messages:  []llm.Message{{Role: llm.RoleUser, Content: "ping"}},
+		MaxTokens: 1024,
+	})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	var tools []llm.ToolCall
+	for chunk := range ch {
+		if chunk.ToolCall != nil {
+			tools = append(tools, *chunk.ToolCall)
+		}
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(tools))
+	}
+	if string(tools[0].Arguments) != "{}" {
+		t.Errorf("tool args = %q, want %q", string(tools[0].Arguments), "{}")
+	}
+}
+
+// anthropicStreamServer creates an httptest server that serves SSE events.
+func anthropicStreamServer(t *testing.T, events []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatalf("flusher unavailable")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, ev := range events {
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", ev)
+			flusher.Flush()
+		}
+	}))
+}


### PR DESCRIPTION
## Summary

Adds full tool_use content block handling to the Anthropic streaming path. Previously, the streaming handler only processed text deltas — any tool calls in streaming mode were silently dropped.

## Problem

The streaming SSE handler only handled `content_block_delta` (text) and `message_delta` (stop). It ignored `content_block_start` (tool ID/name), `input_json_delta` (partial JSON arguments), and `content_block_stop` (signals complete tool call). Agents using Anthropic streaming with tools got no tool output.

## Changes

- `go/llm/anthropic.go`:
  - Added `streamToolState` struct for tracking current content block type
  - Extracted `anthropicStreamLoop` for testability
  - Added `anthropicHandleEvent` state machine dispatcher
  - Handles: `content_block_start` (text/tool_use), `content_block_delta` (text_delta/input_json_delta), `content_block_stop` (emit accumulated tool call)
  - Added `buildToolCallFromState` helper
  - Supports multiple interleaved text + tool blocks in single response

- `go/llm/anthropic_test.go`: 8 new tests covering single tool, interleaved text+tool, multiple tools, text-only (regression), malformed JSON, empty arguments, large arguments (10KB split across 100+ deltas), and empty object `{}`

## Testing

- `go test -race ./llm/...` passes
- `go vet ./...` passes
- `go build ./...` passes

Resolves LLE-9646