### PR TITLE
Fix pt store batch List to overlay journal state

### DIFF
--- a/go/store/pt/pt.go
+++ b/go/store/pt/pt.go
@@ -459,7 +459,71 @@ func (b *batch) Stat(ctx context.Context, p brain.Path) (brain.FileInfo, error) 
 }
 
 func (b *batch) List(ctx context.Context, dir brain.Path, opts brain.ListOpts) ([]brain.FileInfo, error) {
-	return b.store.List(ctx, dir, opts)
+	base, err := b.store.List(ctx, dir, opts)
+	if err != nil {
+		return nil, err
+	}
+	byPath := make(map[brain.Path]brain.FileInfo, len(base))
+	for _, fi := range base {
+		byPath[fi.Path] = fi
+	}
+
+	// Collect every path mentioned by the journal (source and destination).
+	touched := make(map[brain.Path]struct{})
+	for _, op := range b.ops {
+		touched[op.path] = struct{}{}
+		if op.kind == opRename {
+			touched[op.src] = struct{}{}
+		}
+	}
+
+	for p := range touched {
+		if !pathUnder(p, dir, opts.Recursive) {
+			continue
+		}
+		content, present, _, eerr := b.effective(ctx, p, len(b.ops))
+		if eerr != nil {
+			return nil, eerr
+		}
+		if !present {
+			delete(byPath, p)
+			continue
+		}
+		byPath[p] = brain.FileInfo{Path: p, Size: int64(len(content)), ModTime: time.Now()}
+	}
+
+	result := make([]brain.FileInfo, 0, len(byPath))
+	for _, fi := range byPath {
+		if !opts.IncludeGenerated && brain.IsGenerated(fi.Path) {
+			continue
+		}
+		result = append(result, fi)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Path < result[j].Path })
+	return result, nil
+}
+
+// pathUnder reports whether p is under dir according to recursive/shallow
+// semantics.
+func pathUnder(p, dir brain.Path, recursive bool) bool {
+	if dir == "" {
+		return true
+	}
+	ps := string(p)
+	ds := string(dir)
+	if !((ps == ds) || (len(ps) > len(ds) && ps[:len(ds)] == ds && ps[len(ds)] == '/')) {
+		return false
+	}
+	if recursive {
+		return true
+	}
+	rest := ps[len(ds)+1:]
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == '/' {
+			return false
+		}
+	}
+	return true
 }
 
 func (b *batch) Write(ctx context.Context, p brain.Path, content []byte) error {

--- a/go/store/pt/pt_test.go
+++ b/go/store/pt/pt_test.go
@@ -128,3 +128,275 @@ func TestListRecursiveReturnsLogicalPaths(t *testing.T) {
 		}
 	}
 }
+
+// TestBatchListOverlaysJournalState verifies that Batch.List merges
+// journal state (pending writes, deletes, renames) with the base store.
+func TestBatchListOverlaysJournalState(t *testing.T) {
+	t.Parallel()
+
+	type storeSetup struct {
+		path    brain.Path
+		content []byte
+	}
+	type batchAction struct {
+		op      string // "write", "delete", "rename", "append"
+		path    brain.Path
+		dst     brain.Path // rename destination
+		content []byte
+	}
+
+	tests := []struct {
+		name      string
+		setup     []storeSetup
+		actions   []batchAction
+		listDir   brain.Path
+		listOpts  brain.ListOpts
+		wantPaths []string
+	}{
+		{
+			name:  "write in batch is visible before commit",
+			setup: nil,
+			actions: []batchAction{
+				{op: "write", path: "docs/new.md", content: []byte("hello")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/new.md"},
+		},
+		{
+			name:  "multiple writes all visible",
+			setup: nil,
+			actions: []batchAction{
+				{op: "write", path: "docs/a.md", content: []byte("a")},
+				{op: "write", path: "docs/b.md", content: []byte("b")},
+				{op: "write", path: "docs/c.md", content: []byte("c")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/a.md", "docs/b.md", "docs/c.md"},
+		},
+		{
+			name: "prefix filtering works",
+			actions: []batchAction{
+				{op: "write", path: "docs/a.md", content: []byte("a")},
+				{op: "write", path: "other/b.md", content: []byte("b")},
+				{op: "write", path: "docs/sub/c.md", content: []byte("c")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/a.md", "docs/sub/c.md"},
+		},
+		{
+			name: "delete in batch hides path from list",
+			setup: []storeSetup{
+				{path: "docs/existing.md", content: []byte("old")},
+			},
+			actions: []batchAction{
+				{op: "delete", path: "docs/existing.md"},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{},
+		},
+		{
+			name: "delete base store path not shown",
+			setup: []storeSetup{
+				{path: "notes/a.md", content: []byte("a")},
+				{path: "notes/b.md", content: []byte("b")},
+			},
+			actions: []batchAction{
+				{op: "delete", path: "notes/a.md"},
+			},
+			listDir:   "notes",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"notes/b.md"},
+		},
+		{
+			name: "write then delete same path not in list",
+			actions: []batchAction{
+				{op: "write", path: "docs/temp.md", content: []byte("temp")},
+				{op: "delete", path: "docs/temp.md"},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{},
+		},
+		{
+			name: "empty prefix lists everything",
+			setup: []storeSetup{
+				{path: "a/x.md", content: []byte("x")},
+			},
+			actions: []batchAction{
+				{op: "write", path: "b/y.md", content: []byte("y")},
+			},
+			listDir:   "",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"a/x.md", "b/y.md"},
+		},
+		{
+			name:      "prefix with no matches returns empty slice",
+			setup:     nil,
+			actions:   []batchAction{},
+			listDir:   "nonexistent",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{},
+		},
+		{
+			name: "rename moves path in listing",
+			setup: []storeSetup{
+				{path: "docs/old.md", content: []byte("content")},
+			},
+			actions: []batchAction{
+				{op: "rename", path: "docs/old.md", dst: "docs/new.md"},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/new.md"},
+		},
+		{
+			name: "non-recursive list only shows immediate children",
+			setup: []storeSetup{
+				{path: "docs/top.md", content: []byte("top")},
+				{path: "docs/sub/deep.md", content: []byte("deep")},
+			},
+			actions: []batchAction{
+				{op: "write", path: "docs/added.md", content: []byte("added")},
+				{op: "write", path: "docs/nested/other.md", content: []byte("nested")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: false},
+			wantPaths: []string{"docs/added.md", "docs/top.md"},
+		},
+		{
+			name: "batch write overlays base store entry",
+			setup: []storeSetup{
+				{path: "docs/file.md", content: []byte("original")},
+			},
+			actions: []batchAction{
+				{op: "write", path: "docs/file.md", content: []byte("updated")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/file.md"},
+		},
+		{
+			name: "append in batch visible in list",
+			setup: []storeSetup{
+				{path: "docs/file.md", content: []byte("start")},
+			},
+			actions: []batchAction{
+				{op: "append", path: "docs/file.md", content: []byte(" end")},
+			},
+			listDir:   "docs",
+			listOpts:  brain.ListOpts{Recursive: true},
+			wantPaths: []string{"docs/file.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			store, err := New(root)
+			if err != nil {
+				t.Fatalf("pt.New: %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+
+			ctx := context.Background()
+
+			// Pre-populate the store with setup data.
+			for _, s := range tt.setup {
+				if err := store.Write(ctx, s.path, s.content); err != nil {
+					t.Fatalf("setup Write(%s): %v", s.path, err)
+				}
+			}
+
+			// Execute the batch and validate List inside the callback.
+			err = store.Batch(ctx, brain.BatchOptions{Reason: "test"}, func(b brain.Batch) error {
+				for _, a := range tt.actions {
+					switch a.op {
+					case "write":
+						if werr := b.Write(ctx, a.path, a.content); werr != nil {
+							return werr
+						}
+					case "delete":
+						if derr := b.Delete(ctx, a.path); derr != nil {
+							return derr
+						}
+					case "rename":
+						if rerr := b.Rename(ctx, a.path, a.dst); rerr != nil {
+							return rerr
+						}
+					case "append":
+						if aerr := b.Append(ctx, a.path, a.content); aerr != nil {
+							return aerr
+						}
+					}
+				}
+
+				entries, lerr := b.List(ctx, tt.listDir, tt.listOpts)
+				if lerr != nil {
+					return lerr
+				}
+
+				gotPaths := make([]string, 0, len(entries))
+				for _, e := range entries {
+					if e.IsDir {
+						continue
+					}
+					gotPaths = append(gotPaths, string(e.Path))
+				}
+
+				if len(gotPaths) != len(tt.wantPaths) {
+					t.Errorf("List returned %d paths, want %d\ngot:  %v\nwant: %v",
+						len(gotPaths), len(tt.wantPaths), gotPaths, tt.wantPaths)
+					return nil
+				}
+
+				wantSet := make(map[string]struct{}, len(tt.wantPaths))
+				for _, w := range tt.wantPaths {
+					wantSet[w] = struct{}{}
+				}
+				for _, g := range gotPaths {
+					if _, ok := wantSet[g]; !ok {
+						t.Errorf("unexpected path in list: %s\ngot:  %v\nwant: %v",
+							g, gotPaths, tt.wantPaths)
+					}
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("Batch: %v", err)
+			}
+		})
+	}
+}
+
+// TestBatchListReturnsNonNilSlice verifies that an empty result is a
+// non-nil empty slice rather than nil.
+func TestBatchListReturnsNonNilSlice(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store, err := New(root)
+	if err != nil {
+		t.Fatalf("pt.New: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	err = store.Batch(ctx, brain.BatchOptions{Reason: "test"}, func(b brain.Batch) error {
+		entries, lerr := b.List(ctx, "nonexistent", brain.ListOpts{Recursive: true})
+		if lerr != nil {
+			return lerr
+		}
+		if entries == nil {
+			t.Errorf("expected non-nil empty slice, got nil")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Batch: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the passthrough (pt) store's `Batch.List()` to correctly overlay pending journal writes and deletes, matching the behaviour of fs, git, and http stores.

## Problem

`Batch.List()` delegated directly to `b.store.List()` without considering the journal. This meant writes within a batch were invisible to subsequent List calls within the same batch — violating the Store interface contract and diverging from all other store implementations.

## Changes

- `go/store/pt/pt.go`: Replaced one-liner `List()` with proper journal overlay that:
  - Gets base list from underlying store
  - Computes effective state for all journal-touched paths under the prefix
  - Removes deleted paths, adds/updates written paths
  - Respects `IncludeGenerated` and `Recursive` options
  - Returns sorted, deduplicated results
  - Added `pathUnder` helper for directory matching

- `go/store/pt/pt_test.go`: 13 new table-driven tests covering write visibility, prefix filtering, delete hiding, write-then-delete cancellation, empty prefix, rename, non-recursive mode, append visibility, and non-nil empty slice guarantee

## Testing

- `go test -race ./store/...` — all store packages pass (fs, git, http, mem, pt)
- `go vet ./...` passes
- `go build ./...` passes

Resolves LLE-9647