### PR TITLE
Add HTTP client timeouts to all LLM providers

### DIFF
--- a/go/llm/anthropic.go
+++ b/go/llm/anthropic.go
@@ -38,7 +38,7 @@ func NewAnthropic(cfg AnthropicConfig) Provider {
 		cfg.Version = anthropicDefaultVersion
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = newDefaultClient()
 	}
 	return &anthropicProvider{cfg: cfg}
 }

--- a/go/llm/httpclient.go
+++ b/go/llm/httpclient.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llm
+
+import (
+	"net/http"
+	"time"
+)
+
+// Transport-level timeouts for the default HTTP client shared by all LLM
+// providers. ResponseHeaderTimeout governs only the wait for the first
+// response headers, so long-lived SSE streams are not killed once data
+// starts flowing.
+const (
+	defaultResponseHeaderTimeout = 30 * time.Second
+	defaultTLSHandshakeTimeout   = 10 * time.Second
+	defaultIdleConnTimeout       = 90 * time.Second
+	defaultMaxIdleConns          = 100
+	defaultMaxIdleConnsPerHost   = 10
+)
+
+// newDefaultClient returns an *http.Client with sensible transport-level
+// timeouts. It intentionally avoids setting http.Client.Timeout because
+// that applies to the entire request lifecycle including body reads, which
+// would kill long-running SSE streams.
+func newDefaultClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: defaultResponseHeaderTimeout,
+			TLSHandshakeTimeout:   defaultTLSHandshakeTimeout,
+			MaxIdleConns:          defaultMaxIdleConns,
+			MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost,
+			IdleConnTimeout:       defaultIdleConnTimeout,
+		},
+	}
+}

--- a/go/llm/httpclient_test.go
+++ b/go/llm/httpclient_test.go
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package llm_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+// TestDefaultClientTimeoutOnSlowHeaders verifies that a provider using the
+// default client times out when the server delays sending response headers
+// beyond ResponseHeaderTimeout (~30s). We use a scaled-down timeout via a
+// custom client for test speed.
+func TestDefaultClientTimeoutOnSlowHeaders(t *testing.T) {
+	t.Parallel()
+
+	slowClient := &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 200 * time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		provider func(url string) llm.Provider
+	}{
+		{
+			name: "OpenAI",
+			provider: func(url string) llm.Provider {
+				return llm.NewOpenAI(llm.OpenAIConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: slowClient,
+				})
+			},
+		},
+		{
+			name: "Anthropic",
+			provider: func(url string) llm.Provider {
+				return llm.NewAnthropic(llm.AnthropicConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: slowClient,
+				})
+			},
+		},
+		{
+			name: "Ollama",
+			provider: func(url string) llm.Provider {
+				return llm.NewOllama(llm.OllamaConfig{
+					BaseURL:    url,
+					HTTPClient: slowClient,
+				})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Delay longer than ResponseHeaderTimeout to trigger timeout.
+				time.Sleep(2 * time.Second)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			p := tc.provider(srv.URL)
+			defer func() { _ = p.Close() }()
+
+			start := time.Now()
+			_, err := p.Complete(context.Background(), llm.CompleteRequest{
+				Model:    "m",
+				Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+			})
+			elapsed := time.Since(start)
+
+			if err == nil {
+				t.Fatal("expected timeout error, got nil")
+			}
+			if elapsed > 1*time.Second {
+				t.Fatalf("timeout took too long: %v (expected ~200ms)", elapsed)
+			}
+		})
+	}
+}
+
+// TestDefaultClientCompletesWithinTimeout verifies non-streaming calls
+// succeed when the server responds promptly.
+func TestDefaultClientCompletesWithinTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		provider func(url string) llm.Provider
+		verify   func(t *testing.T, resp llm.CompleteResponse)
+	}{
+		{
+			name: "OpenAI",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{
+					"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+					"usage":{"prompt_tokens":1,"completion_tokens":1}
+				}`)
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewOpenAI(llm.OpenAIConfig{APIKey: "k", BaseURL: url})
+			},
+			verify: func(t *testing.T, resp llm.CompleteResponse) {
+				if resp.Text != "ok" {
+					t.Fatalf("text %q", resp.Text)
+				}
+			},
+		},
+		{
+			name: "Anthropic",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{
+					"id":"msg_1","type":"message","role":"assistant",
+					"content":[{"type":"text","text":"ok"}],
+					"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}
+				}`)
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewAnthropic(llm.AnthropicConfig{APIKey: "k", BaseURL: url})
+			},
+			verify: func(t *testing.T, resp llm.CompleteResponse) {
+				if resp.Text != "ok" {
+					t.Fatalf("text %q", resp.Text)
+				}
+			},
+		},
+		{
+			name: "Ollama",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{
+					"model":"m","message":{"role":"assistant","content":"ok"},
+					"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1
+				}`)
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewOllama(llm.OllamaConfig{BaseURL: url})
+			},
+			verify: func(t *testing.T, resp llm.CompleteResponse) {
+				if resp.Text != "ok" {
+					t.Fatalf("text %q", resp.Text)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			p := tc.provider(srv.URL)
+			defer func() { _ = p.Close() }()
+
+			resp, err := p.Complete(context.Background(), llm.CompleteRequest{
+				Model:    "m",
+				Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tc.verify(t, resp)
+		})
+	}
+}
+
+// TestStreamingWithSlowEvents verifies that once headers arrive,
+// ResponseHeaderTimeout does not kill long-running SSE streams. The server
+// sends events slowly over a period exceeding the header timeout.
+func TestStreamingWithSlowEvents(t *testing.T) {
+	t.Parallel()
+
+	// Use a short ResponseHeaderTimeout so the test proves streaming
+	// continues well past that window.
+	shortHeaderClient := &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 100 * time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		provider func(url string) llm.Provider
+		expected string
+	}{
+		{
+			name: "OpenAI",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					return
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				// Send chunks with delays totalling well over 100ms
+				chunks := []string{"hel", "lo", " wo", "rld"}
+				for _, c := range chunks {
+					_, _ = fmt.Fprintf(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":%q}}]}\n\n", c)
+					flusher.Flush()
+					time.Sleep(80 * time.Millisecond)
+				}
+				_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+				flusher.Flush()
+				_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+				flusher.Flush()
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewOpenAI(llm.OpenAIConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: shortHeaderClient,
+				})
+			},
+			expected: "hello world",
+		},
+		{
+			name: "Anthropic",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					return
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				parts := []string{"hel", "lo", " wo", "rld"}
+				for _, p := range parts {
+					_, _ = fmt.Fprintf(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":%q}}\n\n", p)
+					flusher.Flush()
+					time.Sleep(80 * time.Millisecond)
+				}
+				_, _ = fmt.Fprint(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n")
+				flusher.Flush()
+				_, _ = fmt.Fprint(w, "data: {\"type\":\"message_stop\"}\n\n")
+				flusher.Flush()
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewAnthropic(llm.AnthropicConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: shortHeaderClient,
+				})
+			},
+			expected: "hello world",
+		},
+		{
+			name: "Ollama",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					return
+				}
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				parts := []string{"hel", "lo", " wo", "rld"}
+				for _, p := range parts {
+					_, _ = fmt.Fprintf(w, "{\"message\":{\"role\":\"assistant\",\"content\":%q},\"done\":false}\n", p)
+					flusher.Flush()
+					time.Sleep(80 * time.Millisecond)
+				}
+				_, _ = fmt.Fprint(w, "{\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true,\"done_reason\":\"stop\"}\n")
+				flusher.Flush()
+			}),
+			provider: func(url string) llm.Provider {
+				return llm.NewOllama(llm.OllamaConfig{
+					BaseURL:    url,
+					HTTPClient: shortHeaderClient,
+				})
+			},
+			expected: "hello world",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			p := tc.provider(srv.URL)
+			defer func() { _ = p.Close() }()
+
+			ch, err := p.CompleteStream(context.Background(), llm.CompleteRequest{
+				Model:    "m",
+				Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("stream: %v", err)
+			}
+			var text strings.Builder
+			for chunk := range ch {
+				text.WriteString(chunk.DeltaText)
+			}
+			if text.String() != tc.expected {
+				t.Fatalf("text %q, want %q", text.String(), tc.expected)
+			}
+		})
+	}
+}
+
+// TestCustomClientPreserved verifies that providing a custom HTTPClient to
+// any provider constructor prevents the default client from being used.
+func TestCustomClientPreserved(t *testing.T) {
+	t.Parallel()
+
+	customHeaderValue := "custom-client-marker"
+	customTransport := &headerInjectTransport{
+		base:   http.DefaultTransport,
+		header: "X-Custom-Client",
+		value:  customHeaderValue,
+	}
+	customClient := &http.Client{Transport: customTransport}
+
+	tests := []struct {
+		name     string
+		handler  http.HandlerFunc
+		provider func(url string) interface{ Close() error }
+		call     func(ctx context.Context, p interface{ Close() error }) error
+	}{
+		{
+			name: "OpenAI",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Custom-Client"); got != customHeaderValue {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprintf(w, `{"error":{"message":"missing custom header: got %q"}}`, got)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+			}),
+			provider: func(url string) interface{ Close() error } {
+				return llm.NewOpenAI(llm.OpenAIConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: customClient,
+				})
+			},
+			call: func(ctx context.Context, p interface{ Close() error }) error {
+				_, err := p.(llm.Provider).Complete(ctx, llm.CompleteRequest{
+					Model:    "m",
+					Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+				})
+				return err
+			},
+		},
+		{
+			name: "Anthropic",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Custom-Client"); got != customHeaderValue {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprintf(w, `{"error":{"type":"invalid","message":"missing custom header: got %q"}}`, got)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+			}),
+			provider: func(url string) interface{ Close() error } {
+				return llm.NewAnthropic(llm.AnthropicConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					HTTPClient: customClient,
+				})
+			},
+			call: func(ctx context.Context, p interface{ Close() error }) error {
+				_, err := p.(llm.Provider).Complete(ctx, llm.CompleteRequest{
+					Model:     "m",
+					Messages:  []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+					MaxTokens: 32,
+				})
+				return err
+			},
+		},
+		{
+			name: "Ollama",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Custom-Client"); got != customHeaderValue {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "missing custom header")
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"model":"m","message":{"role":"assistant","content":"ok"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`)
+			}),
+			provider: func(url string) interface{ Close() error } {
+				return llm.NewOllama(llm.OllamaConfig{
+					BaseURL:    url,
+					HTTPClient: customClient,
+				})
+			},
+			call: func(ctx context.Context, p interface{ Close() error }) error {
+				_, err := p.(llm.Provider).Complete(ctx, llm.CompleteRequest{
+					Model:    "m",
+					Messages: []llm.Message{{Role: llm.RoleUser, Content: "hi"}},
+				})
+				return err
+			},
+		},
+		{
+			name: "OpenAIEmbedder",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Custom-Client"); got != customHeaderValue {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprintf(w, `{"error":{"message":"missing custom header: got %q"}}`, got)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"data":[{"index":0,"embedding":[0.1,0.2]}]}`)
+			}),
+			provider: func(url string) interface{ Close() error } {
+				return llm.NewOpenAIEmbedder(llm.OpenAIEmbedConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					Dimensions: 2,
+					HTTPClient: customClient,
+				})
+			},
+			call: func(ctx context.Context, p interface{ Close() error }) error {
+				_, err := p.(llm.Embedder).Embed(ctx, []string{"test"})
+				return err
+			},
+		},
+		{
+			name: "OllamaEmbedder",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.Header.Get("X-Custom-Client"); got != customHeaderValue {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = fmt.Fprint(w, "missing custom header")
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"embeddings":[[0.1,0.2]]}`)
+			}),
+			provider: func(url string) interface{ Close() error } {
+				return llm.NewOllamaEmbedder(llm.OllamaEmbedConfig{
+					BaseURL:    url,
+					Model:      "bge-m3",
+					Dimensions: 2,
+					HTTPClient: customClient,
+				})
+			},
+			call: func(ctx context.Context, p interface{ Close() error }) error {
+				_, err := p.(llm.Embedder).Embed(ctx, []string{"test"})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			p := tc.provider(srv.URL)
+			defer func() { _ = p.Close() }()
+
+			if err := tc.call(context.Background(), p); err != nil {
+				t.Fatalf("call failed (custom client not used): %v", err)
+			}
+		})
+	}
+}
+
+// TestEmbedderTimeoutOnSlowHeaders verifies that embedder constructors also
+// get the timeout behaviour.
+func TestEmbedderTimeoutOnSlowHeaders(t *testing.T) {
+	t.Parallel()
+
+	slowClient := &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 200 * time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		embedder func(url string) llm.Embedder
+	}{
+		{
+			name: "OpenAIEmbedder",
+			embedder: func(url string) llm.Embedder {
+				return llm.NewOpenAIEmbedder(llm.OpenAIEmbedConfig{
+					APIKey:     "k",
+					BaseURL:    url,
+					Dimensions: 2,
+					HTTPClient: slowClient,
+				})
+			},
+		},
+		{
+			name: "OllamaEmbedder",
+			embedder: func(url string) llm.Embedder {
+				return llm.NewOllamaEmbedder(llm.OllamaEmbedConfig{
+					BaseURL:    url,
+					Model:      "bge-m3",
+					Dimensions: 2,
+					HTTPClient: slowClient,
+				})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(2 * time.Second)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			e := tc.embedder(srv.URL)
+			defer func() { _ = e.Close() }()
+
+			start := time.Now()
+			_, err := e.Embed(context.Background(), []string{"test"})
+			elapsed := time.Since(start)
+
+			if err == nil {
+				t.Fatal("expected timeout error, got nil")
+			}
+			if elapsed > 1*time.Second {
+				t.Fatalf("timeout took too long: %v (expected ~200ms)", elapsed)
+			}
+		})
+	}
+}
+
+// headerInjectTransport is a test helper that injects a custom header into
+// every request to prove a custom client is being used.
+type headerInjectTransport struct {
+	base   http.RoundTripper
+	header string
+	value  string
+}
+
+func (t *headerInjectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set(t.header, t.value)
+	return t.base.RoundTrip(req)
+}

--- a/go/llm/ollama.go
+++ b/go/llm/ollama.go
@@ -41,7 +41,7 @@ func NewOllama(cfg OllamaConfig) Provider {
 		cfg.BaseURL = ollamaDefaultBase
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = newDefaultClient()
 	}
 	return &ollamaProvider{cfg: cfg}
 }
@@ -59,7 +59,7 @@ func NewOllamaEmbedder(cfg OllamaEmbedConfig) Embedder {
 		cfg.Dimensions = ollamaDefaultEmbedDims
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = newDefaultClient()
 	}
 	return &ollamaEmbedder{cfg: cfg}
 }

--- a/go/llm/openai.go
+++ b/go/llm/openai.go
@@ -45,7 +45,7 @@ func NewOpenAI(cfg OpenAIConfig) Provider {
 		cfg.BaseURL = openAIDefaultBase
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = newDefaultClient()
 	}
 	return &openAIProvider{cfg: cfg}
 }
@@ -62,7 +62,7 @@ func NewOpenAIEmbedder(cfg OpenAIEmbedConfig) Embedder {
 		cfg.Dimensions = openAIDefaultEmbedDims
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
+		cfg.HTTPClient = newDefaultClient()
 	}
 	return &openAIEmbedder{cfg: cfg}
 }


### PR DESCRIPTION
## Summary

Replaces `http.DefaultClient` (zero timeout) with a configured client across all 5 LLM provider constructors. Uses `ResponseHeaderTimeout` which is safe for SSE streaming.

## Problem

All LLM providers fell back to `http.DefaultClient` with no timeout. A hung connection blocks the goroutine indefinitely — a DoS vector and goroutine leak risk in production.

## Design Decision: ResponseHeaderTimeout (Not Client.Timeout)

`http.Client.Timeout` covers the entire request lifecycle including body reading — this kills long-running SSE streams. `ResponseHeaderTimeout` only applies to waiting for the first response headers. Once streaming begins, no timeout interrupts it. This is the correct approach for LLM providers that support both completion and streaming modes.

## Changes

- `go/llm/httpclient.go`: New shared `newDefaultClient()` with `ResponseHeaderTimeout: 30s`, `TLSHandshakeTimeout: 10s`, connection pooling
- `go/llm/openai.go`: Both `NewOpenAI` and `NewOpenAIEmbedder` use `newDefaultClient()` as fallback
- `go/llm/anthropic.go`: `NewAnthropic` uses `newDefaultClient()` as fallback
- `go/llm/ollama.go`: Both `NewOllama` and `NewOllamaEmbedder` use `newDefaultClient()` as fallback
- `go/llm/httpclient_test.go`: Tests verifying timeout on slow headers, streaming survival, and custom client preservation

## Testing

- `go test -race ./llm/...` passes
- `go vet ./...` passes
- `go build ./...` passes

Resolves LLE-9648