### PR TITLE
Skip empty-id candidates in RRF fusion

### DIFF
--- a/sdks/ts/memory/src/retrieval/rrf.test.ts
+++ b/sdks/ts/memory/src/retrieval/rrf.test.ts
@@ -94,6 +94,57 @@ describe('reciprocalRankFusion', () => {
     expect(fused[0]?.summary).toBe('Late summary')
   })
 
+  it('skips candidates with empty id', () => {
+    const list = [
+      { id: 'a', path: 'p/a.md', title: 'A', summary: 'sa' },
+      { id: '', path: 'p/ghost.md', title: 'Ghost', summary: 'sg' },
+      { id: 'b', path: 'p/b.md', title: 'B', summary: 'sb' },
+    ]
+
+    const fused = reciprocalRankFusion([list], RRF_DEFAULT_K)
+    expect(fused.map((r) => r.id)).toEqual(['a', 'b'])
+    expect(fused.find((r) => r.path === 'p/ghost.md')).toBeUndefined()
+  })
+
+  it('returns empty when all candidates have empty id', () => {
+    const list = [
+      { id: '', path: 'p/x.md' },
+      { id: '', path: 'p/y.md' },
+    ]
+
+    const fused = reciprocalRankFusion([list], RRF_DEFAULT_K)
+    expect(fused).toEqual([])
+  })
+
+  it('filters empty ids across multiple lists leaving valid ones intact', () => {
+    const bm25 = [
+      { id: '', path: 'p/ghost.md' },
+      { id: 'a', path: 'p/a.md', title: 'A', summary: 'sa' },
+    ]
+    const vec = [
+      { id: 'b', path: 'p/b.md', title: 'B', summary: 'sb' },
+      { id: '', path: 'p/phantom.md' },
+      { id: 'a', path: 'p/a.md' },
+    ]
+
+    const fused = reciprocalRankFusion([bm25, vec], RRF_DEFAULT_K)
+    const ids = fused.map((r) => r.id)
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    expect(ids).not.toContain('')
+    expect(fused).toHaveLength(2)
+  })
+
+  it('does not skip candidates with id "0" (falsy-looking but valid)', () => {
+    const list = [
+      { id: '0', path: 'p/zero.md', title: 'Zero', summary: 'sz' },
+      { id: 'a', path: 'p/a.md', title: 'A', summary: 'sa' },
+    ]
+
+    const fused = reciprocalRankFusion([list], RRF_DEFAULT_K)
+    expect(fused.map((r) => r.id)).toEqual(['0', 'a'])
+  })
+
   it('breaks score ties by path ascending for deterministic output', () => {
     // Two docs at the same rank across a single list: identical scores,
     // deterministic path-asc ordering.

--- a/sdks/ts/memory/src/retrieval/rrf.ts
+++ b/sdks/ts/memory/src/retrieval/rrf.ts
@@ -72,6 +72,7 @@ export function reciprocalRankFusion(
     for (let rank = 0; rank < list.length; rank++) {
       const c = list[rank]
       if (c === undefined) continue
+      if (c.id === '') continue
       const existing = buckets.get(c.id)
       if (existing === undefined) {
         const next: Bucket = {


### PR DESCRIPTION
## Summary

Adds an empty-id guard to the TypeScript RRF implementation, matching the Go SDK behaviour at `go/retrieval/rrf.go:98-99`.

## Problem

Empty-id candidates from partial/corrupt retrieval source results pollute the fused result set, consuming top-K slots that should go to valid candidates. Go already skips these; TypeScript did not.

## Changes

- `sdks/ts/memory/src/retrieval/rrf.ts`: Added `if (c.id === '') continue;` guard before score accumulation
- `sdks/ts/memory/src/retrieval/rrf.test.ts`: 4 new tests — empty id filtered, all-empty returns empty array, mixed valid/empty, and `"0"` (falsy-looking but valid) not filtered

## Testing

- Typecheck: passes
- RRF tests: 8/8 pass (4 existing + 4 new)

Resolves LLE-9653