### PR TITLE
Fix composite-concrete query detection to require both regexes

### DIFF
--- a/go/retrieval/intent.go
+++ b/go/retrieval/intent.go
@@ -681,7 +681,7 @@ func isCompositeConcreteQuery(query string) bool {
 	}
 	return enumerationOrTotalQueryRe.MatchString(lowered) ||
 		propertyLookupQueryRe.MatchString(lowered) ||
-		firstPersonFactLookupRe.MatchString(lowered)
+		(firstPersonFactLookupRe.MatchString(lowered) && factLookupVerbRe.MatchString(lowered))
 }
 
 func bestCompositeFocusMatch(text string, focuses []string) compositeFocusMatch {

--- a/go/retrieval/intent_test.go
+++ b/go/retrieval/intent_test.go
@@ -682,3 +682,47 @@ func TestReweight_NoIntent_ReturnsInputs(t *testing.T) {
 		t.Fatalf("reweight perturbed no-intent input: %+v", out)
 	}
 }
+
+func TestIsCompositeConcreteQuery(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{
+			name:  "first-person fact with verb",
+			query: "have I finished the report and the presentation",
+			want:  true,
+		},
+		{
+			name:  "enumeration pattern",
+			query: "how many orders and returns were there",
+			want:  true,
+		},
+		{
+			name:  "first-person without verb",
+			query: "did I go to the store and the park",
+			want:  false,
+		},
+		{
+			name:  "verb without first-person",
+			query: "bought a laptop and a monitor",
+			want:  false,
+		},
+		{
+			name:  "empty query",
+			query: "",
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isCompositeConcreteQuery(tc.query)
+			if got != tc.want {
+				t.Errorf("isCompositeConcreteQuery(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Go's `isCompositeConcreteQuery` to require both `firstPersonFactLookupRe` AND `factLookupVerbRe` to match, aligning with the spec and TypeScript implementation.

## Problem

Go `intent.go:684` checked only `firstPersonFactLookupRe` without requiring `factLookupVerbRe`. The spec (ALGORITHMS.md line 191) explicitly says "both FIRST_PERSON_FACT_LOOKUP_RE and FACT_LOOKUP_VERB_RE match". Go's own `detectRetrievalIntent` (line 81) correctly uses `&&` — this was an internal inconsistency introduced in commit `137b55f` when the function was expanded.

This caused Go to classify queries like "did I go to the store" as composite-concrete (triggering unnecessary diversification) when they lack a fact-lookup verb.

## Changes

- `go/retrieval/intent.go`: Changed `firstPersonFactLookupRe.MatchString(lowered)` to `(firstPersonFactLookupRe.MatchString(lowered) && factLookupVerbRe.MatchString(lowered))`
- `go/retrieval/intent_test.go`: Added `TestIsCompositeConcreteQuery` with 5 table-driven cases covering the bug case (first-person without verb)

## Testing

- `go test -race ./retrieval/...` passes
- `go vet ./...` passes

Resolves LLE-9651