### PR TITLE
Align stale-superseded multiplier with TS implementation

### DIFF
--- a/go/retrieval/intent.go
+++ b/go/retrieval/intent.go
@@ -142,9 +142,9 @@ func retrievalIntentMultiplier(intent retrievalIntent, query string, r Retrieved
 	if intent.concreteFactQuery {
 		multiplier *= concreteFactIntentMultiplier(query, r, text)
 		multiplier *= focusAlignedConcreteFactMultiplier(query, text)
-		multiplier *= staleSupersededConcreteFactMultiplier(r, text)
 		multiplier *= firstPersonConcreteFactMultiplier(query, r, text)
 	}
+	multiplier *= staleSupersededNoteMultiplier(r, text)
 	return multiplier
 }
 
@@ -319,9 +319,17 @@ func assistantOutputQuestion(normalisedQuery string) bool {
 		strings.Contains(normalisedQuery, "remind me")
 }
 
-func staleSupersededConcreteFactMultiplier(r RetrievedChunk, text string) float64 {
-	if metadataHasNonEmptyString(r.Metadata, "superseded_by", "supersededBy") || supersededFrontmatterRe.MatchString(text) {
+func staleSupersededNoteMultiplier(r RetrievedChunk, text string) float64 {
+	if metadataHasNonEmptyString(r.Metadata, "superseded_by", "supersededBy") {
 		return 0.18
+	}
+	status := strings.ToLower(metadataStringValue(r.Metadata, "status"))
+	switch status {
+	case "superseded", "stale", "obsolete":
+		return 0.18
+	}
+	if supersededFrontmatterRe.MatchString(text) {
+		return 0.32
 	}
 	return 1.0
 }

--- a/go/retrieval/intent_test.go
+++ b/go/retrieval/intent_test.go
@@ -682,3 +682,142 @@ func TestReweight_NoIntent_ReturnsInputs(t *testing.T) {
 		t.Fatalf("reweight perturbed no-intent input: %+v", out)
 	}
 }
+
+func TestStaleSupersededNoteMultiplier(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		r    RetrievedChunk
+		text string
+		want float64
+	}{
+		{
+			name: "metadata superseded_by present returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"superseded_by": "note-v2.md"}},
+			text: "some note content",
+			want: 0.18,
+		},
+		{
+			name: "metadata supersededBy present returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"supersededBy": "note-v2.md"}},
+			text: "some note content",
+			want: 0.18,
+		},
+		{
+			name: "metadata status superseded returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "superseded"}},
+			text: "some note content",
+			want: 0.18,
+		},
+		{
+			name: "metadata status stale returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "stale"}},
+			text: "some note content",
+			want: 0.18,
+		},
+		{
+			name: "metadata status obsolete returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "obsolete"}},
+			text: "some note content",
+			want: 0.18,
+		},
+		{
+			name: "text matches superseded regex returns 0.32",
+			r:    RetrievedChunk{},
+			text: "superseded_by: newer-note.md\nold content here",
+			want: 0.32,
+		},
+		{
+			name: "text matches replaced by returns 0.32",
+			r:    RetrievedChunk{},
+			text: "this note was replaced by a newer version",
+			want: 0.32,
+		},
+		{
+			name: "no metadata no text match returns 1.0",
+			r:    RetrievedChunk{Metadata: map[string]any{"title": "My Note"}},
+			text: "just a regular note with no stale markers",
+			want: 1.0,
+		},
+		{
+			name: "metadata status active returns 1.0",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "active"}},
+			text: "some active note content",
+			want: 1.0,
+		},
+		{
+			name: "metadata superseded_by takes priority over text match",
+			r:    RetrievedChunk{Metadata: map[string]any{"superseded_by": "newer.md"}},
+			text: "superseded_by: newer.md\nold content replaced by newer version",
+			want: 0.18,
+		},
+		{
+			name: "metadata status takes priority over text match",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "obsolete"}},
+			text: "superseded_by: newer.md\nold content",
+			want: 0.18,
+		},
+		{
+			name: "empty superseded_by metadata falls through",
+			r:    RetrievedChunk{Metadata: map[string]any{"superseded_by": ""}},
+			text: "just a regular note",
+			want: 1.0,
+		},
+		{
+			name: "nil metadata returns 1.0",
+			r:    RetrievedChunk{},
+			text: "some note content",
+			want: 1.0,
+		},
+		{
+			name: "status Superseded case insensitive returns 0.18",
+			r:    RetrievedChunk{Metadata: map[string]any{"status": "Superseded"}},
+			text: "some note content",
+			want: 0.18,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := staleSupersededNoteMultiplier(tc.r, tc.text)
+			if got != tc.want {
+				t.Errorf("staleSupersededNoteMultiplier() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStaleMultiplierAppliedUnconditionally(t *testing.T) {
+	t.Parallel()
+	staleChunk := RetrievedChunk{
+		Path:     "memory/global/user-preference-coffee.md",
+		Text:     "I prefer oat milk",
+		Score:    1.0,
+		Metadata: map[string]any{"status": "stale"},
+	}
+	freshChunk := RetrievedChunk{
+		Path:  "memory/global/user-preference-tea.md",
+		Text:  "I like green tea",
+		Score: 1.0,
+	}
+	query := "recommend a drink"
+	intent := detectRetrievalIntent(query)
+	if !intent.preferenceQuery {
+		t.Fatal("expected preferenceQuery to be true")
+	}
+	if intent.concreteFactQuery {
+		t.Fatal("expected concreteFactQuery to be false for preference-only query")
+	}
+	staleText := retrievalResultText(staleChunk)
+	freshText := retrievalResultText(freshChunk)
+	staleMult := retrievalIntentMultiplier(intent, query, staleChunk)
+	freshMult := retrievalIntentMultiplier(intent, query, freshChunk)
+	staleExpected := preferenceIntentMultiplier(query, staleChunk, staleText) * 0.18
+	freshExpected := preferenceIntentMultiplier(query, freshChunk, freshText) * 1.0
+	if math.Abs(staleMult-staleExpected) > 1e-9 {
+		t.Errorf("stale preference multiplier = %v, want %v", staleMult, staleExpected)
+	}
+	if math.Abs(freshMult-freshExpected) > 1e-9 {
+		t.Errorf("fresh preference multiplier = %v, want %v", freshMult, freshExpected)
+	}
+}


### PR DESCRIPTION
## Summary

Aligns Go's stale-superseded note multiplier with the TypeScript reference implementation. Three divergences fixed.

## Problem

Go and TS disagreed on stale note handling in three ways:
1. Go returned 0.18 for text-regex matches; TS returns 0.32 (softer penalty for heuristic-only detection)
2. Go applied the multiplier only for `concreteFactQuery` intent; TS applies unconditionally
3. Go lacked `status` metadata check (superseded/stale/obsolete); TS returns 0.18 for these

All three divergences were verified against the TS reference (commit `28f7822` introduced the intentional distinction). The TS approach is architecturally correct: metadata-confirmed supersession gets 0.18, text-only heuristic gets 0.32 (lower confidence), and stale notes should be penalised regardless of query intent.

## Changes

- `go/retrieval/intent.go`:
  - Renamed `staleSupersededConcreteFactMultiplier` to `staleSupersededNoteMultiplier`
  - Moved call outside `concreteFactQuery` block (unconditional application)
  - Added `status` metadata check for "superseded"/"stale"/"obsolete" values (returns 0.18)
  - Changed text-regex-only match from 0.18 to 0.32

- `go/retrieval/intent_test.go`:
  - `TestStaleSupersededNoteMultiplier`: 14 table-driven cases
  - `TestStaleMultiplierAppliedUnconditionally`: verifies unconditional scope

## Testing

- `go test -race ./retrieval/...` passes
- `go vet ./...` passes

Resolves LLE-9652