### PR TITLE
Port age-based heuristic confidence from TS to Go

### DIFF
--- a/go/memory/confidence.go
+++ b/go/memory/confidence.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import "time"
+
+// Age-based confidence thresholds ported from the TS consolidation
+// stage (sdks/ts/memory/src/memory/consolidate.ts). These constants
+// control when a heuristic's confidence is demoted due to staleness or
+// promoted due to reinforcement.
+const (
+	// staleAfterDays is the number of days since last observation after
+	// which a heuristic is considered stale. If the current confidence
+	// is "high" it is demoted to "medium"; otherwise it becomes "low".
+	staleAfterDays = 90
+
+	// deepStaleAfterDays is the number of days since last observation
+	// after which a heuristic's confidence is forced to "low" regardless
+	// of other signals.
+	deepStaleAfterDays = 180
+
+	// heuristicReinforcementDays is the minimum span (in days) between
+	// creation and last observation for a heuristic to be considered
+	// reinforced. If the current confidence is "high" it stays "high";
+	// otherwise it is promoted to "medium".
+	heuristicReinforcementDays = 14
+
+	// heuristicStrongReinforcementDays is the span (in days) between
+	// creation and last observation that unconditionally promotes a
+	// heuristic to "high" confidence.
+	heuristicStrongReinforcementDays = 45
+)
+
+// DeriveHeuristicConfidence computes the confidence level for a
+// heuristic memory based on its age and reinforcement span. It mirrors
+// the TS function `deriveHeuristicConfidence` in consolidate.ts.
+//
+// Parameters:
+//   - current: the existing confidence level ("low", "medium", or "high")
+//   - observedAt: the most recent observation time (typically from the
+//     frontmatter "modified" field)
+//   - createdAt: the creation time of the heuristic
+//   - now: the reference time for computing age
+//
+// The function returns the derived confidence string.
+func DeriveHeuristicConfidence(current string, observedAt, createdAt, now time.Time) string {
+	normCurrent := normaliseConfidenceLevel(current)
+	ageDays := diffDaysTruncated(observedAt, now)
+	reinforcementDays := diffDaysTruncated(createdAt, observedAt)
+	if reinforcementDays < 0 {
+		reinforcementDays = 0
+	}
+
+	if ageDays >= deepStaleAfterDays {
+		return "low"
+	}
+	if ageDays >= staleAfterDays {
+		if normCurrent == "high" {
+			return "medium"
+		}
+		return "low"
+	}
+	if reinforcementDays >= heuristicStrongReinforcementDays {
+		return "high"
+	}
+	if reinforcementDays >= heuristicReinforcementDays {
+		if normCurrent == "high" {
+			return "high"
+		}
+		return "medium"
+	}
+	return normCurrent
+}
+
+// normaliseConfidenceLevel normalises a confidence string to one of
+// "low", "medium", or "high". Unrecognised values default to "low".
+func normaliseConfidenceLevel(value string) string {
+	switch value {
+	case "high", "medium", "low":
+		return value
+	default:
+		return "low"
+	}
+}
+
+// diffDaysTruncated returns the number of whole days between start and
+// end, truncating toward zero. Matches the TS `diffDays` which uses
+// Math.floor on (end - start) / millisPerDay.
+func diffDaysTruncated(start, end time.Time) int {
+	duration := end.Sub(start)
+	return int(duration.Hours() / 24)
+}

--- a/go/memory/confidence_test.go
+++ b/go/memory/confidence_test.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeriveHeuristicConfidence(t *testing.T) {
+	// Fixed reference time to ensure deterministic tests.
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		current    string
+		observedAt time.Time
+		createdAt  time.Time
+		want       string
+	}{
+		{
+			name:       "fresh memory (1 day old) retains full confidence",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -1),
+			createdAt:  now.AddDate(0, 0, -1),
+			want:       "high",
+		},
+		{
+			name:       "30 day old, recently accessed retains full confidence (reinforced via strong span)",
+			current:    "medium",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -60),
+			want:       "high",
+		},
+		{
+			name:       "100 day old, never accessed since creation is reduced (high to medium)",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -100),
+			createdAt:  now.AddDate(0, 0, -100),
+			want:       "medium",
+		},
+		{
+			name:       "100 day old, never accessed since creation is reduced (medium to low)",
+			current:    "medium",
+			observedAt: now.AddDate(0, 0, -100),
+			createdAt:  now.AddDate(0, 0, -100),
+			want:       "low",
+		},
+		{
+			name:       "200 day old, never accessed forces minimum confidence",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -200),
+			createdAt:  now.AddDate(0, 0, -200),
+			want:       "low",
+		},
+		{
+			name:       "200 day old, accessed yesterday retains full confidence (reinforced)",
+			current:    "medium",
+			observedAt: now.AddDate(0, 0, -1),
+			createdAt:  now.AddDate(0, 0, -200),
+			want:       "high",
+		},
+		{
+			name:       "future observedAt date handled gracefully (negative age = fresh)",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, 5),
+			createdAt:  now.AddDate(0, 0, -10),
+			want:       "high",
+		},
+		{
+			name:       "future createdAt date handled gracefully (negative reinforcement clamped to 0)",
+			current:    "low",
+			observedAt: now.AddDate(0, 0, -1),
+			createdAt:  now.AddDate(0, 0, 5),
+			want:       "low",
+		},
+		{
+			name:       "exactly 90 days old (at boundary) demotes high to medium",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -90),
+			createdAt:  now.AddDate(0, 0, -90),
+			want:       "medium",
+		},
+		{
+			name:       "exactly 90 days old (at boundary) demotes medium to low",
+			current:    "medium",
+			observedAt: now.AddDate(0, 0, -90),
+			createdAt:  now.AddDate(0, 0, -90),
+			want:       "low",
+		},
+		{
+			name:       "exactly 90 days old (at boundary) low stays low",
+			current:    "low",
+			observedAt: now.AddDate(0, 0, -90),
+			createdAt:  now.AddDate(0, 0, -90),
+			want:       "low",
+		},
+		{
+			name:       "exactly 180 days old (at boundary) forces low regardless of current",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -180),
+			createdAt:  now.AddDate(0, 0, -180),
+			want:       "low",
+		},
+		{
+			name:       "89 days old is not stale",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -89),
+			createdAt:  now.AddDate(0, 0, -89),
+			want:       "high",
+		},
+		{
+			name:       "179 days old with high current is stale but not deep stale",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -179),
+			createdAt:  now.AddDate(0, 0, -179),
+			want:       "medium",
+		},
+		{
+			name:       "reinforcement of exactly 14 days promotes low to medium",
+			current:    "low",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -19),
+			want:       "medium",
+		},
+		{
+			name:       "reinforcement of exactly 14 days keeps high as high",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -19),
+			want:       "high",
+		},
+		{
+			name:       "reinforcement of exactly 45 days promotes to high unconditionally",
+			current:    "low",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -50),
+			want:       "high",
+		},
+		{
+			name:       "reinforcement of 13 days does not promote",
+			current:    "low",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -18),
+			want:       "low",
+		},
+		{
+			name:       "unrecognised confidence value normalises to low",
+			current:    "invalid",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -5),
+			want:       "low",
+		},
+		{
+			name:       "empty confidence value normalises to low",
+			current:    "",
+			observedAt: now.AddDate(0, 0, -5),
+			createdAt:  now.AddDate(0, 0, -5),
+			want:       "low",
+		},
+		{
+			name:       "stale with reinforcement: age takes priority over reinforcement",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -95),
+			createdAt:  now.AddDate(0, 0, -140),
+			want:       "medium",
+		},
+		{
+			name:       "deep stale with reinforcement: deep staleness always wins",
+			current:    "high",
+			observedAt: now.AddDate(0, 0, -185),
+			createdAt:  now.AddDate(0, 0, -230),
+			want:       "low",
+		},
+		{
+			name:       "zero time observedAt treats memory as maximally stale",
+			current:    "high",
+			observedAt: time.Time{},
+			createdAt:  time.Time{},
+			want:       "low",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DeriveHeuristicConfidence(tc.current, tc.observedAt, tc.createdAt, now)
+			if got != tc.want {
+				t.Errorf("DeriveHeuristicConfidence(%q, observedAt=%v, createdAt=%v, now=%v) = %q, want %q",
+					tc.current, tc.observedAt, tc.createdAt, now, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiffDaysTruncated(t *testing.T) {
+	tests := []struct {
+		name  string
+		start time.Time
+		end   time.Time
+		want  int
+	}{
+		{
+			name:  "same instant",
+			start: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name:  "exactly one day",
+			start: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			want:  1,
+		},
+		{
+			name:  "23 hours is 0 days",
+			start: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 1, 1, 23, 59, 59, 0, time.UTC),
+			want:  0,
+		},
+		{
+			name:  "negative direction",
+			start: time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:  -9,
+		},
+		{
+			name:  "90 days exactly",
+			start: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			end:   time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+			want:  90,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffDaysTruncated(tc.start, tc.end)
+			if got != tc.want {
+				t.Errorf("diffDaysTruncated(%v, %v) = %d, want %d", tc.start, tc.end, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormaliseConfidenceLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"high", "high"},
+		{"medium", "medium"},
+		{"low", "low"},
+		{"", "low"},
+		{"invalid", "low"},
+		{"HIGH", "low"},
+		{"Medium", "low"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := normaliseConfidenceLevel(tc.input)
+			if got != tc.want {
+				t.Errorf("normaliseConfidenceLevel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/memory/consolidate.go
+++ b/go/memory/consolidate.go
@@ -436,7 +436,9 @@ func parseDeduplicationResult(content string) deduplicationResult {
 }
 
 // reinforceHeuristicsInBatch recalculates confidence levels for
-// heuristic files under the given logical prefix.
+// heuristic files under the given logical prefix. It combines
+// observation-count confidence with age-based temporal decay so that
+// stale heuristics are demoted and reinforced heuristics are promoted.
 func (c *Consolidator) reinforceHeuristicsInBatch(ctx context.Context, b brain.Batch, prefix brain.Path) (int, []string) {
 	entries, err := b.List(ctx, prefix, brain.ListOpts{IncludeGenerated: true})
 	if err != nil {
@@ -446,6 +448,7 @@ func (c *Consolidator) reinforceHeuristicsInBatch(ctx context.Context, b brain.B
 		return 0, []string{fmt.Sprintf("reading prefix for heuristics: %s: %s", prefix, err)}
 	}
 
+	now := time.Now()
 	var updated int
 	var errs []string
 
@@ -468,8 +471,16 @@ func (c *Consolidator) reinforceHeuristicsInBatch(ctx context.Context, b brain.B
 			continue
 		}
 
+		// Start with the observation-count confidence as baseline.
 		count := countSections(body)
-		newConfidence := confidenceFromObservations(count)
+		obsConfidence := confidenceFromObservations(count)
+
+		// Apply age-based temporal decay on top of the observation
+		// confidence. This matches the TS consolidation behaviour.
+		observedAt := resolveObservedAtFromFrontmatter(fm)
+		createdAt := resolveCreatedAtFromFrontmatter(fm)
+		newConfidence := DeriveHeuristicConfidence(obsConfidence, observedAt, createdAt, now)
+
 		if newConfidence == fm.Confidence {
 			continue
 		}
@@ -483,6 +494,38 @@ func (c *Consolidator) reinforceHeuristicsInBatch(ctx context.Context, b brain.B
 	}
 
 	return updated, errs
+}
+
+// resolveObservedAtFromFrontmatter extracts the most recent observation
+// time from frontmatter. Priority: modified > created > zero time.
+func resolveObservedAtFromFrontmatter(fm Frontmatter) time.Time {
+	if fm.Modified != "" {
+		if t, err := time.Parse(time.RFC3339, fm.Modified); err == nil {
+			return t
+		}
+	}
+	if fm.Created != "" {
+		if t, err := time.Parse(time.RFC3339, fm.Created); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// resolveCreatedAtFromFrontmatter extracts the creation time from
+// frontmatter. Falls back to modified date, then zero time.
+func resolveCreatedAtFromFrontmatter(fm Frontmatter) time.Time {
+	if fm.Created != "" {
+		if t, err := time.Parse(time.RFC3339, fm.Created); err == nil {
+			return t
+		}
+	}
+	if fm.Modified != "" {
+		if t, err := time.Parse(time.RFC3339, fm.Modified); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 // rebuildWithUpdatedConfidence reconstructs a memory file with new

--- a/go/memory/consolidate_test.go
+++ b/go/memory/consolidate_test.go
@@ -151,10 +151,14 @@ func TestReinforceHeuristics_UpdatesConfidence(t *testing.T) {
 	projectPath := "/example/project"
 	slug := ProjectSlug(projectPath)
 
-	writeTopic(t, store, brain.MemoryProjectTopic(slug, "heuristic-testing-go"), `---
+	now := time.Now().UTC().Format(time.RFC3339)
+	createdAt := time.Now().AddDate(0, 0, -60).UTC().Format(time.RFC3339)
+	writeTopic(t, store, brain.MemoryProjectTopic(slug, "heuristic-testing-go"), fmt.Sprintf(`---
 name: "Testing: Go patterns"
 description: "Use table-driven tests"
 type: feedback
+created: %s
+modified: %s
 confidence: low
 source: reflection
 tags:
@@ -177,7 +181,7 @@ Third pattern observed.
 ## Observation 4
 
 Fourth pattern observed.
-`)
+`, createdAt, now))
 
 	c := NewConsolidator(nil, "", mem)
 	report, err := c.RunQuick(context.Background())


### PR DESCRIPTION
## Summary

Ports temporal confidence decay from the TypeScript SDK to Go. Memories now lose confidence as they age without access, matching the TS thresholds exactly.

## Problem

Go calculated memory confidence based on observation count only. A memory from 6 months ago ranked equally with one from yesterday (given equal semantic relevance). The TS SDK applies temporal decay: 90-day stale demotion, 180-day force-low, and reinforcement-span promotion for recently accessed old memories.

## Changes

- `go/memory/confidence.go` (new): `DeriveHeuristicConfidence` function with constants matching TS exactly (`staleAfterDays=90`, `deepStaleAfterDays=180`, `heuristicReinforcementDays=14`, `heuristicStrongReinforcementDays=45`). Includes `normaliseConfidenceLevel` and `diffDaysTruncated` helpers.

- `go/memory/consolidate.go`: `reinforceHeuristicsInBatch` now feeds observation-count confidence through `DeriveHeuristicConfidence` before applying. Added frontmatter date extraction helpers.

- `go/memory/confidence_test.go`: 23 table-driven tests covering fresh, reinforced, stale (90d), deep-stale (180d), boundary cases, future dates, zero times, and invalid confidence values. Plus helper tests.

- `go/memory/consolidate_test.go`: Updated existing fixture with dates for compatibility.

## Design Decision

The TS algorithm was found in `consolidate.ts` function `deriveHeuristicConfidence` (lines 501-515), not in extract or recall. It uses four thresholds and two time inputs (age since last observation, reinforcement span). All constants were matched exactly — no approximation.

## Testing

- `go test -race ./memory/...` passes
- `go vet ./...` passes

Resolves LLE-9661