### PR TITLE
Implement feedback classifier in TypeScript SDK

### DIFF
--- a/sdks/ts/memory/src/memory/feedback/classifier.test.ts
+++ b/sdks/ts/memory/src/memory/feedback/classifier.test.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { toPath } from '../../store/path.js'
+import { createFeedbackClassifier } from './classifier.js'
+
+const testPath = toPath('memory/global/test.md')
+
+describe('FeedbackClassifier', () => {
+  describe('classify', () => {
+    it('detects positive signal', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('perfect, thanks for that', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('reinforced')
+      expect(ev.confidence).toBeGreaterThan(0)
+    })
+
+    it('detects negative signal', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("that's wrong, it was updated last week", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('corrected')
+    })
+
+    it('returns neutral when no patterns match', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('can you show me the deployment logs', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('neutral')
+      expect(ev.confidence).toBe(0.0)
+    })
+
+    it('positive wins when more positive matches', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("no but perfect, that's helpful, spot on", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('reinforced')
+    })
+
+    it('negative wins when more negative matches', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("yes but that's wrong, incorrect, try again", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('corrected')
+    })
+
+    it('tie goes to neutral with 0.2 confidence', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('yes and no', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.reaction).toBe('neutral')
+      expect(ev.confidence).toBe(0.2)
+    })
+
+    it('returns no events for empty input', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('', [testPath])
+
+      expect(result.events).toHaveLength(0)
+    })
+
+    it('returns no events for empty surfaced paths', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('perfect, thanks', [])
+
+      expect(result.events).toHaveLength(0)
+    })
+
+    it('produces events for each surfaced path', () => {
+      const c = createFeedbackClassifier()
+      const paths = [
+        toPath('memory/global/topic-a.md'),
+        toPath('memory/global/topic-b.md'),
+        toPath('memory/project/foo/bar.md'),
+      ]
+      const result = c.classify('great, thanks', paths)
+
+      expect(result.events).toHaveLength(3)
+      for (let i = 0; i < result.events.length; i++) {
+        expect(result.events[i].memoryPath).toBe(paths[i])
+        expect(result.events[i].reaction).toBe('reinforced')
+      }
+    })
+
+    it('confidence scales with match count', () => {
+      const c = createFeedbackClassifier()
+
+      const r1 = c.classify('thanks', [testPath])
+      const r2 = c.classify("thanks, that's helpful, you remembered, that helps, spot on", [
+        testPath,
+      ])
+
+      expect(r1.events).toHaveLength(1)
+      expect(r2.events).toHaveLength(1)
+
+      const c1 = r1.events[0].confidence
+      const c2 = r2.events[0].confidence
+
+      expect(c1).toBeLessThan(c2)
+      expect(Math.abs(c1 - 0.3)).toBeLessThan(0.001)
+      expect(c2).toBeLessThanOrEqual(1.0)
+    })
+
+    it('captures the matched pattern text', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('you remembered that well', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.pattern).not.toBe('')
+      expect(ev.reaction).toBe('reinforced')
+    })
+
+    it('truncates snippet to 200 characters', () => {
+      const c = createFeedbackClassifier()
+      const longInput = 'perfect ' + 'x'.repeat(300)
+      const result = c.classify(longInput, [testPath])
+
+      expect(result.events).toHaveLength(1)
+      const ev = result.events[0]
+      expect(ev.snippet.length).toBeLessThanOrEqual(203)
+      expect(ev.snippet).toMatch(/\.\.\.$/)
+    })
+
+    it('truncates turnContent to 500 characters', () => {
+      const c = createFeedbackClassifier()
+      const longInput = 'perfect ' + 'x'.repeat(600)
+      const result = c.classify(longInput, [testPath])
+
+      expect(result.turnContent.length).toBeLessThanOrEqual(503)
+    })
+
+    // Additional test cases from task requirements
+
+    it('classifies "that\'s correct" as reinforced', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("that's correct", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].reaction).toBe('reinforced')
+    })
+
+    it('classifies "good job" as neutral (no memory-specific pattern)', () => {
+      const c = createFeedbackClassifier()
+      // "good job" does not match "good memory/recall/find" pattern,
+      // but "good" is not in the positive word list alone, so neutral.
+      // However, looking at the Go patterns, there is no standalone "good" match.
+      // Only "good memory", "good recall", "good find".
+      // "job" is not in the positive patterns.
+      const result = c.classify('good job', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      // "good job" does not match any pattern — neutral.
+      expect(result.events[0].reaction).toBe('neutral')
+    })
+
+    it('classifies "that\'s wrong" as corrected', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("that's wrong", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].reaction).toBe('corrected')
+    })
+
+    it('classifies "no, incorrect" as corrected', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('no, incorrect', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].reaction).toBe('corrected')
+    })
+
+    it('classifies "actually it\'s X not Y" as corrected', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify("actually it's TypeScript not JavaScript", [testPath])
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].reaction).toBe('corrected')
+    })
+
+    it('classifies normal conversational text as neutral', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('can you explain how the build system works', [testPath])
+
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].reaction).toBe('neutral')
+      expect(result.events[0].confidence).toBe(0.0)
+    })
+
+    it('returns empty events for whitespace-only input', () => {
+      const c = createFeedbackClassifier()
+      const result = c.classify('   ', [testPath])
+
+      expect(result.events).toHaveLength(0)
+    })
+  })
+})

--- a/sdks/ts/memory/src/memory/feedback/classifier.ts
+++ b/sdks/ts/memory/src/memory/feedback/classifier.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regex-based classification of implicit user feedback on surfaced memories.
+ *
+ * Consumed by the memory reinforcement loop. The classifier is intentionally
+ * conservative so a false positive never demotes a good memory.
+ *
+ * Ported from Go: go/memory/feedback/classifier.go
+ */
+
+import type { Path } from '../../store/index.js'
+
+/** Classifies implicit user feedback on surfaced memories. */
+export type Reaction = 'reinforced' | 'corrected' | 'neutral'
+
+/** Records a detected reaction on a specific memory. */
+export type FeedbackEvent = {
+  readonly memoryPath: Path
+  readonly reaction: Reaction
+  readonly confidence: number
+  readonly pattern: string
+  readonly snippet: string
+}
+
+/** Holds the classification outcome for one turn. */
+export type ClassifyResult = {
+  readonly events: readonly FeedbackEvent[]
+  readonly turnContent: string
+}
+
+/** Detects implicit user feedback from the next user turn. */
+export type FeedbackClassifier = {
+  classify(userInput: string, surfacedThisTurn: readonly Path[]): ClassifyResult
+}
+
+/** Patterns that detect reinforcement signals. */
+const positivePatterns: readonly string[] = [
+  '\\b(perfect|exactly|great|thanks|correct|right|yes)\\b',
+  "\\bthat('s| is| was) (right|correct|helpful|useful|what i needed)\\b",
+  '\\b(good|nice) (memory|recall|find)\\b',
+  '\\byou remembered\\b',
+  '\\bthat helps\\b',
+  '\\bspot on\\b',
+]
+
+/** Patterns that detect correction signals. */
+const negativePatterns: readonly string[] = [
+  '\\b(wrong|incorrect|no|nope|not right)\\b',
+  "\\bthat('s| is| was) (wrong|incorrect|outdated|old|stale)\\b",
+  '\\b(forget|remove|delete) (that|this|it)\\b',
+  '\\bnot what i (meant|asked|wanted)\\b',
+  '\\btry again\\b',
+  "\\bthat('s| is) (not|no longer) (true|accurate|relevant)\\b",
+  '\\bactually[,.]?\\s',
+]
+
+const compilePatterns = (patterns: readonly string[]): readonly RegExp[] =>
+  patterns.reduce<RegExp[]>((acc, p) => {
+    try {
+      acc.push(new RegExp(p, 'i'))
+    } catch {
+      // Skip invalid patterns — mirrors Go's silent skip on compile error.
+    }
+    return acc
+  }, [])
+
+const clamp = (v: number): number => (v > 1.0 ? 1.0 : v)
+
+const truncateSnippet = (s: string, n: number): string =>
+  s.length <= n ? s : `${s.slice(0, n)}...`
+
+const detectReaction = (
+  input: string,
+  positive: readonly RegExp[],
+  negative: readonly RegExp[],
+): { reaction: Reaction; confidence: number; pattern: string } => {
+  let posMatches = 0
+  let posPattern = ''
+  for (const r of positive) {
+    const match = r.exec(input)
+    if (match) {
+      posMatches++
+      if (posPattern === '') {
+        posPattern = match[0]
+      }
+    }
+  }
+
+  let negMatches = 0
+  let negPattern = ''
+  for (const r of negative) {
+    const match = r.exec(input)
+    if (match) {
+      negMatches++
+      if (negPattern === '') {
+        negPattern = match[0]
+      }
+    }
+  }
+
+  if (posMatches === 0 && negMatches === 0) {
+    return { reaction: 'neutral', confidence: 0.0, pattern: '' }
+  }
+
+  if (posMatches > negMatches) {
+    return { reaction: 'reinforced', confidence: clamp(posMatches * 0.3), pattern: posPattern }
+  }
+
+  if (negMatches > posMatches) {
+    return { reaction: 'corrected', confidence: clamp(negMatches * 0.3), pattern: negPattern }
+  }
+
+  // Tie goes to neutral.
+  return { reaction: 'neutral', confidence: 0.2, pattern: '' }
+}
+
+/** Creates a regex-based feedback classifier. */
+export const createFeedbackClassifier = (): FeedbackClassifier => {
+  const positive = compilePatterns(positivePatterns)
+  const negative = compilePatterns(negativePatterns)
+
+  return {
+    classify(userInput: string, surfacedThisTurn: readonly Path[]): ClassifyResult {
+      const turnContent = truncateSnippet(userInput, 500)
+
+      if (surfacedThisTurn.length === 0 || userInput.trim() === '') {
+        return { events: [], turnContent }
+      }
+
+      const { reaction, confidence, pattern } = detectReaction(userInput, positive, negative)
+      const snippet = truncateSnippet(userInput, 200)
+
+      const events: FeedbackEvent[] = surfacedThisTurn.map((memoryPath) => ({
+        memoryPath,
+        reaction,
+        confidence,
+        pattern,
+        snippet,
+      }))
+
+      return { events, turnContent }
+    },
+  }
+}

--- a/sdks/ts/memory/src/memory/feedback/index.ts
+++ b/sdks/ts/memory/src/memory/feedback/index.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export {
+  createFeedbackClassifier,
+  type ClassifyResult,
+  type FeedbackClassifier,
+  type FeedbackEvent,
+  type Reaction,
+} from './classifier.js'

--- a/sdks/ts/memory/src/memory/index.ts
+++ b/sdks/ts/memory/src/memory/index.ts
@@ -294,3 +294,10 @@ export {
   type QueryProceduralRecordsArgs,
   type StoredProceduralRecord,
 } from './procedural-store.js'
+export {
+  createFeedbackClassifier,
+  type ClassifyResult,
+  type FeedbackClassifier,
+  type FeedbackEvent,
+  type Reaction,
+} from './feedback/index.js'


### PR DESCRIPTION
## Summary

Ports the feedback classifier from Go to TypeScript, enabling the TS SDK to detect when user input is positive feedback, negative feedback, or a correction.

## Problem

The Go SDK's `memory/feedback/classifier.go` detects user feedback and feeds it into the memory system (reinforcing correct memories, flagging incorrect ones, creating supersession for corrections). The TS SDK had no equivalent — user feedback went undetected and unprocessed.

## Changes

- `sdks/ts/memory/src/memory/feedback/classifier.ts`: Core classifier with:
  - 6 positive regex patterns (correct, right, thanks, good memory/recall, spot on, etc.)
  - 7 negative regex patterns (wrong, incorrect, not right, outdated, forget/remove, try again, etc.)
  - Confidence scaling (0.3 per match, clamped to 1.0)
  - Same priority logic as Go (positive wins if more matches, tie goes to neutral)
  - `Reaction` type ("reinforced" | "corrected" | "neutral")

- `sdks/ts/memory/src/memory/feedback/classifier.test.ts`: 20 test cases ported from Go

- `sdks/ts/memory/src/memory/feedback/index.ts`: Barrel exports

- `sdks/ts/memory/src/memory/index.ts`: Added feedback module re-exports

## Testing

- 20/20 feedback tests pass
- Typecheck passes

Resolves LLE-9663