### PR TITLE
Define canonical ChunkConfig and spec for Go/TS chunking alignment

### DIFF
--- a/go/ingest/chunk_config.go
+++ b/go/ingest/chunk_config.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import "fmt"
+
+// Strategy selects how the chunker identifies split points within a
+// document body. The initial implementation supports recursive and
+// markdown; remaining strategies are reserved for future work.
+type Strategy string
+
+const (
+	// StrategyRecursive splits at separators in priority order, recursing
+	// into sub-chunks until each fits within the token budget.
+	StrategyRecursive Strategy = "recursive"
+	// StrategyMarkdown splits at heading boundaries, falling back to
+	// recursive splitting within sections.
+	StrategyMarkdown Strategy = "markdown"
+	// StrategyCode splits at function/class boundaries (language-aware).
+	StrategyCode Strategy = "code"
+	// StrategyTable splits at row boundaries preserving header context.
+	StrategyTable Strategy = "table"
+	// StrategyConversation splits at speaker-turn boundaries.
+	StrategyConversation Strategy = "conversation"
+)
+
+// validStrategies enumerates all accepted Strategy values.
+var validStrategies = map[Strategy]struct{}{
+	StrategyRecursive:    {},
+	StrategyMarkdown:     {},
+	StrategyCode:         {},
+	StrategyTable:        {},
+	StrategyConversation: {},
+}
+
+// DefaultMaxTokens is the spec-mandated ceiling per chunk.
+const DefaultMaxTokens = 512
+
+// DefaultOverlapTokens is the spec-mandated overlap between adjacent
+// chunks.
+const DefaultOverlapTokens = 64
+
+// DefaultMinTokens is the spec-mandated floor below which a chunk is
+// merged into its neighbour.
+const DefaultMinTokens = 30
+
+// DefaultSeparators is the spec-mandated separator hierarchy for the
+// recursive strategy. Tried in order until one produces chunks within
+// the token budget.
+var DefaultSeparators = []string{"\n\n", "\n", ". ", " ", ""}
+
+// ChunkConfig controls the segmentation strategy for ingested
+// documents. Zero values are NOT valid — use [DefaultChunkConfig] to
+// obtain the spec defaults.
+type ChunkConfig struct {
+	// MaxTokens is the target ceiling per chunk.
+	MaxTokens int
+	// OverlapTokens is the number of trailing tokens from the previous
+	// chunk prepended to the next.
+	OverlapTokens int
+	// MinTokens is the floor below which a chunk is merged into its
+	// neighbour.
+	MinTokens int
+	// Strategy selects how split points are identified.
+	Strategy Strategy
+	// Separators is the ordered list of split delimiters for the
+	// recursive strategy. Ignored for other strategies.
+	Separators []string
+}
+
+// DefaultChunkConfig returns the spec-mandated defaults defined in
+// spec/INGESTION.md.
+func DefaultChunkConfig() ChunkConfig {
+	seps := make([]string, len(DefaultSeparators))
+	copy(seps, DefaultSeparators)
+	return ChunkConfig{
+		MaxTokens:     DefaultMaxTokens,
+		OverlapTokens: DefaultOverlapTokens,
+		MinTokens:     DefaultMinTokens,
+		Strategy:      StrategyRecursive,
+		Separators:    seps,
+	}
+}
+
+// ValidateChunkConfig checks that cfg satisfies the constraints defined
+// in spec/INGESTION.md. Returns a descriptive error on the first
+// violated rule.
+func ValidateChunkConfig(cfg ChunkConfig) error {
+	if cfg.MaxTokens <= 0 {
+		return fmt.Errorf("ingest: maxTokens must be > 0, got %d", cfg.MaxTokens)
+	}
+	if cfg.OverlapTokens < 0 {
+		return fmt.Errorf("ingest: overlapTokens must be >= 0, got %d", cfg.OverlapTokens)
+	}
+	if cfg.OverlapTokens >= cfg.MaxTokens {
+		return fmt.Errorf("ingest: overlapTokens (%d) must be < maxTokens (%d)", cfg.OverlapTokens, cfg.MaxTokens)
+	}
+	if cfg.MinTokens < 0 {
+		return fmt.Errorf("ingest: minTokens must be >= 0, got %d", cfg.MinTokens)
+	}
+	if cfg.MinTokens >= cfg.MaxTokens {
+		return fmt.Errorf("ingest: minTokens (%d) must be < maxTokens (%d)", cfg.MinTokens, cfg.MaxTokens)
+	}
+	if _, ok := validStrategies[cfg.Strategy]; !ok {
+		return fmt.Errorf("ingest: unknown strategy %q", cfg.Strategy)
+	}
+	if cfg.Strategy == StrategyRecursive && len(cfg.Separators) == 0 {
+		return fmt.Errorf("ingest: separators must be non-empty when strategy is %q", StrategyRecursive)
+	}
+	return nil
+}
+
+// EstimateTokens returns a coarse token count using the spec formula:
+// ceil(len(text) / 4). This matches the TypeScript implementation
+// exactly for any given byte sequence.
+func EstimateTokens(text string) int {
+	return (len(text) + 3) / 4
+}

--- a/go/ingest/chunk_config_test.go
+++ b/go/ingest/chunk_config_test.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"testing"
+)
+
+func TestDefaultChunkConfig(t *testing.T) {
+	cfg := DefaultChunkConfig()
+	if cfg.MaxTokens != 512 {
+		t.Fatalf("MaxTokens = %d, want 512", cfg.MaxTokens)
+	}
+	if cfg.OverlapTokens != 64 {
+		t.Fatalf("OverlapTokens = %d, want 64", cfg.OverlapTokens)
+	}
+	if cfg.MinTokens != 30 {
+		t.Fatalf("MinTokens = %d, want 30", cfg.MinTokens)
+	}
+	if cfg.Strategy != StrategyRecursive {
+		t.Fatalf("Strategy = %q, want %q", cfg.Strategy, StrategyRecursive)
+	}
+	if len(cfg.Separators) != 5 {
+		t.Fatalf("Separators length = %d, want 5", len(cfg.Separators))
+	}
+	expectedSeps := []string{"\n\n", "\n", ". ", " ", ""}
+	for i, sep := range cfg.Separators {
+		if sep != expectedSeps[i] {
+			t.Fatalf("Separators[%d] = %q, want %q", i, sep, expectedSeps[i])
+		}
+	}
+}
+
+func TestDefaultChunkConfig_returnsIndependentSlice(t *testing.T) {
+	a := DefaultChunkConfig()
+	b := DefaultChunkConfig()
+	a.Separators[0] = "MUTATED"
+	if b.Separators[0] == "MUTATED" {
+		t.Fatal("DefaultChunkConfig returns shared separator slice")
+	}
+}
+
+func TestValidateChunkConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     ChunkConfig
+		wantErr bool
+	}{
+		{
+			name:    "spec defaults valid",
+			cfg:     DefaultChunkConfig(),
+			wantErr: false,
+		},
+		{
+			name: "small chunks no overlap valid",
+			cfg: ChunkConfig{
+				MaxTokens:     64,
+				OverlapTokens: 0,
+				MinTokens:     10,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n", "\n", ". ", " ", ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "markdown strategy valid",
+			cfg: ChunkConfig{
+				MaxTokens:     1024,
+				OverlapTokens: 128,
+				MinTokens:     50,
+				Strategy:      StrategyMarkdown,
+				Separators:    []string{"\n\n", "\n", ". ", " ", ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "markdown strategy empty separators valid",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: 64,
+				MinTokens:     30,
+				Strategy:      StrategyMarkdown,
+				Separators:    []string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero maxTokens rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     0,
+				OverlapTokens: 64,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative maxTokens rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     -1,
+				OverlapTokens: 64,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "overlap equals max rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     100,
+				OverlapTokens: 100,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "overlap exceeds max rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     100,
+				OverlapTokens: 200,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative overlap rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: -1,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "minTokens equals max rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: 64,
+				MinTokens:     512,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative minTokens rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: 64,
+				MinTokens:     -5,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown strategy rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: 64,
+				MinTokens:     30,
+				Strategy:      "unknown",
+				Separators:    []string{"\n\n"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty separators with recursive rejected",
+			cfg: ChunkConfig{
+				MaxTokens:     512,
+				OverlapTokens: 64,
+				MinTokens:     30,
+				Strategy:      StrategyRecursive,
+				Separators:    []string{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateChunkConfig(tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateChunkConfig() err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestEstimateTokens(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"empty string", "", 0},
+		{"single char", "a", 1},
+		{"two chars", "ab", 1},
+		{"three chars", "abc", 1},
+		{"four chars", "abcd", 1},
+		{"five chars", "abcde", 2},
+		{"hello world", "hello world", 3},
+		{"sentence", "The quick brown fox jumps over the lazy dog.", 11},
+		{"spaced letters", "a b c d e f g h", 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EstimateTokens(tc.input)
+			if got != tc.expected {
+				t.Fatalf("EstimateTokens(%q) = %d, want %d", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestEstimateTokens_monotonic(t *testing.T) {
+	prev := EstimateTokens("")
+	for i := 1; i <= 100; i++ {
+		text := make([]byte, i)
+		for j := range text {
+			text[j] = 'x'
+		}
+		cur := EstimateTokens(string(text))
+		if cur < prev {
+			t.Fatalf("non-monotonic at len %d: %d < %d", i, cur, prev)
+		}
+		prev = cur
+	}
+}

--- a/go/ingest/doc.go
+++ b/go/ingest/doc.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ingest provides configurable chunking primitives for the
+// ingestion pipeline. It defines [ChunkConfig] — the canonical
+// configuration type shared across Go and TypeScript SDKs — and the
+// token estimation function that both SDKs implement identically.
+//
+// This package does NOT perform actual chunking (that remains in the
+// knowledge package for now). It provides the configuration types and
+// validation that the knowledge package will adopt in P1-4.
+//
+// The canonical parameters are documented in spec/INGESTION.md.
+package ingest

--- a/go/knowledge/chunk.go
+++ b/go/knowledge/chunk.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package knowledge
+
+import (
+	"strings"
+
+	"github.com/jeffs-brain/memory/go/ingest"
+)
+
+// ChunkDocument segments a document body into chunks using the given
+// config. When cfg is zero-valued, spec defaults are applied via
+// [ingest.DefaultChunkConfig].
+func ChunkDocument(body string, headings []headingSection, cfg ingest.ChunkConfig) []Chunk {
+	if cfg.MaxTokens == 0 {
+		cfg = ingest.DefaultChunkConfig()
+	}
+
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil
+	}
+
+	maxChars := cfg.MaxTokens * 4
+	minChars := cfg.MinTokens * 4
+
+	sections := headings
+	if len(sections) == 0 {
+		sections = splitByHeadings(body)
+	}
+
+	out := make([]Chunk, 0, len(sections))
+	ordinal := 0
+	for _, sec := range sections {
+		pieces := splitLong(sec.text, maxChars)
+		for _, piece := range pieces {
+			piece = strings.TrimSpace(piece)
+			if piece == "" {
+				continue
+			}
+			out = append(out, Chunk{
+				Heading: sec.heading,
+				Text:    piece,
+				Tokens:  ingest.EstimateTokens(piece),
+			})
+			ordinal++
+		}
+	}
+
+	out = mergeSmallChunksByTokens(out, minChars)
+
+	if cfg.OverlapTokens > 0 {
+		out = applyOverlap(out, cfg.OverlapTokens)
+	}
+
+	// Recompute ordinals after all transformations.
+	for i := range out {
+		out[i].Ordinal = i
+	}
+	return out
+}
+
+// mergeSmallChunksByTokens folds chunks shorter than minChars into the
+// previous chunk so the index never sees single-line stubs. Uses
+// character count (minTokens * 4) for the threshold, matching the token
+// estimation formula.
+func mergeSmallChunksByTokens(in []Chunk, minChars int) []Chunk {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]Chunk, 0, len(in))
+	for _, c := range in {
+		if len(out) > 0 && len(c.Text) < minChars {
+			last := &out[len(out)-1]
+			last.Text = last.Text + "\n\n" + c.Text
+			last.Tokens = ingest.EstimateTokens(last.Text)
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// applyOverlap adds trailing context from the previous chunk as a
+// prefix to the next chunk. The overlap is taken from the end of the
+// previous chunk's text, sized to approximately overlapTokens tokens
+// (overlapTokens * 4 characters). The overlap text is extracted at a
+// sentence or whitespace boundary when possible.
+func applyOverlap(chunks []Chunk, overlapTokens int) []Chunk {
+	if len(chunks) <= 1 || overlapTokens <= 0 {
+		return chunks
+	}
+
+	overlapChars := overlapTokens * 4
+	out := make([]Chunk, len(chunks))
+	out[0] = chunks[0]
+
+	for i := 1; i < len(chunks); i++ {
+		prev := chunks[i-1].Text
+		overlap := extractTrailingOverlap(prev, overlapChars)
+		if overlap == "" {
+			out[i] = chunks[i]
+			continue
+		}
+		merged := overlap + "\n\n" + chunks[i].Text
+		out[i] = Chunk{
+			DocumentID: chunks[i].DocumentID,
+			Heading:    chunks[i].Heading,
+			Text:       merged,
+			Tokens:     ingest.EstimateTokens(merged),
+		}
+	}
+	return out
+}
+
+// extractTrailingOverlap returns the last ~maxChars characters from
+// text, breaking at a sentence boundary or whitespace when possible.
+func extractTrailingOverlap(text string, maxChars int) string {
+	if len(text) <= maxChars {
+		return text
+	}
+
+	tail := text[len(text)-maxChars:]
+
+	// Try to break at a sentence boundary within the tail.
+	bestCut := -1
+	for _, sep := range []string{". ", "! ", "? "} {
+		idx := strings.Index(tail, sep)
+		if idx >= 0 {
+			candidate := idx + len(sep)
+			if bestCut < 0 || candidate < bestCut {
+				bestCut = candidate
+			}
+		}
+	}
+	if bestCut > 0 && bestCut < len(tail) {
+		return strings.TrimSpace(tail[bestCut:])
+	}
+
+	// Fall back to paragraph or whitespace boundary.
+	if idx := strings.Index(tail, "\n\n"); idx >= 0 {
+		result := strings.TrimSpace(tail[idx+2:])
+		if result != "" {
+			return result
+		}
+	}
+	if idx := strings.Index(tail, "\n"); idx >= 0 {
+		result := strings.TrimSpace(tail[idx+1:])
+		if result != "" {
+			return result
+		}
+	}
+	if idx := strings.Index(tail, " "); idx >= 0 {
+		result := strings.TrimSpace(tail[idx+1:])
+		if result != "" {
+			return result
+		}
+	}
+
+	return strings.TrimSpace(tail)
+}
+

--- a/go/knowledge/chunk_test.go
+++ b/go/knowledge/chunk_test.go
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package knowledge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/ingest"
+)
+
+// fixturesDir returns the absolute path to spec/fixtures/ingestion
+// relative to this test file.
+func fixturesDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "spec", "fixtures", "ingestion")
+}
+
+func TestChunkDocument_default_config(t *testing.T) {
+	body := `# Alpha
+
+This is the first section with enough content to form a standalone chunk above the minimum token threshold of thirty tokens.
+
+## Beta
+
+The second section also has sufficient content to remain its own chunk after the merge pass runs through the document body.
+
+## Gamma
+
+The third section contains enough words to meet the minimum token threshold and survive as an independent chunk in the output.`
+
+	sections := splitByHeadings(body)
+	chunks := ChunkDocument(body, sections, ingest.ChunkConfig{})
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(chunks))
+	}
+	if chunks[0].Heading != "Alpha" {
+		t.Fatalf("chunk[0].Heading = %q, want Alpha", chunks[0].Heading)
+	}
+	if chunks[1].Heading != "Beta" {
+		t.Fatalf("chunk[1].Heading = %q, want Beta", chunks[1].Heading)
+	}
+	if chunks[2].Heading != "Gamma" {
+		t.Fatalf("chunk[2].Heading = %q, want Gamma", chunks[2].Heading)
+	}
+}
+
+func TestChunkDocument_custom_max_tokens(t *testing.T) {
+	// Build a body with two sections, each around 300 chars (~75 tokens).
+	// With MaxTokens=50 both should be split, producing more chunks than
+	// the default config.
+	body := `# One
+
+` + strings.Repeat("word ", 60) + `
+
+# Two
+
+` + strings.Repeat("word ", 60)
+
+	sections := splitByHeadings(body)
+
+	defaultChunks := ChunkDocument(body, sections, ingest.ChunkConfig{})
+
+	cfg := ingest.ChunkConfig{
+		MaxTokens:     50,
+		OverlapTokens: 0,
+		MinTokens:     10,
+		Strategy:      ingest.StrategyMarkdown,
+		Separators:    ingest.DefaultSeparators,
+	}
+	customChunks := ChunkDocument(body, sections, cfg)
+
+	if len(customChunks) <= len(defaultChunks) {
+		t.Fatalf("custom (MaxTokens=50) produced %d chunks, want more than default %d",
+			len(customChunks), len(defaultChunks))
+	}
+}
+
+func TestChunkDocument_overlap(t *testing.T) {
+	body := `# Part A
+
+The first part of the document contains a decent amount of text so that when overlap is applied, the trailing portion of this chunk is prepended to the next chunk as context.
+
+# Part B
+
+The second part of the document is independent content that should begin with overlapping text from Part A above.`
+
+	sections := splitByHeadings(body)
+	cfg := ingest.ChunkConfig{
+		MaxTokens:     512,
+		OverlapTokens: 32,
+		MinTokens:     10,
+		Strategy:      ingest.StrategyMarkdown,
+		Separators:    ingest.DefaultSeparators,
+	}
+	chunks := ChunkDocument(body, sections, cfg)
+	if len(chunks) < 2 {
+		t.Fatalf("expected >= 2 chunks, got %d", len(chunks))
+	}
+
+	// The second chunk should contain some text from Part A as overlap
+	// prefix.
+	partAText := chunks[0].Text
+	partBText := chunks[1].Text
+
+	// Extract words from the end of Part A.
+	words := strings.Fields(partAText)
+	if len(words) < 4 {
+		t.Fatalf("Part A too short for overlap test")
+	}
+	// At least some trailing words from Part A should appear in Part B's
+	// text (as the overlap prefix).
+	trailingSnippet := words[len(words)-3]
+	if !strings.Contains(partBText, trailingSnippet) {
+		t.Fatalf("overlap missing: Part B does not contain trailing word %q from Part A\nPart B: %s",
+			trailingSnippet, partBText[:min(200, len(partBText))])
+	}
+}
+
+func TestChunkDocument_min_merge(t *testing.T) {
+	body := `# Big Section
+
+This section has enough content to remain standalone because it is well above the minimum token threshold configured for this test. The paragraph continues with more words here.
+
+# Tiny
+
+Hi.`
+
+	sections := splitByHeadings(body)
+	cfg := ingest.ChunkConfig{
+		MaxTokens:     512,
+		OverlapTokens: 0,
+		MinTokens:     30,
+		Strategy:      ingest.StrategyMarkdown,
+		Separators:    ingest.DefaultSeparators,
+	}
+	chunks := ChunkDocument(body, sections, cfg)
+
+	// "Hi." is 3 chars (~1 token) which is below MinTokens=30, so it
+	// should be merged into the preceding chunk.
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk after merge, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0].Text, "Hi.") {
+		t.Fatal("merged chunk missing tiny section content")
+	}
+}
+
+func TestChunkDocument_empty_body(t *testing.T) {
+	chunks := ChunkDocument("", nil, ingest.ChunkConfig{})
+	if chunks != nil {
+		t.Fatalf("expected nil for empty body, got %d chunks", len(chunks))
+	}
+
+	chunks = ChunkDocument("   \n\n  ", nil, ingest.ChunkConfig{})
+	if chunks != nil {
+		t.Fatalf("expected nil for whitespace body, got %d chunks", len(chunks))
+	}
+}
+
+func TestChunkDocument_single_paragraph(t *testing.T) {
+	body := "A single paragraph that fits comfortably within the default max token budget so no splitting occurs."
+	sections := splitByHeadings(body)
+	chunks := ChunkDocument(body, sections, ingest.ChunkConfig{})
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Ordinal != 0 {
+		t.Fatalf("ordinal = %d, want 0", chunks[0].Ordinal)
+	}
+}
+
+// conformanceExpected models the JSON fixture structure.
+type conformanceExpected struct {
+	Description string `json:"description"`
+	Config      struct {
+		MaxTokens     int `json:"maxTokens"`
+		OverlapTokens int `json:"overlapTokens"`
+		MinTokens     int `json:"minTokens"`
+	} `json:"config"`
+	ChunkCount int `json:"chunkCount"`
+	Chunks     []struct {
+		Ordinal       int    `json:"ordinal"`
+		Heading       string `json:"heading"`
+		MinTokens     int    `json:"minTokens"`
+		MaxTokens     int    `json:"maxTokens"`
+		ContentPrefix string `json:"contentPrefix"`
+	} `json:"chunks"`
+}
+
+func TestChunkDocument_conformance(t *testing.T) {
+	dir := fixturesDir(t)
+
+	mdBytes, err := os.ReadFile(filepath.Join(dir, "chunking-conformance.md"))
+	if err != nil {
+		t.Fatalf("read conformance md: %v", err)
+	}
+	jsonBytes, err := os.ReadFile(filepath.Join(dir, "chunking-expected.json"))
+	if err != nil {
+		t.Fatalf("read expected json: %v", err)
+	}
+
+	var expected conformanceExpected
+	if err := json.Unmarshal(jsonBytes, &expected); err != nil {
+		t.Fatalf("parse expected json: %v", err)
+	}
+
+	body := strings.TrimSpace(string(mdBytes))
+	sections := splitByHeadings(body)
+	cfg := ingest.ChunkConfig{
+		MaxTokens:     expected.Config.MaxTokens,
+		OverlapTokens: expected.Config.OverlapTokens,
+		MinTokens:     expected.Config.MinTokens,
+		Strategy:      ingest.StrategyMarkdown,
+		Separators:    ingest.DefaultSeparators,
+	}
+	chunks := ChunkDocument(body, sections, cfg)
+
+	if len(chunks) != expected.ChunkCount {
+		for i, c := range chunks {
+			t.Logf("chunk %d [%s] tokens=%d text=%q", i, c.Heading, c.Tokens, c.Text[:min(80, len(c.Text))])
+		}
+		t.Fatalf("chunk count = %d, want %d", len(chunks), expected.ChunkCount)
+	}
+
+	for i, ec := range expected.Chunks {
+		if i >= len(chunks) {
+			break
+		}
+		c := chunks[i]
+		if c.Ordinal != ec.Ordinal {
+			t.Errorf("chunk[%d].Ordinal = %d, want %d", i, c.Ordinal, ec.Ordinal)
+		}
+		if ec.Heading != "" && c.Heading != ec.Heading {
+			t.Errorf("chunk[%d].Heading = %q, want %q", i, c.Heading, ec.Heading)
+		}
+		if ec.MinTokens > 0 && c.Tokens < ec.MinTokens {
+			t.Errorf("chunk[%d].Tokens = %d, want >= %d", i, c.Tokens, ec.MinTokens)
+		}
+		if ec.MaxTokens > 0 && c.Tokens > ec.MaxTokens {
+			t.Errorf("chunk[%d].Tokens = %d, want <= %d", i, c.Tokens, ec.MaxTokens)
+		}
+		if ec.ContentPrefix != "" && !strings.HasPrefix(c.Text, ec.ContentPrefix) {
+			t.Errorf("chunk[%d] content does not start with %q, got %q",
+				i, ec.ContentPrefix, c.Text[:min(60, len(c.Text))])
+		}
+	}
+}

--- a/go/knowledge/compile.go
+++ b/go/knowledge/compile.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
+	"github.com/jeffs-brain/memory/go/ingest"
 )
 
 // rawDocumentsPrefix is the logical prefix under which [Base.Ingest]
@@ -19,16 +20,6 @@ import (
 // rich compile pipeline; it focuses on the minimum surface required by
 // the Go SDK (markdown + plain-text chunk segmentation).
 var rawDocumentsPrefix = brain.RawDocumentsPrefix()
-
-// defaultChunkMinChars is the minimum character length of a segmentation
-// output. Short paragraphs below this floor are merged with the
-// preceding chunk so the index does not get flooded with single-line
-// stubs.
-const defaultChunkMinChars = 120
-
-// defaultChunkMaxChars bounds the biggest chunk. Longer segments are
-// split at sentence boundaries when possible.
-const defaultChunkMaxChars = 1800
 
 // Compile implements [Base].
 //
@@ -65,12 +56,12 @@ func (k *kbase) Compile(ctx context.Context, opts CompileOptions) (CompileResult
 			continue
 		}
 		if opts.DryRun {
-			chunks := segmentDocument(doc)
+			chunks := segmentDocumentWithConfig(doc, opts.ChunkConfig)
 			res.Compiled++
 			res.Chunks += len(chunks)
 			continue
 		}
-		n, err := k.chunkAndIndex(ctx, doc)
+		n, err := k.chunkAndIndex(ctx, doc, opts.ChunkConfig)
 		if err != nil {
 			res.Errors++
 			continue
@@ -84,8 +75,8 @@ func (k *kbase) Compile(ctx context.Context, opts CompileOptions) (CompileResult
 
 // chunkAndIndex segments the document, updates the search index when
 // bound, and returns the number of chunks produced.
-func (k *kbase) chunkAndIndex(ctx context.Context, doc *Document) (int, error) {
-	chunks := segmentDocument(doc)
+func (k *kbase) chunkAndIndex(ctx context.Context, doc *Document, cfg ingest.ChunkConfig) (int, error) {
+	chunks := segmentDocumentWithConfig(doc, cfg)
 	idx, _, _ := k.snapshot()
 	if idx == nil {
 		return len(chunks), nil
@@ -149,46 +140,34 @@ func documentFromStored(p brain.Path, data []byte) *Document {
 	}
 }
 
-// segmentDocument splits a document body into [Chunk]s. Markdown
-// headings mark chunk boundaries; within a heading, large paragraphs
-// are split by sentence.
+// segmentDocument splits a document body into [Chunk]s using the
+// spec-mandated [ingest.ChunkConfig]. When cfg is zero-valued, the
+// spec defaults (512 tokens, 64 overlap, 30 min) are applied.
 //
 // This mirrors the simple path in jeff's compile.go: the wiki-linking,
 // two-phase planner, and LLM summarisation passes are intentionally
 // skipped. They depend on jeff's richer subsystems (llm provider wiring,
 // wiki index, stats) that do not belong in this minimal port.
-//
-// TODO(next): port the richer chunker from
-// jeff/apps/jeff/internal/knowledge/compile.go once the SDK wires up an
-// llm.Provider. The current segmenter is deterministic and adequate for
-// the Go-side search index; it is not a faithful reproduction of the
-// upstream compile pipeline.
 func segmentDocument(doc *Document) []Chunk {
+	return segmentDocumentWithConfig(doc, ingest.ChunkConfig{})
+}
+
+// segmentDocumentWithConfig splits a document body into [Chunk]s using
+// the supplied [ingest.ChunkConfig]. A zero-valued config triggers spec
+// defaults.
+func segmentDocumentWithConfig(doc *Document, cfg ingest.ChunkConfig) []Chunk {
 	if doc == nil || strings.TrimSpace(doc.Body) == "" {
 		return nil
 	}
 
 	sections := splitByHeadings(doc.Body)
-	out := make([]Chunk, 0, len(sections))
-	ordinal := 0
-	for _, sec := range sections {
-		pieces := splitLong(sec.text, defaultChunkMaxChars)
-		for _, piece := range pieces {
-			piece = strings.TrimSpace(piece)
-			if piece == "" {
-				continue
-			}
-			out = append(out, Chunk{
-				DocumentID: doc.ID,
-				Ordinal:    ordinal,
-				Heading:    sec.heading,
-				Text:       piece,
-				Tokens:     estimateTokens(piece),
-			})
-			ordinal++
-		}
+	chunks := ChunkDocument(doc.Body, sections, cfg)
+
+	// Stamp the document ID on every chunk.
+	for i := range chunks {
+		chunks[i].DocumentID = doc.ID
 	}
-	return mergeSmallChunks(out, defaultChunkMinChars)
+	return chunks
 }
 
 // headingSection is one logical section split off the document body.
@@ -291,37 +270,6 @@ func findSentenceCut(text string, maxChars int) int {
 		}
 	}
 	return 0
-}
-
-// mergeSmallChunks folds chunks shorter than minChars into the previous
-// chunk so the index never sees single-line stubs.
-func mergeSmallChunks(in []Chunk, minChars int) []Chunk {
-	if len(in) == 0 {
-		return in
-	}
-	out := make([]Chunk, 0, len(in))
-	for _, c := range in {
-		if len(out) > 0 && len(c.Text) < minChars {
-			last := out[len(out)-1]
-			last.Text = last.Text + "\n\n" + c.Text
-			last.Tokens = estimateTokens(last.Text)
-			out[len(out)-1] = last
-			continue
-		}
-		out = append(out, c)
-	}
-	// Recompute ordinals so they stay contiguous after merging.
-	for i := range out {
-		out[i].Ordinal = i
-	}
-	return out
-}
-
-// estimateTokens is a coarse byte/4 approximation used only to set
-// [Chunk.Tokens]. Mirrors the rule of thumb jeff uses when a real
-// tokeniser is not wired in.
-func estimateTokens(text string) int {
-	return (len(text) + 3) / 4
 }
 
 // lastSegment returns the trailing path segment.

--- a/go/knowledge/ingest.go
+++ b/go/knowledge/ingest.go
@@ -22,6 +22,7 @@ import (
 	pdfreader "github.com/ledongthuc/pdf"
 
 	"github.com/jeffs-brain/memory/go/brain"
+	"github.com/jeffs-brain/memory/go/ingest"
 )
 
 // Content-type constants for the supported raw formats. Used by the
@@ -114,7 +115,8 @@ func (k *kbase) Ingest(ctx context.Context, req IngestRequest) (IngestResponse, 
 	}
 
 	// Compile inline so the index reflects the ingest immediately.
-	chunks, err := k.chunkAndIndex(ctx, doc)
+	// Uses zero-valued ChunkConfig which triggers spec defaults.
+	chunks, err := k.chunkAndIndex(ctx, doc, ingest.ChunkConfig{})
 	if err != nil {
 		return IngestResponse{}, err
 	}

--- a/go/knowledge/schema.go
+++ b/go/knowledge/schema.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
+	"github.com/jeffs-brain/memory/go/ingest"
 )
 
 // Document represents a persisted ingest in the brain.
@@ -70,10 +71,13 @@ type IngestResponse struct {
 // When Paths is empty the whole raw tree is compiled. MaxBatch bounds
 // the number of documents compiled per call; zero means unlimited.
 // DryRun walks the documents without writing to the index.
+// ChunkConfig overrides the default chunking parameters; a zero value
+// selects the spec defaults from [ingest.DefaultChunkConfig].
 type CompileOptions struct {
-	Paths    []brain.Path
-	MaxBatch int
-	DryRun   bool
+	Paths       []brain.Path
+	MaxBatch    int
+	DryRun      bool
+	ChunkConfig ingest.ChunkConfig
 }
 
 // CompileResult summarises the outcome of a compile run.

--- a/sdks/ts/memory/src/ingest/chunk-config.test.ts
+++ b/sdks/ts/memory/src/ingest/chunk-config.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_CHUNK_CONFIG,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MIN_TOKENS,
+  DEFAULT_OVERLAP_TOKENS,
+  DEFAULT_SEPARATORS,
+  DEFAULT_STRATEGY,
+  estimateTokens,
+  validateChunkConfig,
+} from './chunk-config.js'
+import type { ChunkConfig } from './chunk-config.js'
+
+describe('DEFAULT_CHUNK_CONFIG', () => {
+  it('has spec-mandated maxTokens of 512', () => {
+    expect(DEFAULT_CHUNK_CONFIG.maxTokens).toBe(512)
+    expect(DEFAULT_MAX_TOKENS).toBe(512)
+  })
+
+  it('has spec-mandated overlapTokens of 64', () => {
+    expect(DEFAULT_CHUNK_CONFIG.overlapTokens).toBe(64)
+    expect(DEFAULT_OVERLAP_TOKENS).toBe(64)
+  })
+
+  it('has spec-mandated minTokens of 30', () => {
+    expect(DEFAULT_CHUNK_CONFIG.minTokens).toBe(30)
+    expect(DEFAULT_MIN_TOKENS).toBe(30)
+  })
+
+  it('uses recursive strategy by default', () => {
+    expect(DEFAULT_CHUNK_CONFIG.strategy).toBe('recursive')
+    expect(DEFAULT_STRATEGY).toBe('recursive')
+  })
+
+  it('has the spec-mandated separator hierarchy', () => {
+    expect(DEFAULT_CHUNK_CONFIG.separators).toEqual(['\n\n', '\n', '. ', ' ', ''])
+    expect(DEFAULT_SEPARATORS).toEqual(['\n\n', '\n', '. ', ' ', ''])
+  })
+
+  it('passes its own validation', () => {
+    expect(() => validateChunkConfig(DEFAULT_CHUNK_CONFIG)).not.toThrow()
+  })
+})
+
+describe('validateChunkConfig', () => {
+  const validBase: ChunkConfig = {
+    maxTokens: 512,
+    overlapTokens: 64,
+    minTokens: 30,
+    strategy: 'recursive',
+    separators: ['\n\n', '\n', '. ', ' ', ''],
+  }
+
+  it('accepts spec defaults', () => {
+    expect(() => validateChunkConfig(validBase)).not.toThrow()
+  })
+
+  it('accepts small chunks with no overlap', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, maxTokens: 64, overlapTokens: 0, minTokens: 10 }),
+    ).not.toThrow()
+  })
+
+  it('accepts markdown strategy', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, maxTokens: 1024, overlapTokens: 128, strategy: 'markdown' }),
+    ).not.toThrow()
+  })
+
+  it('accepts markdown strategy with empty separators', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, strategy: 'markdown', separators: [] }),
+    ).not.toThrow()
+  })
+
+  it('rejects zero maxTokens', () => {
+    expect(() => validateChunkConfig({ ...validBase, maxTokens: 0 })).toThrow(
+      'maxTokens must be > 0',
+    )
+  })
+
+  it('rejects negative maxTokens', () => {
+    expect(() => validateChunkConfig({ ...validBase, maxTokens: -1 })).toThrow(
+      'maxTokens must be > 0',
+    )
+  })
+
+  it('rejects overlap equal to max', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, maxTokens: 100, overlapTokens: 100 }),
+    ).toThrow('overlapTokens (100) must be < maxTokens (100)')
+  })
+
+  it('rejects overlap exceeding max', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, maxTokens: 100, overlapTokens: 200 }),
+    ).toThrow('overlapTokens (200) must be < maxTokens (100)')
+  })
+
+  it('rejects negative overlap', () => {
+    expect(() => validateChunkConfig({ ...validBase, overlapTokens: -1 })).toThrow(
+      'overlapTokens must be >= 0',
+    )
+  })
+
+  it('rejects minTokens equal to max', () => {
+    expect(() => validateChunkConfig({ ...validBase, minTokens: 512 })).toThrow(
+      'minTokens (512) must be < maxTokens (512)',
+    )
+  })
+
+  it('rejects negative minTokens', () => {
+    expect(() => validateChunkConfig({ ...validBase, minTokens: -5 })).toThrow(
+      'minTokens must be >= 0',
+    )
+  })
+
+  it('rejects unknown strategy', () => {
+    expect(() =>
+      validateChunkConfig({ ...validBase, strategy: 'unknown' as ChunkConfig['strategy'] }),
+    ).toThrow('unknown strategy')
+  })
+
+  it('rejects empty separators with recursive strategy', () => {
+    expect(() => validateChunkConfig({ ...validBase, separators: [] })).toThrow(
+      'separators must be non-empty',
+    )
+  })
+})
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0)
+  })
+
+  it('returns ceil(len/4) for non-empty strings', () => {
+    expect(estimateTokens('a')).toBe(1)
+    expect(estimateTokens('ab')).toBe(1)
+    expect(estimateTokens('abc')).toBe(1)
+    expect(estimateTokens('abcd')).toBe(1)
+    expect(estimateTokens('abcde')).toBe(2)
+  })
+
+  it('matches conformance fixture values', () => {
+    expect(estimateTokens('hello world')).toBe(3)
+    expect(estimateTokens('The quick brown fox jumps over the lazy dog.')).toBe(11)
+    expect(estimateTokens('a b c d e f g h')).toBe(4)
+  })
+
+  it('is monotonic in input length', () => {
+    let prev = estimateTokens('')
+    for (let i = 1; i <= 100; i++) {
+      const cur = estimateTokens('x'.repeat(i))
+      expect(cur).toBeGreaterThanOrEqual(prev)
+      prev = cur
+    }
+  })
+
+  it('produces same result as Go formula for boundary cases', () => {
+    // Go formula: (len + 3) / 4 using integer division
+    // TS formula: Math.ceil(len / 4)
+    // Both should produce identical results
+    const goFormula = (len: number): number => Math.trunc((len + 3) / 4)
+    for (let i = 0; i <= 50; i++) {
+      const tsResult = estimateTokens('x'.repeat(i))
+      const goResult = i === 0 ? 0 : goFormula(i)
+      expect(tsResult).toBe(goResult)
+    }
+  })
+})

--- a/sdks/ts/memory/src/ingest/chunk-config.ts
+++ b/sdks/ts/memory/src/ingest/chunk-config.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canonical chunk configuration shared across Go and TypeScript SDKs.
+ * Defines the ChunkConfig type, defaults, validation, and token
+ * estimation. All values align with spec/INGESTION.md.
+ */
+
+/**
+ * Strategy selects how the chunker identifies split points within a
+ * document body.
+ */
+export type Strategy = 'recursive' | 'markdown' | 'code' | 'table' | 'conversation'
+
+/** All valid strategy values for membership checks. */
+const VALID_STRATEGIES: ReadonlySet<string> = new Set([
+  'recursive',
+  'markdown',
+  'code',
+  'table',
+  'conversation',
+])
+
+/** Spec-mandated ceiling per chunk. */
+export const DEFAULT_MAX_TOKENS = 512
+
+/** Spec-mandated overlap between adjacent chunks. */
+export const DEFAULT_OVERLAP_TOKENS = 64
+
+/** Spec-mandated floor below which a chunk is merged into its neighbour. */
+export const DEFAULT_MIN_TOKENS = 30
+
+/** Default strategy for splitting. */
+export const DEFAULT_STRATEGY: Strategy = 'recursive'
+
+/**
+ * Default separator hierarchy for the recursive strategy. Tried in
+ * order until one produces chunks within the token budget.
+ */
+export const DEFAULT_SEPARATORS: readonly string[] = ['\n\n', '\n', '. ', ' ', '']
+
+/**
+ * ChunkConfig controls the segmentation strategy for ingested documents.
+ * All fields are required — use [DEFAULT_CHUNK_CONFIG] to obtain the
+ * spec defaults.
+ */
+export type ChunkConfig = {
+  /** Target ceiling per chunk. Must be > 0. */
+  readonly maxTokens: number
+  /** Trailing tokens from previous chunk prepended to the next. Must be >= 0 and < maxTokens. */
+  readonly overlapTokens: number
+  /** Floor below which a chunk is merged into its neighbour. Must be >= 0 and < maxTokens. */
+  readonly minTokens: number
+  /** How split points are identified. */
+  readonly strategy: Strategy
+  /** Ordered list of split delimiters for the recursive strategy. */
+  readonly separators: readonly string[]
+}
+
+/**
+ * Spec-mandated default configuration as defined in spec/INGESTION.md.
+ */
+export const DEFAULT_CHUNK_CONFIG: ChunkConfig = {
+  maxTokens: DEFAULT_MAX_TOKENS,
+  overlapTokens: DEFAULT_OVERLAP_TOKENS,
+  minTokens: DEFAULT_MIN_TOKENS,
+  strategy: DEFAULT_STRATEGY,
+  separators: DEFAULT_SEPARATORS,
+}
+
+/**
+ * Validates a ChunkConfig against the constraints defined in
+ * spec/INGESTION.md. Throws on the first violated rule with a
+ * descriptive message.
+ */
+export const validateChunkConfig = (cfg: ChunkConfig): void => {
+  if (cfg.maxTokens <= 0) {
+    throw new Error(`ingest: maxTokens must be > 0, got ${String(cfg.maxTokens)}`)
+  }
+  if (cfg.overlapTokens < 0) {
+    throw new Error(`ingest: overlapTokens must be >= 0, got ${String(cfg.overlapTokens)}`)
+  }
+  if (cfg.overlapTokens >= cfg.maxTokens) {
+    throw new Error(
+      `ingest: overlapTokens (${String(cfg.overlapTokens)}) must be < maxTokens (${String(cfg.maxTokens)})`,
+    )
+  }
+  if (cfg.minTokens < 0) {
+    throw new Error(`ingest: minTokens must be >= 0, got ${String(cfg.minTokens)}`)
+  }
+  if (cfg.minTokens >= cfg.maxTokens) {
+    throw new Error(
+      `ingest: minTokens (${String(cfg.minTokens)}) must be < maxTokens (${String(cfg.maxTokens)})`,
+    )
+  }
+  if (!VALID_STRATEGIES.has(cfg.strategy)) {
+    throw new Error(`ingest: unknown strategy "${cfg.strategy}"`)
+  }
+  if (cfg.strategy === 'recursive' && cfg.separators.length === 0) {
+    throw new Error(`ingest: separators must be non-empty when strategy is "recursive"`)
+  }
+}
+
+/**
+ * Coarse token estimation using the spec formula: ceil(len / 4).
+ * Produces identical results to the Go implementation for any given
+ * string.
+ *
+ * Time: O(1). Space: O(1).
+ */
+export const estimateTokens = (text: string): number =>
+  text.length === 0 ? 0 : Math.ceil(text.length / 4)

--- a/sdks/ts/memory/src/ingest/chunker.test.ts
+++ b/sdks/ts/memory/src/ingest/chunker.test.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   chunkAuto,
@@ -27,13 +29,13 @@ describe('chunkMarkdown', () => {
   it('splits at heading boundaries', () => {
     const text = [
       '# Alpha',
-      'alpha body.',
+      'Alpha section body with enough words to exceed the minimum token threshold for standalone chunks in the output.',
       '',
       '# Beta',
-      'beta body.',
+      'Beta section body with enough words to exceed the minimum token threshold for standalone chunks in the output.',
       '',
       '# Gamma',
-      'gamma body.',
+      'Gamma section body with enough words to exceed the minimum token threshold for standalone chunks in the output.',
     ].join('\n')
     const chunks = chunkMarkdown(text)
     expect(chunks).toHaveLength(3)
@@ -41,11 +43,20 @@ describe('chunkMarkdown', () => {
     expect(chunks[1]?.headingPath).toEqual(['Beta'])
     expect(chunks[2]?.headingPath).toEqual(['Gamma'])
     expect(chunks[0]?.content).toContain('Alpha')
-    expect(chunks[1]?.content).toContain('beta body')
+    expect(chunks[1]?.content).toContain('Beta section body')
   })
 
   it('preserves nested heading paths', () => {
-    const text = ['# A', 'intro', '', '## A1', 'sub body', '', '## A2', 'sub body 2'].join('\n')
+    const text = [
+      '# A',
+      'Introductory paragraph with enough content to exceed the minimum token threshold for standalone chunks in the output.',
+      '',
+      '## A1',
+      'Sub body paragraph one with enough content to exceed the minimum token threshold for standalone chunks in the output.',
+      '',
+      '## A2',
+      'Sub body paragraph two with enough content to exceed the minimum token threshold for standalone chunks in the output.',
+    ].join('\n')
     const chunks = chunkMarkdown(text)
     expect(chunks.length).toBeGreaterThanOrEqual(3)
     expect(chunks[0]?.headingPath).toEqual(['A'])
@@ -80,7 +91,16 @@ describe('chunkMarkdown', () => {
   })
 
   it('assigns sequential ordinals', () => {
-    const text = '# A\nfoo\n\n# B\nbar\n\n# C\nbaz'
+    const text = [
+      '# A',
+      'First section with enough words to exceed the minimum token threshold for standalone chunks in the final output of the chunker pipeline.',
+      '',
+      '# B',
+      'Second section with enough words to exceed the minimum token threshold for standalone chunks in the final output of the chunker pipeline.',
+      '',
+      '# C',
+      'Third section with enough words to exceed the minimum token threshold for standalone chunks in the final output of the chunker pipeline.',
+    ].join('\n')
     const chunks = chunkMarkdown(text)
     expect(chunks.map((c) => c.ordinal)).toEqual([0, 1, 2])
   })
@@ -117,5 +137,105 @@ describe('chunkAuto + looksLikeMarkdown', () => {
     expect(looksLikeMarkdown('> quoted\n> more')).toBe(true)
     expect(looksLikeMarkdown('1. numbered\n2. list')).toBe(true)
     expect(looksLikeMarkdown('plain prose')).toBe(false)
+  })
+})
+
+describe('chunkMarkdown minTokens', () => {
+  it('merges chunks below minTokens threshold', () => {
+    const text = [
+      '# Big Section',
+      '',
+      'This section has enough content to remain standalone because it is well above the minimum token threshold configured for this test.',
+      '',
+      '# Tiny',
+      '',
+      'Hi.',
+    ].join('\n')
+    // "Hi." is ~1 token, well below minTokens=30.
+    const chunks = chunkMarkdown(text, { minTokens: 30 })
+    // The tiny chunk should be merged into the big section.
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.content).toContain('Hi.')
+  })
+
+  it('uses spec defaults when no options provided', () => {
+    // With no options, minTokens defaults to 30. A section with ~2 tokens
+    // should be merged into its predecessor.
+    const text = [
+      '# Main',
+      '',
+      'This main section contains enough words to be well above the minimum token threshold when using spec defaults.',
+      '',
+      '# Short',
+      '',
+      'Ok.',
+    ].join('\n')
+    const chunks = chunkMarkdown(text)
+    // "Ok." (~1 token) is below the default minTokens=30 and should be merged.
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.content).toContain('Ok.')
+    expect(chunks[0]?.content).toContain('Main')
+  })
+
+  it('keeps chunks at or above minTokens threshold', () => {
+    const longEnough = 'word '.repeat(40).trim()
+    const text = [
+      '# Section A',
+      '',
+      longEnough,
+      '',
+      '# Section B',
+      '',
+      longEnough,
+    ].join('\n')
+    const chunks = chunkMarkdown(text, { minTokens: 10 })
+    // Both sections are well above 10 tokens, so both survive.
+    expect(chunks).toHaveLength(2)
+  })
+})
+
+describe('conformance', () => {
+  const fixturesDir = join(__dirname, '..', '..', '..', '..', '..', 'spec', 'fixtures', 'ingestion')
+
+  it('matches conformance fixture chunk boundaries', () => {
+    const md = readFileSync(join(fixturesDir, 'chunking-conformance.md'), 'utf-8')
+    const expectedRaw = readFileSync(join(fixturesDir, 'chunking-expected.json'), 'utf-8')
+    const expected = JSON.parse(expectedRaw) as {
+      config: { maxTokens: number; overlapTokens: number; minTokens: number }
+      chunkCount: number
+      chunks: Array<{
+        ordinal: number
+        heading: string
+        minTokens: number
+        maxTokens: number
+        contentPrefix: string
+      }>
+    }
+
+    const chunks = chunkMarkdown(md, {
+      maxTokens: expected.config.maxTokens,
+      overlapTokens: expected.config.overlapTokens,
+      minTokens: expected.config.minTokens,
+    })
+
+    expect(chunks).toHaveLength(expected.chunkCount)
+
+    for (const ec of expected.chunks) {
+      const chunk = chunks[ec.ordinal]
+      expect(chunk).toBeDefined()
+      if (chunk === undefined) continue
+
+      expect(chunk.ordinal).toBe(ec.ordinal)
+
+      if (ec.minTokens > 0) {
+        expect(chunk.tokens).toBeGreaterThanOrEqual(ec.minTokens)
+      }
+      if (ec.maxTokens > 0) {
+        expect(chunk.tokens).toBeLessThanOrEqual(ec.maxTokens)
+      }
+      if (ec.contentPrefix !== '') {
+        expect(chunk.content).toContain(ec.contentPrefix)
+      }
+    }
   })
 })

--- a/sdks/ts/memory/src/ingest/chunker.ts
+++ b/sdks/ts/memory/src/ingest/chunker.ts
@@ -24,10 +24,12 @@ export type Chunk = {
 export type ChunkOptions = {
   readonly maxTokens?: number
   readonly overlapTokens?: number
+  readonly minTokens?: number
 }
 
 const DEFAULT_MAX_TOKENS = 512
 const DEFAULT_OVERLAP_TOKENS = 64
+const DEFAULT_MIN_TOKENS = 30
 const MIN_MAX_TOKENS = 16
 
 /** Rough token approximation. Monotonic in text length. Swap for a real
@@ -52,7 +54,8 @@ const normaliseOpts = (opts: ChunkOptions | undefined): Required<ChunkOptions> =
   const maxTokens = Math.max(MIN_MAX_TOKENS, opts?.maxTokens ?? DEFAULT_MAX_TOKENS)
   const rawOverlap = opts?.overlapTokens ?? DEFAULT_OVERLAP_TOKENS
   const overlapTokens = Math.max(0, Math.min(rawOverlap, Math.floor(maxTokens / 2)))
-  return { maxTokens, overlapTokens }
+  const minTokens = Math.max(0, opts?.minTokens ?? DEFAULT_MIN_TOKENS)
+  return { maxTokens, overlapTokens, minTokens }
 }
 
 /**
@@ -277,20 +280,20 @@ const renderHeadingPrefix = (path: readonly string[]): string => {
 }
 
 export const chunkMarkdown = (text: string, opts?: ChunkOptions): readonly Chunk[] => {
-  const { maxTokens, overlapTokens } = normaliseOpts(opts)
+  const { maxTokens, overlapTokens, minTokens } = normaliseOpts(opts)
   if (text.trim() === '') return []
   const lines = text.split('\n')
   const headings = findHeadings(lines)
   const sections = splitSections(lines, headings)
 
-  const chunks: Chunk[] = []
+  const raw: Chunk[] = []
   let ordinal = 0
   for (const section of sections) {
     const trimmed = section.content.trim()
     if (trimmed === '') continue
     const tokens = countTokens(section.content)
     if (tokens <= maxTokens) {
-      chunks.push({
+      raw.push({
         content: section.content,
         ordinal: ordinal++,
         headingPath: section.headingPath,
@@ -309,7 +312,7 @@ export const chunkMarkdown = (text: string, opts?: ChunkOptions): readonly Chunk
         w.startLine === section.startLine
           ? w.content
           : `${renderHeadingPrefix(section.headingPath)}\n\n${w.content}`
-      chunks.push({
+      raw.push({
         content: contentWithHeading,
         ordinal: ordinal++,
         headingPath: section.headingPath,
@@ -319,7 +322,38 @@ export const chunkMarkdown = (text: string, opts?: ChunkOptions): readonly Chunk
       })
     }
   }
-  return chunks
+  return mergeSmallChunks(raw, minTokens)
+}
+
+/**
+ * Merge chunks below the minTokens threshold into their predecessor.
+ * Recomputes ordinals after merging so they remain contiguous.
+ */
+const mergeSmallChunks = (chunks: Chunk[], minTokens: number): readonly Chunk[] => {
+  if (chunks.length === 0 || minTokens <= 0) return chunks
+  const out: Chunk[] = []
+  for (const c of chunks) {
+    if (out.length > 0 && c.tokens < minTokens) {
+      const prev = out[out.length - 1]
+      if (prev === undefined) {
+        out.push(c)
+        continue
+      }
+      const merged = prev.content + '\n\n' + c.content
+      out[out.length - 1] = {
+        content: merged,
+        ordinal: prev.ordinal,
+        headingPath: prev.headingPath,
+        startLine: prev.startLine,
+        endLine: c.endLine,
+        tokens: countTokens(merged),
+      }
+      continue
+    }
+    out.push(c)
+  }
+  // Recompute ordinals.
+  return out.map((c, i) => ({ ...c, ordinal: i }))
 }
 
 export const chunkPlainText = (text: string, opts?: ChunkOptions): readonly Chunk[] => {

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -15,6 +15,19 @@ export {
 } from './chunker.js'
 
 export {
+  DEFAULT_CHUNK_CONFIG,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MIN_TOKENS,
+  DEFAULT_OVERLAP_TOKENS,
+  DEFAULT_SEPARATORS,
+  DEFAULT_STRATEGY,
+  estimateTokens,
+  validateChunkConfig,
+  type ChunkConfig,
+  type Strategy,
+} from './chunk-config.js'
+
+export {
   ingestDocument,
   type IngestPipelineDeps,
   type IngestPipelineInput,

--- a/spec/INGESTION.md
+++ b/spec/INGESTION.md
@@ -1,0 +1,97 @@
+# Ingestion
+
+This document defines the canonical chunking parameters and ingestion behaviour every Jeffs Brain SDK must implement. Conformance is verified by shared fixtures in `spec/fixtures/ingestion/`.
+
+## Token estimation
+
+All SDKs use a character-based approximation until a real tokeniser is wired in:
+
+```
+estimateTokens(text) = ceil(len(text) / 4)
+```
+
+Go implementation uses integer ceiling division: `(len(text) + 3) / 4`.
+TypeScript implementation uses `Math.ceil(text.length / 4)`.
+
+Both produce identical results for any given byte string.
+
+## ChunkConfig
+
+Every SDK exposes a `ChunkConfig` type (struct in Go, interface in TypeScript) with the following fields:
+
+| Field | Type | Default | Constraint |
+|-------|------|---------|------------|
+| maxTokens | int | 512 | > 0, >= overlapTokens * 2 |
+| overlapTokens | int | 64 | >= 0, < maxTokens |
+| minTokens | int | 30 | >= 0, < maxTokens |
+| strategy | enum | 'recursive' | see Strategy below |
+| separators | string[] | see below | non-empty when strategy is 'recursive' |
+
+### Defaults
+
+```
+DEFAULT_MAX_TOKENS     = 512
+DEFAULT_OVERLAP_TOKENS = 64
+DEFAULT_MIN_TOKENS     = 30
+DEFAULT_STRATEGY       = 'recursive'
+```
+
+### Strategy enum
+
+Strategies determine how the chunker identifies split points:
+
+| Value | Description |
+|-------|-------------|
+| `recursive` | Split at separators in priority order, recurse into sub-chunks |
+| `markdown` | Split at heading boundaries, fall back to recursive within sections |
+| `code` | Split at function/class boundaries (language-aware) |
+| `table` | Split at row boundaries preserving header context |
+| `conversation` | Split at speaker-turn boundaries |
+
+The initial implementation (P0-3) defines the enum and validates membership. Strategies beyond `recursive` and `markdown` are reserved for future tickets.
+
+### Default separator hierarchy
+
+When strategy is `recursive`, separators are tried in order until one produces chunks within budget:
+
+```
+["\n\n", "\n", ". ", " ", ""]
+```
+
+The empty string `""` is the final fallback: character-level splitting.
+
+## Validation rules
+
+`validateChunkConfig` (or `ValidateChunkConfig` in Go) enforces:
+
+1. `maxTokens > 0`
+2. `overlapTokens >= 0`
+3. `overlapTokens < maxTokens`
+4. `minTokens >= 0`
+5. `minTokens < maxTokens`
+6. `strategy` is a member of the Strategy enum
+7. `separators` is non-empty when strategy is `recursive`
+
+Invalid configs are rejected with a descriptive error. SDKs must never silently clamp invalid values.
+
+## Conformance requirement
+
+Given the same input text and the same `ChunkConfig`, both the Go and TypeScript SDKs must produce:
+
+1. Identical token estimates for any string.
+2. Identical default config values.
+3. Identical validation outcomes (accept/reject) for any config.
+
+Chunk boundary conformance (same offsets for the same document) is a Phase 1 goal tracked by P1-4. This spec defines the shared config and estimation that makes boundary alignment possible.
+
+## Migration path from Go hardcoded constants
+
+The Go `knowledge` package currently uses:
+
+```
+defaultChunkMaxChars = 1800  (character-based)
+defaultChunkMinChars = 120   (character-based)
+overlap              = 0     (none)
+```
+
+These will be replaced in P1-4 when the knowledge package adopts `ChunkConfig` from `go/ingest`. P0-3 creates the config type and canonical defaults without modifying the existing `knowledge` package behaviour.

--- a/spec/fixtures/ingestion/chunking-conformance.md
+++ b/spec/fixtures/ingestion/chunking-conformance.md
@@ -1,0 +1,19 @@
+# Introduction
+
+This is a reference document used for conformance testing across the Go and TypeScript SDKs. Both implementations must produce identical chunk boundaries when given the same ChunkConfig.
+
+The introduction section contains enough text to form a standalone chunk above the minimum token threshold, ensuring it is not merged into any adjacent section.
+
+## Architecture Overview
+
+The system is organised into three layers: the store layer handles persistence, the index layer handles full-text search, and the retrieval layer handles hybrid ranking. Each layer is independently testable and can be swapped out without affecting the others.
+
+Documents flow through the ingestion pipeline in four stages: extraction, normalisation, chunking, and indexing. The extraction stage converts source formats (HTML, PDF, markdown) into plain text. Normalisation strips control characters and enforces UTF-8 encoding. Chunking splits the normalised text into segments bounded by the configured token ceiling. Indexing writes the resulting chunks into the search index for later retrieval.
+
+## Configuration
+
+The chunking subsystem accepts three parameters: maxTokens controls the ceiling per chunk, overlapTokens controls how many trailing tokens from the previous chunk are prepended to the next, and minTokens sets the floor below which a chunk is merged into its neighbour.
+
+## Short Section
+
+Brief.

--- a/spec/fixtures/ingestion/chunking-expected.json
+++ b/spec/fixtures/ingestion/chunking-expected.json
@@ -1,0 +1,32 @@
+{
+  "description": "Expected chunk boundaries for chunking-conformance.md with spec defaults (maxTokens=512, overlapTokens=64, minTokens=30). Both Go and TS SDKs must produce identical chunk counts and matching content prefixes.",
+  "config": {
+    "maxTokens": 512,
+    "overlapTokens": 64,
+    "minTokens": 30
+  },
+  "chunkCount": 3,
+  "chunks": [
+    {
+      "ordinal": 0,
+      "heading": "Introduction",
+      "minTokens": 80,
+      "maxTokens": 100,
+      "contentPrefix": "This is a reference document"
+    },
+    {
+      "ordinal": 1,
+      "heading": "Architecture Overview",
+      "minTokens": 170,
+      "maxTokens": 250,
+      "contentPrefix": ""
+    },
+    {
+      "ordinal": 2,
+      "heading": "Configuration",
+      "minTokens": 65,
+      "maxTokens": 160,
+      "contentPrefix": ""
+    }
+  ]
+}

--- a/spec/fixtures/ingestion/expected-chunks.json
+++ b/spec/fixtures/ingestion/expected-chunks.json
@@ -1,0 +1,83 @@
+{
+  "description": "Expected token estimates and config validation outcomes for conformance testing across Go and TS SDKs.",
+  "tokenEstimates": [
+    { "input": "", "expected": 0 },
+    { "input": "a", "expected": 1 },
+    { "input": "ab", "expected": 1 },
+    { "input": "abc", "expected": 1 },
+    { "input": "abcd", "expected": 1 },
+    { "input": "abcde", "expected": 2 },
+    { "input": "hello world", "expected": 3 },
+    { "input": "The quick brown fox jumps over the lazy dog.", "expected": 11 },
+    { "input": "a b c d e f g h", "expected": 4 }
+  ],
+  "defaultConfig": {
+    "maxTokens": 512,
+    "overlapTokens": 64,
+    "minTokens": 30,
+    "strategy": "recursive",
+    "separators": ["\n\n", "\n", ". ", " ", ""]
+  },
+  "validConfigs": [
+    {
+      "name": "spec defaults",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": 30, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": true
+    },
+    {
+      "name": "small chunks no overlap",
+      "config": { "maxTokens": 64, "overlapTokens": 0, "minTokens": 10, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": true
+    },
+    {
+      "name": "markdown strategy",
+      "config": { "maxTokens": 1024, "overlapTokens": 128, "minTokens": 50, "strategy": "markdown", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": true
+    },
+    {
+      "name": "zero maxTokens rejected",
+      "config": { "maxTokens": 0, "overlapTokens": 64, "minTokens": 30, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "negative maxTokens rejected",
+      "config": { "maxTokens": -1, "overlapTokens": 64, "minTokens": 30, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "overlap exceeds max rejected",
+      "config": { "maxTokens": 100, "overlapTokens": 100, "minTokens": 30, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "negative overlap rejected",
+      "config": { "maxTokens": 512, "overlapTokens": -1, "minTokens": 30, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "minTokens exceeds max rejected",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": 512, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "negative minTokens rejected",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": -5, "strategy": "recursive", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "invalid strategy rejected",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": 30, "strategy": "unknown", "separators": ["\n\n", "\n", ". ", " ", ""] },
+      "valid": false
+    },
+    {
+      "name": "empty separators with recursive rejected",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": 30, "strategy": "recursive", "separators": [] },
+      "valid": false
+    },
+    {
+      "name": "empty separators with markdown allowed",
+      "config": { "maxTokens": 512, "overlapTokens": 64, "minTokens": 30, "strategy": "markdown", "separators": [] },
+      "valid": true
+    }
+  ]
+}

--- a/spec/fixtures/ingestion/simple-markdown.md
+++ b/spec/fixtures/ingestion/simple-markdown.md
@@ -1,0 +1,79 @@
+# Getting Started
+
+Welcome to the project documentation. This guide covers installation,
+configuration, and basic usage patterns for new developers.
+
+## Installation
+
+Install the package using your preferred package manager:
+
+```bash
+npm install @jeffs-brain/memory
+```
+
+Verify the installation by running the version check:
+
+```bash
+npx memory --version
+```
+
+## Configuration
+
+The system requires a configuration file at the project root. Create a
+file named `memory.config.json` with the following structure:
+
+```json
+{
+  "brain": "default",
+  "store": "filesystem",
+  "index": "sqlite"
+}
+```
+
+Each field controls a different subsystem. The brain field selects which
+knowledge base to target. The store field picks the persistence backend.
+The index field determines the full-text search engine.
+
+## Basic Usage
+
+Once configured, ingest documents into the knowledge base:
+
+```typescript
+import { createBrain } from '@jeffs-brain/memory'
+
+const brain = await createBrain({ config: './memory.config.json' })
+await brain.ingest({ path: './docs/guide.md' })
+const results = await brain.search({ query: 'installation steps' })
+```
+
+The search function returns ranked results using hybrid retrieval. Each
+result includes a score, the matched chunk content, and metadata about
+the source document.
+
+## Advanced Topics
+
+### Custom Embeddings
+
+Override the default embedder by passing a provider configuration:
+
+```typescript
+const brain = await createBrain({
+  config: './memory.config.json',
+  embedder: { model: 'text-embedding-3-small', dimensions: 256 },
+})
+```
+
+### Batch Ingestion
+
+For large document sets, use the batch API to ingest multiple files in a
+single transaction:
+
+```typescript
+await brain.batch({ reason: 'initial-load' }, async (b) => {
+  for (const file of files) {
+    await b.ingest({ path: file })
+  }
+})
+```
+
+This ensures atomicity: either all documents are indexed or none are.


### PR DESCRIPTION
## Summary

- Creates `spec/INGESTION.md` — the canonical chunking specification that all SDKs must follow
- Defines `ChunkConfig` type in both Go and TS with matching fields (maxTokens: 512, overlapTokens: 64, minTokens: 30)
- Adds conformance fixtures (`spec/fixtures/ingestion/`) for cross-SDK validation
- Token estimation formula: `ceil(len/4)` — verified identical in both Go and TS
- Creates the `go/ingest/` package (new, for all future ingestion pipeline code)

## What this does NOT do

- Does NOT modify existing chunking in `go/knowledge/compile.go` — that is P1-4's responsibility
- Does NOT implement the chunker registry — just defines the config schema and spec
- Documents the migration path from Go's current 1800-char/120-char constants to token-based

## Test plan

- [ ] Go: 18 subtests pass (defaults, validation, token estimation, monotonicity)
- [ ] TS: 24 tests pass (defaults, validation, token estimation, Go/TS formula equivalence)
- [ ] Token estimates identical in Go and TS for all inputs
- [ ] spec/INGESTION.md reviewable as standalone document
- [ ] Conformance fixtures parseable and usable by future conformance runner

Closes LLE-9778