### PR TITLE
Add PipelineStateStore interface with dual-backend persistence

### DIFF
--- a/go/ingest/state_store.go
+++ b/go/ingest/state_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
@@ -63,27 +64,61 @@ type PipelineStateStore interface {
 	Delete(ctx context.Context, documentHash string) error
 }
 
-const statePrefix = "raw/.pipeline-state"
+const defaultStatePrefix = "raw/.pipeline-state"
 
-func statePath(documentHash string) brain.Path {
-	return brain.Path(fmt.Sprintf("%s/%s.json", statePrefix, documentHash))
+// documentHashPattern validates that a document hash is a 64-character
+// lowercase hex string (SHA-256). Rejects path traversal attempts.
+var documentHashPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+func validateDocumentHash(documentHash string) error {
+	if !documentHashPattern.MatchString(documentHash) {
+		return fmt.Errorf("ingest: invalid document hash %q", documentHash)
+	}
+	return nil
+}
+
+func statePath(prefix, documentHash string) brain.Path {
+	return brain.Path(fmt.Sprintf("%s/%s.json", prefix, documentHash))
+}
+
+// FilePipelineStateStoreConfig configures the file-based state store.
+type FilePipelineStateStoreConfig struct {
+	// Store is the brain Store backend used for persistence.
+	Store brain.Store
+	// Prefix is the path prefix inside the store where state files are written.
+	// Defaults to "raw/.pipeline-state" when empty.
+	Prefix string
 }
 
 // FilePipelineStateStore implements PipelineStateStore by persisting each
-// document's state as a JSON file at raw/.pipeline-state/{hash}.json using
-// the brain.Store interface.
+// document's state as a JSON file at {prefix}/{hash}.json using the
+// brain.Store interface. The default prefix is "raw/.pipeline-state".
 type FilePipelineStateStore struct {
-	store brain.Store
+	store  brain.Store
+	prefix string
 }
 
 // NewFilePipelineStateStore creates a file-based state store backed by the
-// given brain.Store.
+// given brain.Store using the default prefix.
 func NewFilePipelineStateStore(store brain.Store) *FilePipelineStateStore {
-	return &FilePipelineStateStore{store: store}
+	return &FilePipelineStateStore{store: store, prefix: defaultStatePrefix}
+}
+
+// NewFilePipelineStateStoreWithConfig creates a file-based state store with
+// explicit configuration, including a custom path prefix.
+func NewFilePipelineStateStoreWithConfig(cfg FilePipelineStateStoreConfig) *FilePipelineStateStore {
+	prefix := cfg.Prefix
+	if prefix == "" {
+		prefix = defaultStatePrefix
+	}
+	return &FilePipelineStateStore{store: cfg.Store, prefix: prefix}
 }
 
 func (s *FilePipelineStateStore) Get(ctx context.Context, documentHash string) (*PipelineStateEntry, error) {
-	data, err := s.store.Read(ctx, statePath(documentHash))
+	if err := validateDocumentHash(documentHash); err != nil {
+		return nil, err
+	}
+	data, err := s.store.Read(ctx, statePath(s.prefix, documentHash))
 	if err != nil {
 		if errors.Is(err, brain.ErrNotFound) {
 			return nil, nil
@@ -98,18 +133,21 @@ func (s *FilePipelineStateStore) Get(ctx context.Context, documentHash string) (
 }
 
 func (s *FilePipelineStateStore) Set(ctx context.Context, entry PipelineStateEntry) error {
+	if err := validateDocumentHash(entry.DocumentHash); err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {
 		return fmt.Errorf("ingest: state encode %s: %w", entry.DocumentHash, err)
 	}
-	if err := s.store.Write(ctx, statePath(entry.DocumentHash), data); err != nil {
+	if err := s.store.Write(ctx, statePath(s.prefix, entry.DocumentHash), data); err != nil {
 		return fmt.Errorf("ingest: state set %s: %w", entry.DocumentHash, err)
 	}
 	return nil
 }
 
 func (s *FilePipelineStateStore) ListIncomplete(ctx context.Context, brainID string) ([]PipelineStateEntry, error) {
-	dir := brain.Path(statePrefix)
+	dir := brain.Path(s.prefix)
 	exists, err := s.store.Exists(ctx, dir)
 	if err != nil {
 		return nil, fmt.Errorf("ingest: state list check dir: %w", err)
@@ -148,7 +186,10 @@ func (s *FilePipelineStateStore) ListIncomplete(ctx context.Context, brainID str
 }
 
 func (s *FilePipelineStateStore) Delete(ctx context.Context, documentHash string) error {
-	err := s.store.Delete(ctx, statePath(documentHash))
+	if err := validateDocumentHash(documentHash); err != nil {
+		return err
+	}
+	err := s.store.Delete(ctx, statePath(s.prefix, documentHash))
 	if err != nil {
 		if errors.Is(err, brain.ErrNotFound) {
 			return nil

--- a/go/ingest/state_store.go
+++ b/go/ingest/state_store.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+// PipelineStage represents the ordered stages a document passes through
+// during ingestion. Terminal stages are "completed" and "failed".
+type PipelineStage string
+
+const (
+	StageReceived  PipelineStage = "received"
+	StageStored    PipelineStage = "stored"
+	StageChunked   PipelineStage = "chunked"
+	StageEmbedded  PipelineStage = "embedded"
+	StageIndexed   PipelineStage = "indexed"
+	StageCompleted PipelineStage = "completed"
+	StageFailed    PipelineStage = "failed"
+)
+
+// IsTerminal reports whether the stage represents a final state that
+// should not appear in ListIncomplete results.
+func (s PipelineStage) IsTerminal() bool {
+	return s == StageCompleted || s == StageFailed
+}
+
+// PipelineStateEntry tracks a single document's progress through the
+// ingest pipeline.
+type PipelineStateEntry struct {
+	DocumentHash string        `json:"documentHash"`
+	BrainID      string        `json:"brainId"`
+	Stage        PipelineStage `json:"stage"`
+	RetryCount   int           `json:"retryCount"`
+	LastError    string        `json:"lastError,omitempty"`
+	CreatedAt    time.Time     `json:"createdAt"`
+	UpdatedAt    time.Time     `json:"updatedAt"`
+	CompletedAt  *time.Time    `json:"completedAt,omitempty"`
+}
+
+// PipelineStateStore persists pipeline state for crash recovery. Both
+// file-based and PostgreSQL implementations satisfy this interface.
+type PipelineStateStore interface {
+	// Get retrieves the state entry for the given document hash. Returns
+	// nil without error when no record exists.
+	Get(ctx context.Context, documentHash string) (*PipelineStateEntry, error)
+
+	// Set creates or overwrites the state entry for a document.
+	Set(ctx context.Context, entry PipelineStateEntry) error
+
+	// ListIncomplete returns all entries for the given brainID whose stage
+	// is not terminal (not "completed" or "failed").
+	ListIncomplete(ctx context.Context, brainID string) ([]PipelineStateEntry, error)
+
+	// Delete removes the state entry for the given document hash. Does not
+	// return an error if the entry does not exist.
+	Delete(ctx context.Context, documentHash string) error
+}
+
+const statePrefix = "raw/.pipeline-state"
+
+func statePath(documentHash string) brain.Path {
+	return brain.Path(fmt.Sprintf("%s/%s.json", statePrefix, documentHash))
+}
+
+// FilePipelineStateStore implements PipelineStateStore by persisting each
+// document's state as a JSON file at raw/.pipeline-state/{hash}.json using
+// the brain.Store interface.
+type FilePipelineStateStore struct {
+	store brain.Store
+}
+
+// NewFilePipelineStateStore creates a file-based state store backed by the
+// given brain.Store.
+func NewFilePipelineStateStore(store brain.Store) *FilePipelineStateStore {
+	return &FilePipelineStateStore{store: store}
+}
+
+func (s *FilePipelineStateStore) Get(ctx context.Context, documentHash string) (*PipelineStateEntry, error) {
+	data, err := s.store.Read(ctx, statePath(documentHash))
+	if err != nil {
+		if errors.Is(err, brain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ingest: state get %s: %w", documentHash, err)
+	}
+	var entry PipelineStateEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("ingest: state decode %s: %w", documentHash, err)
+	}
+	return &entry, nil
+}
+
+func (s *FilePipelineStateStore) Set(ctx context.Context, entry PipelineStateEntry) error {
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return fmt.Errorf("ingest: state encode %s: %w", entry.DocumentHash, err)
+	}
+	if err := s.store.Write(ctx, statePath(entry.DocumentHash), data); err != nil {
+		return fmt.Errorf("ingest: state set %s: %w", entry.DocumentHash, err)
+	}
+	return nil
+}
+
+func (s *FilePipelineStateStore) ListIncomplete(ctx context.Context, brainID string) ([]PipelineStateEntry, error) {
+	dir := brain.Path(statePrefix)
+	exists, err := s.store.Exists(ctx, dir)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: state list check dir: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	files, err := s.store.List(ctx, dir, brain.ListOpts{Recursive: false, Glob: "*.json"})
+	if err != nil {
+		return nil, fmt.Errorf("ingest: state list: %w", err)
+	}
+
+	entries := make([]PipelineStateEntry, 0, len(files))
+	for _, file := range files {
+		if file.IsDir {
+			continue
+		}
+		data, readErr := s.store.Read(ctx, file.Path)
+		if readErr != nil {
+			if errors.Is(readErr, brain.ErrNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("ingest: state list read %s: %w", file.Path, readErr)
+		}
+		var entry PipelineStateEntry
+		if decodeErr := json.Unmarshal(data, &entry); decodeErr != nil {
+			return nil, fmt.Errorf("ingest: state list decode %s: %w", file.Path, decodeErr)
+		}
+		if entry.BrainID == brainID && !entry.Stage.IsTerminal() {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}
+
+func (s *FilePipelineStateStore) Delete(ctx context.Context, documentHash string) error {
+	err := s.store.Delete(ctx, statePath(documentHash))
+	if err != nil {
+		if errors.Is(err, brain.ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("ingest: state delete %s: %w", documentHash, err)
+	}
+	return nil
+}
+
+var _ PipelineStateStore = (*FilePipelineStateStore)(nil)

--- a/go/ingest/state_store_pg.go
+++ b/go/ingest/state_store_pg.go
@@ -4,9 +4,19 @@ package ingest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"regexp"
 	"time"
 )
+
+// listIncompleteInitialCap is the initial capacity for the result slice in
+// ListIncomplete, chosen to avoid small re-allocations for typical workloads.
+const listIncompleteInitialCap = 16
+
+// schemaNamePattern validates PostgreSQL schema names: lowercase letters or
+// underscore start, followed by lowercase alphanumerics or underscores.
+var schemaNamePattern = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 
 // PostgresPipelineStateStore implements PipelineStateStore backed by a
 // PostgreSQL pipeline_state table. Uses prepared statements for safe
@@ -26,12 +36,16 @@ type PostgresStateStoreConfig struct {
 }
 
 // NewPostgresPipelineStateStore creates a PostgreSQL-backed state store.
-func NewPostgresPipelineStateStore(cfg PostgresStateStoreConfig) *PostgresPipelineStateStore {
+// Returns an error if the schema name is invalid.
+func NewPostgresPipelineStateStore(cfg PostgresStateStoreConfig) (*PostgresPipelineStateStore, error) {
 	schema := cfg.Schema
 	if schema == "" {
 		schema = "memory"
 	}
-	return &PostgresPipelineStateStore{db: cfg.DB, schema: schema}
+	if !schemaNamePattern.MatchString(schema) {
+		return nil, fmt.Errorf("ingest: invalid schema name %q: must match ^[a-z_][a-z0-9_]*$", schema)
+	}
+	return &PostgresPipelineStateStore{db: cfg.DB, schema: schema}, nil
 }
 
 func (s *PostgresPipelineStateStore) table() string {
@@ -49,7 +63,7 @@ func (s *PostgresPipelineStateStore) Get(ctx context.Context, documentHash strin
 	row := s.db.QueryRowContext(ctx, query, documentHash)
 	entry, err := scanEntry(row)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("ingest: pg state get %s: %w", documentHash, err)
@@ -111,7 +125,7 @@ func (s *PostgresPipelineStateStore) ListIncomplete(ctx context.Context, brainID
 	}
 	defer rows.Close()
 
-	entries := make([]PipelineStateEntry, 0, 16)
+	entries := make([]PipelineStateEntry, 0, listIncompleteInitialCap)
 	for rows.Next() {
 		entry, scanErr := scanRows(rows)
 		if scanErr != nil {
@@ -132,10 +146,6 @@ func (s *PostgresPipelineStateStore) Delete(ctx context.Context, documentHash st
 		return fmt.Errorf("ingest: pg state delete %s: %w", documentHash, err)
 	}
 	return nil
-}
-
-type scanner interface {
-	Scan(dest ...interface{}) error
 }
 
 func scanEntry(row *sql.Row) (*PipelineStateEntry, error) {

--- a/go/ingest/state_store_pg.go
+++ b/go/ingest/state_store_pg.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// PostgresPipelineStateStore implements PipelineStateStore backed by a
+// PostgreSQL pipeline_state table. Uses prepared statements for safe
+// parameterised queries.
+type PostgresPipelineStateStore struct {
+	db     *sql.DB
+	schema string
+}
+
+// PostgresStateStoreConfig configures the PostgreSQL state store.
+type PostgresStateStoreConfig struct {
+	// DB is the database connection pool.
+	DB *sql.DB
+	// Schema is the PostgreSQL schema containing the pipeline_state table.
+	// Defaults to "memory" when empty.
+	Schema string
+}
+
+// NewPostgresPipelineStateStore creates a PostgreSQL-backed state store.
+func NewPostgresPipelineStateStore(cfg PostgresStateStoreConfig) *PostgresPipelineStateStore {
+	schema := cfg.Schema
+	if schema == "" {
+		schema = "memory"
+	}
+	return &PostgresPipelineStateStore{db: cfg.DB, schema: schema}
+}
+
+func (s *PostgresPipelineStateStore) table() string {
+	return fmt.Sprintf("%s.pipeline_state", s.schema)
+}
+
+func (s *PostgresPipelineStateStore) Get(ctx context.Context, documentHash string) (*PipelineStateEntry, error) {
+	query := fmt.Sprintf(`
+		SELECT document_hash, brain_id, stage, retry_count, last_error,
+		       created_at, updated_at, completed_at
+		  FROM %s
+		 WHERE document_hash = $1
+		 LIMIT 1`, s.table())
+
+	row := s.db.QueryRowContext(ctx, query, documentHash)
+	entry, err := scanEntry(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ingest: pg state get %s: %w", documentHash, err)
+	}
+	return entry, nil
+}
+
+func (s *PostgresPipelineStateStore) Set(ctx context.Context, entry PipelineStateEntry) error {
+	query := fmt.Sprintf(`
+		INSERT INTO %s
+		  (document_hash, brain_id, stage, retry_count, last_error, created_at, updated_at, completed_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (document_hash) DO UPDATE SET
+		  brain_id = EXCLUDED.brain_id,
+		  stage = EXCLUDED.stage,
+		  retry_count = EXCLUDED.retry_count,
+		  last_error = EXCLUDED.last_error,
+		  updated_at = EXCLUDED.updated_at,
+		  completed_at = EXCLUDED.completed_at`, s.table())
+
+	var lastError *string
+	if entry.LastError != "" {
+		lastError = &entry.LastError
+	}
+
+	var completedAt *time.Time
+	if entry.CompletedAt != nil {
+		completedAt = entry.CompletedAt
+	}
+
+	_, err := s.db.ExecContext(ctx, query,
+		entry.DocumentHash,
+		entry.BrainID,
+		string(entry.Stage),
+		entry.RetryCount,
+		lastError,
+		entry.CreatedAt,
+		entry.UpdatedAt,
+		completedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("ingest: pg state set %s: %w", entry.DocumentHash, err)
+	}
+	return nil
+}
+
+func (s *PostgresPipelineStateStore) ListIncomplete(ctx context.Context, brainID string) ([]PipelineStateEntry, error) {
+	query := fmt.Sprintf(`
+		SELECT document_hash, brain_id, stage, retry_count, last_error,
+		       created_at, updated_at, completed_at
+		  FROM %s
+		 WHERE brain_id = $1
+		   AND stage NOT IN ('completed', 'failed')
+		 ORDER BY created_at ASC`, s.table())
+
+	rows, err := s.db.QueryContext(ctx, query, brainID)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: pg state list incomplete: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]PipelineStateEntry, 0, 16)
+	for rows.Next() {
+		entry, scanErr := scanRows(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("ingest: pg state list scan: %w", scanErr)
+		}
+		entries = append(entries, *entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ingest: pg state list iterate: %w", err)
+	}
+	return entries, nil
+}
+
+func (s *PostgresPipelineStateStore) Delete(ctx context.Context, documentHash string) error {
+	query := fmt.Sprintf(`DELETE FROM %s WHERE document_hash = $1`, s.table())
+	_, err := s.db.ExecContext(ctx, query, documentHash)
+	if err != nil {
+		return fmt.Errorf("ingest: pg state delete %s: %w", documentHash, err)
+	}
+	return nil
+}
+
+type scanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func scanEntry(row *sql.Row) (*PipelineStateEntry, error) {
+	var entry PipelineStateEntry
+	var lastError sql.NullString
+	var completedAt sql.NullTime
+	var stage string
+
+	err := row.Scan(
+		&entry.DocumentHash,
+		&entry.BrainID,
+		&stage,
+		&entry.RetryCount,
+		&lastError,
+		&entry.CreatedAt,
+		&entry.UpdatedAt,
+		&completedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	entry.Stage = PipelineStage(stage)
+	if lastError.Valid {
+		entry.LastError = lastError.String
+	}
+	if completedAt.Valid {
+		entry.CompletedAt = &completedAt.Time
+	}
+	return &entry, nil
+}
+
+func scanRows(rows *sql.Rows) (*PipelineStateEntry, error) {
+	var entry PipelineStateEntry
+	var lastError sql.NullString
+	var completedAt sql.NullTime
+	var stage string
+
+	err := rows.Scan(
+		&entry.DocumentHash,
+		&entry.BrainID,
+		&stage,
+		&entry.RetryCount,
+		&lastError,
+		&entry.CreatedAt,
+		&entry.UpdatedAt,
+		&completedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	entry.Stage = PipelineStage(stage)
+	if lastError.Valid {
+		entry.LastError = lastError.String
+	}
+	if completedAt.Valid {
+		entry.CompletedAt = &completedAt.Time
+	}
+	return &entry, nil
+}
+
+var _ PipelineStateStore = (*PostgresPipelineStateStore)(nil)

--- a/go/ingest/state_store_pg.go
+++ b/go/ingest/state_store_pg.go
@@ -38,6 +38,9 @@ type PostgresStateStoreConfig struct {
 // NewPostgresPipelineStateStore creates a PostgreSQL-backed state store.
 // Returns an error if the schema name is invalid.
 func NewPostgresPipelineStateStore(cfg PostgresStateStoreConfig) (*PostgresPipelineStateStore, error) {
+	if cfg.DB == nil {
+		return nil, fmt.Errorf("ingest: postgres DB is required")
+	}
 	schema := cfg.Schema
 	if schema == "" {
 		schema = "memory"

--- a/go/ingest/state_store_test.go
+++ b/go/ingest/state_store_test.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/ingest"
+	"github.com/jeffs-brain/memory/go/store/fs"
+)
+
+const testBrainID = "test-brain"
+
+func makeEntry(overrides ...func(*ingest.PipelineStateEntry)) ingest.PipelineStateEntry {
+	entry := ingest.PipelineStateEntry{
+		DocumentHash: "abc123def456",
+		BrainID:      testBrainID,
+		Stage:        ingest.StageStored,
+		RetryCount:   0,
+		CreatedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	for _, fn := range overrides {
+		fn(&entry)
+	}
+	return entry
+}
+
+// Factory creates a fresh PipelineStateStore for each subtest.
+type Factory func(t *testing.T) ingest.PipelineStateStore
+
+// runContractSuite executes the full contract test suite against any
+// PipelineStateStore implementation.
+func runContractSuite(t *testing.T, factory Factory) {
+	t.Helper()
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, store ingest.PipelineStateStore)
+	}{
+		{"Get returns nil when no state exists", testGetNonExistent},
+		{"Set then Get round-trips", testSetGetRoundTrip},
+		{"Set overwrites existing entry", testSetOverwrite},
+		{"ListIncomplete excludes completed and failed", testListIncompleteExcludes},
+		{"ListIncomplete filters by brainID", testListIncompleteFiltersBrain},
+		{"Delete removes entry", testDelete},
+		{"Delete non-existent does not error", testDeleteNonExistent},
+		{"Preserves lastError field", testPreservesLastError},
+		{"Preserves completedAt field", testPreservesCompletedAt},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := factory(t)
+			tc.fn(t, store)
+		})
+	}
+}
+
+func testGetNonExistent(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	entry, err := store.Get(ctx, "nonexistent-hash")
+	if err != nil {
+		t.Fatalf("Get returned unexpected error: %v", err)
+	}
+	if entry != nil {
+		t.Fatalf("expected nil entry, got %+v", entry)
+	}
+}
+
+func testSetGetRoundTrip(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	entry := makeEntry()
+
+	if err := store.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := store.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil after Set")
+	}
+	if got.DocumentHash != entry.DocumentHash {
+		t.Errorf("DocumentHash = %q, want %q", got.DocumentHash, entry.DocumentHash)
+	}
+	if got.BrainID != entry.BrainID {
+		t.Errorf("BrainID = %q, want %q", got.BrainID, entry.BrainID)
+	}
+	if got.Stage != entry.Stage {
+		t.Errorf("Stage = %q, want %q", got.Stage, entry.Stage)
+	}
+	if got.RetryCount != entry.RetryCount {
+		t.Errorf("RetryCount = %d, want %d", got.RetryCount, entry.RetryCount)
+	}
+	if !got.CreatedAt.Equal(entry.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, entry.CreatedAt)
+	}
+	if !got.UpdatedAt.Equal(entry.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", got.UpdatedAt, entry.UpdatedAt)
+	}
+}
+
+func testSetOverwrite(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	entry := makeEntry()
+
+	if err := store.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	updated := makeEntry(func(e *ingest.PipelineStateEntry) {
+		e.Stage = ingest.StageChunked
+		e.UpdatedAt = time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	})
+	if err := store.Set(ctx, updated); err != nil {
+		t.Fatalf("Set overwrite: %v", err)
+	}
+
+	got, err := store.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil after overwrite")
+	}
+	if got.Stage != ingest.StageChunked {
+		t.Errorf("Stage = %q, want %q", got.Stage, ingest.StageChunked)
+	}
+	if !got.UpdatedAt.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("UpdatedAt not updated: %v", got.UpdatedAt)
+	}
+}
+
+func testListIncompleteExcludes(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	entries := []ingest.PipelineStateEntry{
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-received"; e.Stage = ingest.StageReceived }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-stored"; e.Stage = ingest.StageStored }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-completed"; e.Stage = ingest.StageCompleted }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-failed"; e.Stage = ingest.StageFailed }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-embedded"; e.Stage = ingest.StageEmbedded }),
+	}
+	for _, entry := range entries {
+		if err := store.Set(ctx, entry); err != nil {
+			t.Fatalf("Set %s: %v", entry.DocumentHash, err)
+		}
+	}
+
+	incomplete, err := store.ListIncomplete(ctx, testBrainID)
+	if err != nil {
+		t.Fatalf("ListIncomplete: %v", err)
+	}
+
+	hashes := make(map[string]bool, len(incomplete))
+	for _, e := range incomplete {
+		hashes[e.DocumentHash] = true
+	}
+
+	if !hashes["hash-received"] {
+		t.Error("expected hash-received in incomplete list")
+	}
+	if !hashes["hash-stored"] {
+		t.Error("expected hash-stored in incomplete list")
+	}
+	if !hashes["hash-embedded"] {
+		t.Error("expected hash-embedded in incomplete list")
+	}
+	if hashes["hash-completed"] {
+		t.Error("hash-completed should not be in incomplete list")
+	}
+	if hashes["hash-failed"] {
+		t.Error("hash-failed should not be in incomplete list")
+	}
+	if len(incomplete) != 3 {
+		t.Errorf("expected 3 incomplete entries, got %d", len(incomplete))
+	}
+}
+
+func testListIncompleteFiltersBrain(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+
+	ours := makeEntry(func(e *ingest.PipelineStateEntry) {
+		e.DocumentHash = "hash-ours"
+		e.BrainID = testBrainID
+		e.Stage = ingest.StageStored
+	})
+	theirs := makeEntry(func(e *ingest.PipelineStateEntry) {
+		e.DocumentHash = "hash-theirs"
+		e.BrainID = "other-brain"
+		e.Stage = ingest.StageStored
+	})
+
+	if err := store.Set(ctx, ours); err != nil {
+		t.Fatalf("Set ours: %v", err)
+	}
+	if err := store.Set(ctx, theirs); err != nil {
+		t.Fatalf("Set theirs: %v", err)
+	}
+
+	incomplete, err := store.ListIncomplete(ctx, testBrainID)
+	if err != nil {
+		t.Fatalf("ListIncomplete: %v", err)
+	}
+	if len(incomplete) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(incomplete))
+	}
+	if incomplete[0].DocumentHash != "hash-ours" {
+		t.Errorf("expected hash-ours, got %s", incomplete[0].DocumentHash)
+	}
+}
+
+func testDelete(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	entry := makeEntry()
+
+	if err := store.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := store.Delete(ctx, entry.DocumentHash); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	got, err := store.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get after Delete: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil after Delete, got %+v", got)
+	}
+}
+
+func testDeleteNonExistent(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.Delete(ctx, "nonexistent-hash"); err != nil {
+		t.Fatalf("Delete non-existent returned error: %v", err)
+	}
+}
+
+func testPreservesLastError(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	entry := makeEntry(func(e *ingest.PipelineStateEntry) {
+		e.Stage = ingest.StageFailed
+		e.LastError = "embedder timeout after 30s"
+		e.RetryCount = 3
+	})
+
+	if err := store.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := store.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.LastError != "embedder timeout after 30s" {
+		t.Errorf("LastError = %q, want %q", got.LastError, "embedder timeout after 30s")
+	}
+	if got.RetryCount != 3 {
+		t.Errorf("RetryCount = %d, want 3", got.RetryCount)
+	}
+}
+
+func testPreservesCompletedAt(t *testing.T, store ingest.PipelineStateStore) {
+	t.Helper()
+	ctx := context.Background()
+	completedAt := time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC)
+	entry := makeEntry(func(e *ingest.PipelineStateEntry) {
+		e.Stage = ingest.StageCompleted
+		e.CompletedAt = &completedAt
+	})
+
+	if err := store.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := store.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.CompletedAt == nil {
+		t.Fatal("CompletedAt is nil after round-trip")
+	}
+	if !got.CompletedAt.Equal(completedAt) {
+		t.Errorf("CompletedAt = %v, want %v", got.CompletedAt, completedAt)
+	}
+}
+
+// TestFilePipelineStateStore runs the full contract suite against the
+// file-based implementation using a real filesystem-backed brain.Store.
+func TestFilePipelineStateStore(t *testing.T) {
+	runContractSuite(t, func(t *testing.T) ingest.PipelineStateStore {
+		t.Helper()
+		store, err := fs.New(t.TempDir())
+		if err != nil {
+			t.Fatalf("fs.New: %v", err)
+		}
+		t.Cleanup(func() { _ = store.Close() })
+		return ingest.NewFilePipelineStateStore(store)
+	})
+}

--- a/go/ingest/state_store_test.go
+++ b/go/ingest/state_store_test.go
@@ -12,9 +12,12 @@ import (
 
 const testBrainID = "test-brain"
 
+// defaultHash is a valid 64-character lowercase hex string (SHA-256).
+const defaultHash = "abc123def4560000000000000000000000000000000000000000000000000000"
+
 func makeEntry(overrides ...func(*ingest.PipelineStateEntry)) ingest.PipelineStateEntry {
 	entry := ingest.PipelineStateEntry{
-		DocumentHash: "abc123def456",
+		DocumentHash: defaultHash,
 		BrainID:      testBrainID,
 		Stage:        ingest.StageStored,
 		RetryCount:   0,
@@ -61,7 +64,7 @@ func runContractSuite(t *testing.T, factory Factory) {
 func testGetNonExistent(t *testing.T, store ingest.PipelineStateStore) {
 	t.Helper()
 	ctx := context.Background()
-	entry, err := store.Get(ctx, "nonexistent-hash")
+	entry, err := store.Get(ctx, "0000000000000000000000000000000000000000000000000000000000000000")
 	if err != nil {
 		t.Fatalf("Get returned unexpected error: %v", err)
 	}
@@ -141,12 +144,18 @@ func testListIncompleteExcludes(t *testing.T, store ingest.PipelineStateStore) {
 	t.Helper()
 	ctx := context.Background()
 
+	hashReceived := "1111111111111111111111111111111111111111111111111111111111111111"
+	hashStored := "2222222222222222222222222222222222222222222222222222222222222222"
+	hashCompleted := "3333333333333333333333333333333333333333333333333333333333333333"
+	hashFailed := "4444444444444444444444444444444444444444444444444444444444444444"
+	hashEmbedded := "5555555555555555555555555555555555555555555555555555555555555555"
+
 	entries := []ingest.PipelineStateEntry{
-		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-received"; e.Stage = ingest.StageReceived }),
-		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-stored"; e.Stage = ingest.StageStored }),
-		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-completed"; e.Stage = ingest.StageCompleted }),
-		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-failed"; e.Stage = ingest.StageFailed }),
-		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = "hash-embedded"; e.Stage = ingest.StageEmbedded }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = hashReceived; e.Stage = ingest.StageReceived }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = hashStored; e.Stage = ingest.StageStored }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = hashCompleted; e.Stage = ingest.StageCompleted }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = hashFailed; e.Stage = ingest.StageFailed }),
+		makeEntry(func(e *ingest.PipelineStateEntry) { e.DocumentHash = hashEmbedded; e.Stage = ingest.StageEmbedded }),
 	}
 	for _, entry := range entries {
 		if err := store.Set(ctx, entry); err != nil {
@@ -164,20 +173,20 @@ func testListIncompleteExcludes(t *testing.T, store ingest.PipelineStateStore) {
 		hashes[e.DocumentHash] = true
 	}
 
-	if !hashes["hash-received"] {
-		t.Error("expected hash-received in incomplete list")
+	if !hashes[hashReceived] {
+		t.Error("expected hashReceived in incomplete list")
 	}
-	if !hashes["hash-stored"] {
-		t.Error("expected hash-stored in incomplete list")
+	if !hashes[hashStored] {
+		t.Error("expected hashStored in incomplete list")
 	}
-	if !hashes["hash-embedded"] {
-		t.Error("expected hash-embedded in incomplete list")
+	if !hashes[hashEmbedded] {
+		t.Error("expected hashEmbedded in incomplete list")
 	}
-	if hashes["hash-completed"] {
-		t.Error("hash-completed should not be in incomplete list")
+	if hashes[hashCompleted] {
+		t.Error("hashCompleted should not be in incomplete list")
 	}
-	if hashes["hash-failed"] {
-		t.Error("hash-failed should not be in incomplete list")
+	if hashes[hashFailed] {
+		t.Error("hashFailed should not be in incomplete list")
 	}
 	if len(incomplete) != 3 {
 		t.Errorf("expected 3 incomplete entries, got %d", len(incomplete))
@@ -188,13 +197,16 @@ func testListIncompleteFiltersBrain(t *testing.T, store ingest.PipelineStateStor
 	t.Helper()
 	ctx := context.Background()
 
+	hashOurs := "aaaa000000000000000000000000000000000000000000000000000000000000"
+	hashTheirs := "bbbb000000000000000000000000000000000000000000000000000000000000"
+
 	ours := makeEntry(func(e *ingest.PipelineStateEntry) {
-		e.DocumentHash = "hash-ours"
+		e.DocumentHash = hashOurs
 		e.BrainID = testBrainID
 		e.Stage = ingest.StageStored
 	})
 	theirs := makeEntry(func(e *ingest.PipelineStateEntry) {
-		e.DocumentHash = "hash-theirs"
+		e.DocumentHash = hashTheirs
 		e.BrainID = "other-brain"
 		e.Stage = ingest.StageStored
 	})
@@ -213,8 +225,8 @@ func testListIncompleteFiltersBrain(t *testing.T, store ingest.PipelineStateStor
 	if len(incomplete) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(incomplete))
 	}
-	if incomplete[0].DocumentHash != "hash-ours" {
-		t.Errorf("expected hash-ours, got %s", incomplete[0].DocumentHash)
+	if incomplete[0].DocumentHash != hashOurs {
+		t.Errorf("expected %s, got %s", hashOurs, incomplete[0].DocumentHash)
 	}
 }
 
@@ -242,7 +254,7 @@ func testDelete(t *testing.T, store ingest.PipelineStateStore) {
 func testDeleteNonExistent(t *testing.T, store ingest.PipelineStateStore) {
 	t.Helper()
 	ctx := context.Background()
-	if err := store.Delete(ctx, "nonexistent-hash"); err != nil {
+	if err := store.Delete(ctx, "0000000000000000000000000000000000000000000000000000000000000000"); err != nil {
 		t.Fatalf("Delete non-existent returned error: %v", err)
 	}
 }
@@ -313,4 +325,130 @@ func TestFilePipelineStateStore(t *testing.T) {
 		t.Cleanup(func() { _ = store.Close() })
 		return ingest.NewFilePipelineStateStore(store)
 	})
+}
+
+// TestFilePipelineStateStore_CustomPrefix verifies that a custom path prefix
+// is honoured by the state store.
+func TestFilePipelineStateStore_CustomPrefix(t *testing.T) {
+	store, err := fs.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("fs.New: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	customPrefix := "raw/.custom-state-dir"
+	ss := ingest.NewFilePipelineStateStoreWithConfig(ingest.FilePipelineStateStoreConfig{
+		Store:  store,
+		Prefix: customPrefix,
+	})
+
+	ctx := context.Background()
+	entry := makeEntry()
+
+	if err := ss.Set(ctx, entry); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := ss.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil after Set with custom prefix")
+	}
+	if got.DocumentHash != entry.DocumentHash {
+		t.Errorf("DocumentHash = %q, want %q", got.DocumentHash, entry.DocumentHash)
+	}
+
+	// Verify the file is stored under the custom prefix, not the default.
+	defaultStore := ingest.NewFilePipelineStateStore(store)
+	fromDefault, err := defaultStore.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get from default store: %v", err)
+	}
+	if fromDefault != nil {
+		t.Error("entry should not be found under the default prefix")
+	}
+}
+
+// TestFilePipelineStateStore_DefaultPrefix verifies that omitting the
+// prefix in config uses the default "raw/.pipeline-state".
+func TestFilePipelineStateStore_DefaultPrefix(t *testing.T) {
+	store, err := fs.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("fs.New: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ssConfig := ingest.NewFilePipelineStateStoreWithConfig(ingest.FilePipelineStateStoreConfig{
+		Store: store,
+	})
+	ssDefault := ingest.NewFilePipelineStateStore(store)
+
+	ctx := context.Background()
+	entry := makeEntry()
+
+	if err := ssConfig.Set(ctx, entry); err != nil {
+		t.Fatalf("Set via config: %v", err)
+	}
+
+	got, err := ssDefault.Get(ctx, entry.DocumentHash)
+	if err != nil {
+		t.Fatalf("Get via default: %v", err)
+	}
+	if got == nil {
+		t.Fatal("default prefix should find entry written with empty config prefix")
+	}
+}
+
+// TestFilePipelineStateStore_RejectsInvalidHash verifies that path-traversal
+// or otherwise invalid document hashes are rejected.
+func TestFilePipelineStateStore_RejectsInvalidHash(t *testing.T) {
+	store, err := fs.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("fs.New: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ss := ingest.NewFilePipelineStateStore(store)
+
+	ctx := context.Background()
+	invalidHashes := []string{
+		"../../../etc/passwd",
+		"short",
+		"ABCD000000000000000000000000000000000000000000000000000000000000", // uppercase
+		"abc123def456",    // too short
+		"abc/123/def/456", // path separators
+	}
+
+	for _, hash := range invalidHashes {
+		_, err := ss.Get(ctx, hash)
+		if err == nil {
+			t.Errorf("Get(%q) should have returned error for invalid hash", hash)
+		}
+
+		err = ss.Delete(ctx, hash)
+		if err == nil {
+			t.Errorf("Delete(%q) should have returned error for invalid hash", hash)
+		}
+
+		err = ss.Set(ctx, ingest.PipelineStateEntry{
+			DocumentHash: hash,
+			BrainID:      testBrainID,
+			Stage:        ingest.StageStored,
+		})
+		if err == nil {
+			t.Errorf("Set with hash %q should have returned error for invalid hash", hash)
+		}
+	}
+}
+
+// TestPostgresPipelineStateStore_RejectsNilDB verifies that the constructor
+// rejects a nil DB connection.
+func TestPostgresPipelineStateStore_RejectsNilDB(t *testing.T) {
+	_, err := ingest.NewPostgresPipelineStateStore(ingest.PostgresStateStoreConfig{
+		DB: nil,
+	})
+	if err == nil {
+		t.Fatal("expected error for nil DB, got nil")
+	}
 }

--- a/sdks/ts/memory-postgres/migrations/0005_pipeline_state.sql
+++ b/sdks/ts/memory-postgres/migrations/0005_pipeline_state.sql
@@ -1,0 +1,42 @@
+-- 0005_pipeline_state.sql
+-- Pipeline state tracking for crash recovery. Stores the progress of each
+-- document through the ingest pipeline so that incomplete documents can be
+-- resumed from their last completed stage on restart.
+--
+-- Owned by ticket P1-1 (LLE-9779).
+
+CREATE TABLE IF NOT EXISTS memory.pipeline_state (
+  document_hash  TEXT        PRIMARY KEY,
+  brain_id       TEXT        NOT NULL,
+  stage          TEXT        NOT NULL DEFAULT 'received',
+  retry_count    INTEGER     NOT NULL DEFAULT 0,
+  last_error     TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at   TIMESTAMPTZ
+);
+
+-- Index for ListIncomplete queries: find all in-flight documents for a brain.
+CREATE INDEX IF NOT EXISTS idx_pipeline_state_brain_incomplete
+  ON memory.pipeline_state (brain_id, stage)
+  WHERE stage NOT IN ('completed', 'failed');
+
+-- Index for cleanup queries: find completed documents older than a threshold.
+CREATE INDEX IF NOT EXISTS idx_pipeline_state_completed_at
+  ON memory.pipeline_state (completed_at)
+  WHERE completed_at IS NOT NULL;
+
+COMMENT ON TABLE memory.pipeline_state IS
+  'Tracks each document''s progress through the ingest pipeline for crash recovery.';
+COMMENT ON COLUMN memory.pipeline_state.document_hash IS
+  'Content-addressable hash of the raw document bytes (SHA-256 hex).';
+COMMENT ON COLUMN memory.pipeline_state.brain_id IS
+  'Identifies which brain the document belongs to.';
+COMMENT ON COLUMN memory.pipeline_state.stage IS
+  'Current pipeline stage: received, stored, chunked, embedded, indexed, completed, failed.';
+COMMENT ON COLUMN memory.pipeline_state.retry_count IS
+  'Number of times processing has been retried after failure.';
+COMMENT ON COLUMN memory.pipeline_state.last_error IS
+  'Human-readable description of the most recent failure, if any.';
+COMMENT ON COLUMN memory.pipeline_state.completed_at IS
+  'Timestamp when the document reached a terminal stage (completed or failed).';

--- a/sdks/ts/memory-postgres/migrations/0005_pipeline_state.sql
+++ b/sdks/ts/memory-postgres/migrations/0005_pipeline_state.sql
@@ -8,8 +8,10 @@
 CREATE TABLE IF NOT EXISTS memory.pipeline_state (
   document_hash  TEXT        PRIMARY KEY,
   brain_id       TEXT        NOT NULL,
-  stage          TEXT        NOT NULL DEFAULT 'received',
-  retry_count    INTEGER     NOT NULL DEFAULT 0,
+  stage          TEXT        NOT NULL DEFAULT 'received'
+                             CHECK (stage IN ('received','stored','chunked','embedded','indexed','completed','failed')),
+  retry_count    INTEGER     NOT NULL DEFAULT 0
+                             CHECK (retry_count >= 0),
   last_error     TEXT,
   created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -35,3 +35,16 @@ export {
   type SafetyMetadata,
   type IsolatedContent,
 } from './safety.js'
+
+export {
+  FilePipelineStateStore,
+  type PipelineStage,
+  type PipelineStateEntry,
+  type PipelineStateStore,
+} from './state-store.js'
+
+export {
+  PostgresPipelineStateStore,
+  type PostgresPipelineStateStoreOptions,
+  type PgSql as PipelineStatePgSql,
+} from './state-store-pg.js'

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -38,6 +38,7 @@ export {
 
 export {
   FilePipelineStateStore,
+  type FilePipelineStateStoreOptions,
   type PipelineStage,
   type PipelineStateEntry,
   type PipelineStateStore,

--- a/sdks/ts/memory/src/ingest/state-store-pg.ts
+++ b/sdks/ts/memory/src/ingest/state-store-pg.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * PostgreSQL-backed pipeline state store.
+ *
+ * Stores pipeline state in a `memory.pipeline_state` table. Designed for
+ * hosted deployments where multiple ingestion workers share state via a
+ * central database rather than the brain's file-based Store.
+ *
+ * Uses a structural `PgSql` interface to avoid a hard dependency on the
+ * `postgres` driver package.
+ */
+
+import type { PipelineStage, PipelineStateEntry, PipelineStateStore } from './state-store.js'
+
+/**
+ * Minimal SQL execution interface. Accepts a tagged template and returns
+ * an array of row objects. Structurally compatible with the `postgres`
+ * package's Sql type.
+ */
+export type PgSql = {
+  <T = unknown>(strings: TemplateStringsArray, ...values: unknown[]): Promise<ReadonlyArray<T>>
+  begin<T>(fn: (sql: PgSql) => Promise<T>): Promise<T>
+  unsafe<T = unknown>(query: string, params?: unknown[]): Promise<ReadonlyArray<T>>
+}
+
+export type PostgresPipelineStateStoreOptions = {
+  readonly sql: PgSql
+  readonly schema?: string
+}
+
+type StateRow = {
+  document_hash: string
+  brain_id: string
+  stage: string
+  retry_count: number
+  last_error: string | null
+  created_at: Date
+  updated_at: Date
+  completed_at: Date | null
+}
+
+const rowToEntry = (row: StateRow): PipelineStateEntry => ({
+  documentHash: row.document_hash,
+  brainId: row.brain_id,
+  stage: row.stage as PipelineStage,
+  retryCount: row.retry_count,
+  ...(row.last_error !== null ? { lastError: row.last_error } : {}),
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+  ...(row.completed_at !== null ? { completedAt: row.completed_at } : {}),
+})
+
+/**
+ * PostgreSQL implementation of PipelineStateStore.
+ *
+ * Expects the `memory.pipeline_state` table to exist (see migration
+ * `0005_pipeline_state.sql`). Uses upsert semantics for Set so that
+ * concurrent calls for the same document hash are safe.
+ */
+export class PostgresPipelineStateStore implements PipelineStateStore {
+  private readonly sql: PgSql
+  private readonly table: string
+
+  constructor(opts: PostgresPipelineStateStoreOptions) {
+    this.sql = opts.sql
+    const schema = opts.schema ?? 'memory'
+    this.table = `${schema}.pipeline_state`
+  }
+
+  async get(documentHash: string): Promise<PipelineStateEntry | undefined> {
+    const rows = await this.sql.unsafe<StateRow>(
+      `SELECT document_hash, brain_id, stage, retry_count, last_error,
+              created_at, updated_at, completed_at
+         FROM ${this.table}
+        WHERE document_hash = $1
+        LIMIT 1`,
+      [documentHash],
+    )
+    const row = rows[0]
+    if (row === undefined) return undefined
+    return rowToEntry(row)
+  }
+
+  async set(entry: PipelineStateEntry): Promise<void> {
+    await this.sql.unsafe(
+      `INSERT INTO ${this.table}
+         (document_hash, brain_id, stage, retry_count, last_error, created_at, updated_at, completed_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (document_hash) DO UPDATE SET
+         brain_id = EXCLUDED.brain_id,
+         stage = EXCLUDED.stage,
+         retry_count = EXCLUDED.retry_count,
+         last_error = EXCLUDED.last_error,
+         updated_at = EXCLUDED.updated_at,
+         completed_at = EXCLUDED.completed_at`,
+      [
+        entry.documentHash,
+        entry.brainId,
+        entry.stage,
+        entry.retryCount,
+        entry.lastError ?? null,
+        entry.createdAt,
+        entry.updatedAt,
+        entry.completedAt ?? null,
+      ],
+    )
+  }
+
+  async listIncomplete(brainId: string): Promise<readonly PipelineStateEntry[]> {
+    const rows = await this.sql.unsafe<StateRow>(
+      `SELECT document_hash, brain_id, stage, retry_count, last_error,
+              created_at, updated_at, completed_at
+         FROM ${this.table}
+        WHERE brain_id = $1
+          AND stage NOT IN ('completed', 'failed')
+        ORDER BY created_at ASC`,
+      [brainId],
+    )
+    return rows.map(rowToEntry)
+  }
+
+  async delete(documentHash: string): Promise<void> {
+    await this.sql.unsafe(
+      `DELETE FROM ${this.table} WHERE document_hash = $1`,
+      [documentHash],
+    )
+  }
+}

--- a/sdks/ts/memory/src/ingest/state-store-pg.ts
+++ b/sdks/ts/memory/src/ingest/state-store-pg.ts
@@ -40,6 +40,8 @@ type StateRow = {
   completed_at: Date | null
 }
 
+const SCHEMA_NAME_PATTERN = /^[a-z_][a-z0-9_]*$/
+
 const rowToEntry = (row: StateRow): PipelineStateEntry => ({
   documentHash: row.document_hash,
   brainId: row.brain_id,
@@ -65,6 +67,11 @@ export class PostgresPipelineStateStore implements PipelineStateStore {
   constructor(opts: PostgresPipelineStateStoreOptions) {
     this.sql = opts.sql
     const schema = opts.schema ?? 'memory'
+    if (!SCHEMA_NAME_PATTERN.test(schema)) {
+      throw new Error(
+        `Invalid schema name "${schema}": must match ^[a-z_][a-z0-9_]*$`,
+      )
+    }
     this.table = `${schema}.pipeline_state`
   }
 

--- a/sdks/ts/memory/src/ingest/state-store-pg.ts
+++ b/sdks/ts/memory/src/ingest/state-store-pg.ts
@@ -75,7 +75,7 @@ export class PostgresPipelineStateStore implements PipelineStateStore {
     this.table = `${schema}.pipeline_state`
   }
 
-  async get(documentHash: string): Promise<PipelineStateEntry | undefined> {
+  async get(documentHash: string, _signal?: AbortSignal): Promise<PipelineStateEntry | undefined> {
     const rows = await this.sql.unsafe<StateRow>(
       `SELECT document_hash, brain_id, stage, retry_count, last_error,
               created_at, updated_at, completed_at
@@ -89,7 +89,7 @@ export class PostgresPipelineStateStore implements PipelineStateStore {
     return rowToEntry(row)
   }
 
-  async set(entry: PipelineStateEntry): Promise<void> {
+  async set(entry: PipelineStateEntry, _signal?: AbortSignal): Promise<void> {
     await this.sql.unsafe(
       `INSERT INTO ${this.table}
          (document_hash, brain_id, stage, retry_count, last_error, created_at, updated_at, completed_at)
@@ -114,7 +114,7 @@ export class PostgresPipelineStateStore implements PipelineStateStore {
     )
   }
 
-  async listIncomplete(brainId: string): Promise<readonly PipelineStateEntry[]> {
+  async listIncomplete(brainId: string, _signal?: AbortSignal): Promise<readonly PipelineStateEntry[]> {
     const rows = await this.sql.unsafe<StateRow>(
       `SELECT document_hash, brain_id, stage, retry_count, last_error,
               created_at, updated_at, completed_at
@@ -127,7 +127,7 @@ export class PostgresPipelineStateStore implements PipelineStateStore {
     return rows.map(rowToEntry)
   }
 
-  async delete(documentHash: string): Promise<void> {
+  async delete(documentHash: string, _signal?: AbortSignal): Promise<void> {
     await this.sql.unsafe(
       `DELETE FROM ${this.table} WHERE document_hash = $1`,
       [documentHash],

--- a/sdks/ts/memory/src/ingest/state-store.test.ts
+++ b/sdks/ts/memory/src/ingest/state-store.test.ts
@@ -19,8 +19,11 @@ import type { PgSql } from './state-store-pg.js'
 
 const BRAIN_ID = 'test-brain'
 
+/** Valid 64-character lowercase hex hash for tests. */
+const DEFAULT_HASH = 'abc123def4560000000000000000000000000000000000000000000000000000'
+
 const makeEntry = (overrides: Partial<PipelineStateEntry> = {}): PipelineStateEntry => ({
-  documentHash: 'abc123def456',
+  documentHash: DEFAULT_HASH,
   brainId: BRAIN_ID,
   stage: 'stored',
   retryCount: 0,
@@ -144,7 +147,7 @@ for (const factory of factories) {
     })
 
     it('returns undefined when no state exists', async () => {
-      const entry = await stateStore.get('nonexistent-hash')
+      const entry = await stateStore.get('0000000000000000000000000000000000000000000000000000000000000000')
       expect(entry).toBeUndefined()
     })
 
@@ -178,11 +181,11 @@ for (const factory of factories) {
     })
 
     it('lists only incomplete entries', async () => {
-      const received = makeEntry({ documentHash: 'hash-received', stage: 'received' })
-      const stored = makeEntry({ documentHash: 'hash-stored', stage: 'stored' })
-      const completed = makeEntry({ documentHash: 'hash-completed', stage: 'completed' })
-      const failed = makeEntry({ documentHash: 'hash-failed', stage: 'failed' })
-      const embedded = makeEntry({ documentHash: 'hash-embedded', stage: 'embedded' })
+      const received = makeEntry({ documentHash: '1111111111111111111111111111111111111111111111111111111111111111', stage: 'received' })
+      const stored = makeEntry({ documentHash: '2222222222222222222222222222222222222222222222222222222222222222', stage: 'stored' })
+      const completed = makeEntry({ documentHash: '3333333333333333333333333333333333333333333333333333333333333333', stage: 'completed' })
+      const failed = makeEntry({ documentHash: '4444444444444444444444444444444444444444444444444444444444444444', stage: 'failed' })
+      const embedded = makeEntry({ documentHash: '5555555555555555555555555555555555555555555555555555555555555555', stage: 'embedded' })
 
       await stateStore.set(received)
       await stateStore.set(stored)
@@ -193,18 +196,18 @@ for (const factory of factories) {
       const incomplete = await stateStore.listIncomplete(BRAIN_ID)
       const hashes = incomplete.map((e) => e.documentHash)
 
-      expect(hashes).toContain('hash-received')
-      expect(hashes).toContain('hash-stored')
-      expect(hashes).toContain('hash-embedded')
-      expect(hashes).not.toContain('hash-completed')
-      expect(hashes).not.toContain('hash-failed')
+      expect(hashes).toContain('1111111111111111111111111111111111111111111111111111111111111111')
+      expect(hashes).toContain('2222222222222222222222222222222222222222222222222222222222222222')
+      expect(hashes).toContain('5555555555555555555555555555555555555555555555555555555555555555')
+      expect(hashes).not.toContain('3333333333333333333333333333333333333333333333333333333333333333')
+      expect(hashes).not.toContain('4444444444444444444444444444444444444444444444444444444444444444')
       expect(incomplete).toHaveLength(3)
     })
 
     it('listIncomplete filters by brainId', async () => {
-      const ours = makeEntry({ documentHash: 'hash-ours', brainId: BRAIN_ID, stage: 'stored' })
+      const ours = makeEntry({ documentHash: 'aaaa000000000000000000000000000000000000000000000000000000000000', brainId: BRAIN_ID, stage: 'stored' })
       const theirs = makeEntry({
-        documentHash: 'hash-theirs',
+        documentHash: 'bbbb000000000000000000000000000000000000000000000000000000000000',
         brainId: 'other-brain',
         stage: 'stored',
       })
@@ -214,7 +217,7 @@ for (const factory of factories) {
 
       const incomplete = await stateStore.listIncomplete(BRAIN_ID)
       expect(incomplete).toHaveLength(1)
-      expect(incomplete[0]!.documentHash).toBe('hash-ours')
+      expect(incomplete[0]!.documentHash).toBe('aaaa000000000000000000000000000000000000000000000000000000000000')
     })
 
     it('deletes state by document hash', async () => {
@@ -227,7 +230,7 @@ for (const factory of factories) {
     })
 
     it('delete on non-existent hash does not throw', async () => {
-      await expect(stateStore.delete('nonexistent')).resolves.toBeUndefined()
+      await expect(stateStore.delete('0000000000000000000000000000000000000000000000000000000000000001')).resolves.toBeUndefined()
     })
 
     it('preserves lastError field', async () => {
@@ -256,3 +259,74 @@ for (const factory of factories) {
     })
   })
 }
+
+describe('FilePipelineStateStore prefix configuration', () => {
+  it('uses a custom prefix when provided via options', async () => {
+    const store: Store = createMemStore()
+    const customStore = new FilePipelineStateStore({ store, prefix: 'raw/.custom-state-dir' })
+    const defaultStore = new FilePipelineStateStore(store)
+
+    const entry = makeEntry()
+    await customStore.set(entry)
+
+    const fromCustom = await customStore.get(entry.documentHash)
+    expect(fromCustom).toBeDefined()
+    expect(fromCustom!.documentHash).toBe(entry.documentHash)
+
+    const fromDefault = await defaultStore.get(entry.documentHash)
+    expect(fromDefault).toBeUndefined()
+
+    await store.close()
+  })
+
+  it('uses the default prefix when prefix is omitted in options', async () => {
+    const store: Store = createMemStore()
+    const configStore = new FilePipelineStateStore({ store })
+    const defaultStore = new FilePipelineStateStore(store)
+
+    const entry = makeEntry()
+    await configStore.set(entry)
+
+    const fromDefault = await defaultStore.get(entry.documentHash)
+    expect(fromDefault).toBeDefined()
+
+    await store.close()
+  })
+})
+
+describe('FilePipelineStateStore document hash validation', () => {
+  let store: Store
+  let stateStore: PipelineStateStore
+
+  beforeEach(() => {
+    store = createMemStore()
+    stateStore = new FilePipelineStateStore(store)
+  })
+
+  afterEach(async () => {
+    await store.close()
+  })
+
+  const invalidHashes = [
+    '../../../etc/passwd',
+    'short',
+    'ABCD000000000000000000000000000000000000000000000000000000000000',
+    'abc123def456',
+    'abc/123/def/456',
+  ]
+
+  for (const hash of invalidHashes) {
+    it(`rejects invalid hash "${hash}" on get`, async () => {
+      await expect(stateStore.get(hash)).rejects.toThrow('Invalid document hash')
+    })
+
+    it(`rejects invalid hash "${hash}" on delete`, async () => {
+      await expect(stateStore.delete(hash)).rejects.toThrow('Invalid document hash')
+    })
+
+    it(`rejects invalid hash "${hash}" on set`, async () => {
+      const entry = makeEntry({ documentHash: hash })
+      await expect(stateStore.set(entry)).rejects.toThrow('Invalid document hash')
+    })
+  }
+})

--- a/sdks/ts/memory/src/ingest/state-store.test.ts
+++ b/sdks/ts/memory/src/ingest/state-store.test.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Contract test suite for PipelineStateStore implementations.
+ *
+ * Both FilePipelineStateStore and PostgresPipelineStateStore must pass the
+ * same behavioural contract. The file-based implementation is tested here
+ * directly (no Docker). The Postgres implementation uses an in-memory fake
+ * that honours the same interface.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createMemStore } from '../store/memstore.js'
+import type { Store } from '../store/index.js'
+import type { PipelineStateEntry, PipelineStateStore } from './state-store.js'
+import { FilePipelineStateStore } from './state-store.js'
+import { PostgresPipelineStateStore } from './state-store-pg.js'
+import type { PgSql } from './state-store-pg.js'
+
+const BRAIN_ID = 'test-brain'
+
+const makeEntry = (overrides: Partial<PipelineStateEntry> = {}): PipelineStateEntry => ({
+  documentHash: 'abc123def456',
+  brainId: BRAIN_ID,
+  stage: 'stored',
+  retryCount: 0,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+})
+
+/**
+ * In-memory fake that mimics the PostgresPipelineStateStore's SQL behaviour
+ * without requiring a real database connection. Routes based on the query
+ * string passed to `unsafe()`.
+ */
+const createFakePgSql = (): PgSql => {
+  const rows = new Map<string, Record<string, unknown>>()
+
+  const taggedTemplate = (
+    _strings: TemplateStringsArray,
+    ..._values: unknown[]
+  ): Promise<ReadonlyArray<unknown>> => Promise.resolve([])
+
+  const unsafe = (query: string, params?: unknown[]): Promise<ReadonlyArray<unknown>> => {
+    const safeParams = params ?? []
+
+    if (query.includes('SELECT') && query.includes('LIMIT 1')) {
+      const documentHash = safeParams[0] as string
+      const row = rows.get(documentHash)
+      if (row === undefined) return Promise.resolve([])
+      return Promise.resolve([row])
+    }
+
+    if (query.includes('SELECT') && query.includes('NOT IN')) {
+      const brainId = safeParams[0] as string
+      const matching: Record<string, unknown>[] = []
+      for (const row of rows.values()) {
+        if (
+          row['brain_id'] === brainId &&
+          row['stage'] !== 'completed' &&
+          row['stage'] !== 'failed'
+        ) {
+          matching.push(row)
+        }
+      }
+      matching.sort((a, b) => {
+        const aTime = (a['created_at'] as Date).getTime()
+        const bTime = (b['created_at'] as Date).getTime()
+        return aTime - bTime
+      })
+      return Promise.resolve(matching)
+    }
+
+    if (query.includes('INSERT')) {
+      const documentHash = safeParams[0] as string
+      const row: Record<string, unknown> = {
+        document_hash: safeParams[0],
+        brain_id: safeParams[1],
+        stage: safeParams[2],
+        retry_count: safeParams[3],
+        last_error: safeParams[4],
+        created_at: safeParams[5],
+        updated_at: safeParams[6],
+        completed_at: safeParams[7],
+      }
+      rows.set(documentHash, row)
+      return Promise.resolve([])
+    }
+
+    if (query.includes('DELETE')) {
+      const documentHash = safeParams[0] as string
+      rows.delete(documentHash)
+      return Promise.resolve([])
+    }
+
+    return Promise.resolve([])
+  }
+
+  const begin = async <T>(fn: (s: PgSql) => Promise<T>): Promise<T> => fn(sql)
+
+  const sql = Object.assign(taggedTemplate, { begin, unsafe }) as unknown as PgSql
+
+  return sql
+}
+
+type StoreFactory = {
+  readonly name: string
+  readonly create: () => { stateStore: PipelineStateStore; cleanup: () => Promise<void> }
+}
+
+const factories: readonly StoreFactory[] = [
+  {
+    name: 'FilePipelineStateStore',
+    create: () => {
+      const store: Store = createMemStore()
+      const stateStore = new FilePipelineStateStore(store)
+      return { stateStore, cleanup: async () => store.close() }
+    },
+  },
+  {
+    name: 'PostgresPipelineStateStore',
+    create: () => {
+      const sql = createFakePgSql()
+      const stateStore = new PostgresPipelineStateStore({ sql })
+      return { stateStore, cleanup: async () => {} }
+    },
+  },
+]
+
+for (const factory of factories) {
+  describe(`PipelineStateStore contract: ${factory.name}`, () => {
+    let stateStore: PipelineStateStore
+    let cleanup: () => Promise<void>
+
+    beforeEach(() => {
+      const created = factory.create()
+      stateStore = created.stateStore
+      cleanup = created.cleanup
+    })
+
+    afterEach(async () => {
+      await cleanup()
+    })
+
+    it('returns undefined when no state exists', async () => {
+      const entry = await stateStore.get('nonexistent-hash')
+      expect(entry).toBeUndefined()
+    })
+
+    it('round-trips state through set and get', async () => {
+      const entry = makeEntry()
+      await stateStore.set(entry)
+      const retrieved = await stateStore.get(entry.documentHash)
+      expect(retrieved).toBeDefined()
+      expect(retrieved!.documentHash).toBe(entry.documentHash)
+      expect(retrieved!.brainId).toBe(entry.brainId)
+      expect(retrieved!.stage).toBe(entry.stage)
+      expect(retrieved!.retryCount).toBe(entry.retryCount)
+      expect(retrieved!.createdAt.toISOString()).toBe(entry.createdAt.toISOString())
+      expect(retrieved!.updatedAt.toISOString()).toBe(entry.updatedAt.toISOString())
+    })
+
+    it('overwrites existing entry on set', async () => {
+      const entry = makeEntry({ stage: 'stored' })
+      await stateStore.set(entry)
+
+      const updated = makeEntry({
+        stage: 'chunked',
+        updatedAt: new Date('2026-01-02T00:00:00Z'),
+      })
+      await stateStore.set(updated)
+
+      const retrieved = await stateStore.get(entry.documentHash)
+      expect(retrieved).toBeDefined()
+      expect(retrieved!.stage).toBe('chunked')
+      expect(retrieved!.updatedAt.toISOString()).toBe('2026-01-02T00:00:00.000Z')
+    })
+
+    it('lists only incomplete entries', async () => {
+      const received = makeEntry({ documentHash: 'hash-received', stage: 'received' })
+      const stored = makeEntry({ documentHash: 'hash-stored', stage: 'stored' })
+      const completed = makeEntry({ documentHash: 'hash-completed', stage: 'completed' })
+      const failed = makeEntry({ documentHash: 'hash-failed', stage: 'failed' })
+      const embedded = makeEntry({ documentHash: 'hash-embedded', stage: 'embedded' })
+
+      await stateStore.set(received)
+      await stateStore.set(stored)
+      await stateStore.set(completed)
+      await stateStore.set(failed)
+      await stateStore.set(embedded)
+
+      const incomplete = await stateStore.listIncomplete(BRAIN_ID)
+      const hashes = incomplete.map((e) => e.documentHash)
+
+      expect(hashes).toContain('hash-received')
+      expect(hashes).toContain('hash-stored')
+      expect(hashes).toContain('hash-embedded')
+      expect(hashes).not.toContain('hash-completed')
+      expect(hashes).not.toContain('hash-failed')
+      expect(incomplete).toHaveLength(3)
+    })
+
+    it('listIncomplete filters by brainId', async () => {
+      const ours = makeEntry({ documentHash: 'hash-ours', brainId: BRAIN_ID, stage: 'stored' })
+      const theirs = makeEntry({
+        documentHash: 'hash-theirs',
+        brainId: 'other-brain',
+        stage: 'stored',
+      })
+
+      await stateStore.set(ours)
+      await stateStore.set(theirs)
+
+      const incomplete = await stateStore.listIncomplete(BRAIN_ID)
+      expect(incomplete).toHaveLength(1)
+      expect(incomplete[0]!.documentHash).toBe('hash-ours')
+    })
+
+    it('deletes state by document hash', async () => {
+      const entry = makeEntry()
+      await stateStore.set(entry)
+
+      await stateStore.delete(entry.documentHash)
+      const retrieved = await stateStore.get(entry.documentHash)
+      expect(retrieved).toBeUndefined()
+    })
+
+    it('delete on non-existent hash does not throw', async () => {
+      await expect(stateStore.delete('nonexistent')).resolves.toBeUndefined()
+    })
+
+    it('preserves lastError field', async () => {
+      const entry = makeEntry({
+        stage: 'failed',
+        lastError: 'embedder timeout after 30s',
+        retryCount: 3,
+      })
+      await stateStore.set(entry)
+
+      const retrieved = await stateStore.get(entry.documentHash)
+      expect(retrieved).toBeDefined()
+      expect(retrieved!.lastError).toBe('embedder timeout after 30s')
+      expect(retrieved!.retryCount).toBe(3)
+    })
+
+    it('preserves completedAt field', async () => {
+      const completedAt = new Date('2026-01-05T12:00:00Z')
+      const entry = makeEntry({ stage: 'completed', completedAt })
+      await stateStore.set(entry)
+
+      const retrieved = await stateStore.get(entry.documentHash)
+      expect(retrieved).toBeDefined()
+      expect(retrieved!.completedAt).toBeDefined()
+      expect(retrieved!.completedAt!.toISOString()).toBe(completedAt.toISOString())
+    })
+  })
+}

--- a/sdks/ts/memory/src/ingest/state-store.ts
+++ b/sdks/ts/memory/src/ingest/state-store.ts
@@ -57,9 +57,21 @@ export type PipelineStateStore = {
   delete(documentHash: string, signal?: AbortSignal): Promise<void>
 }
 
-const STATE_PREFIX = 'raw/.pipeline-state'
+const DEFAULT_STATE_PREFIX = 'raw/.pipeline-state'
 
-const statePath = (documentHash: string) => toPath(`${STATE_PREFIX}/${documentHash}.json`)
+/**
+ * Validates that a document hash contains only lowercase hex characters and is
+ * exactly 64 characters long (SHA-256 hex). Rejects path traversal attempts.
+ */
+const DOCUMENT_HASH_PATTERN = /^[a-f0-9]{64}$/
+
+const assertDocumentHash = (documentHash: string): void => {
+  if (!DOCUMENT_HASH_PATTERN.test(documentHash)) {
+    throw new Error(`Invalid document hash: "${documentHash}"`)
+  }
+}
+
+const statePath = (prefix: string, documentHash: string) => toPath(`${prefix}/${documentHash}.json`)
 
 /** JSON wire format for serialisation. Dates are stored as ISO strings. */
 type SerializedEntry = {
@@ -102,21 +114,42 @@ const deserialize = (buf: Buffer): PipelineStateEntry => {
   }
 }
 
+/** Options for constructing a FilePipelineStateStore. */
+export type FilePipelineStateStoreOptions = {
+  /** Brain Store backend used for persistence. */
+  readonly store: Store
+  /**
+   * Path prefix inside the store where state files are written.
+   * Defaults to `raw/.pipeline-state`.
+   */
+  readonly prefix?: string
+}
+
 /**
  * File-based pipeline state store. Persists each document's state as a JSON
- * file at `raw/.pipeline-state/{documentHash}.json` using the brain Store
- * interface.
+ * file at `{prefix}/{documentHash}.json` using the brain Store interface.
+ * The default prefix is `raw/.pipeline-state`.
  */
 export class FilePipelineStateStore implements PipelineStateStore {
   private readonly store: Store
+  private readonly prefix: string
 
-  constructor(store: Store) {
-    this.store = store
+  constructor(store: Store)
+  constructor(opts: FilePipelineStateStoreOptions)
+  constructor(storeOrOpts: Store | FilePipelineStateStoreOptions) {
+    if ('read' in storeOrOpts) {
+      this.store = storeOrOpts
+      this.prefix = DEFAULT_STATE_PREFIX
+    } else {
+      this.store = storeOrOpts.store
+      this.prefix = storeOrOpts.prefix ?? DEFAULT_STATE_PREFIX
+    }
   }
 
-  async get(documentHash: string): Promise<PipelineStateEntry | undefined> {
+  async get(documentHash: string, _signal?: AbortSignal): Promise<PipelineStateEntry | undefined> {
+    assertDocumentHash(documentHash)
     try {
-      const buf = await this.store.read(statePath(documentHash))
+      const buf = await this.store.read(statePath(this.prefix, documentHash))
       return deserialize(buf)
     } catch (err: unknown) {
       if (isNotFound(err)) return undefined
@@ -124,12 +157,13 @@ export class FilePipelineStateStore implements PipelineStateStore {
     }
   }
 
-  async set(entry: PipelineStateEntry): Promise<void> {
-    await this.store.write(statePath(entry.documentHash), serialize(entry))
+  async set(entry: PipelineStateEntry, _signal?: AbortSignal): Promise<void> {
+    assertDocumentHash(entry.documentHash)
+    await this.store.write(statePath(this.prefix, entry.documentHash), serialize(entry))
   }
 
-  async listIncomplete(brainId: string): Promise<readonly PipelineStateEntry[]> {
-    const dir = toPath(STATE_PREFIX)
+  async listIncomplete(brainId: string, _signal?: AbortSignal): Promise<readonly PipelineStateEntry[]> {
+    const dir = toPath(this.prefix)
     const exists = await this.store.exists(dir)
     if (!exists) return []
 
@@ -148,9 +182,10 @@ export class FilePipelineStateStore implements PipelineStateStore {
     return entries
   }
 
-  async delete(documentHash: string): Promise<void> {
+  async delete(documentHash: string, _signal?: AbortSignal): Promise<void> {
+    assertDocumentHash(documentHash)
     try {
-      await this.store.delete(statePath(documentHash))
+      await this.store.delete(statePath(this.prefix, documentHash))
     } catch (err: unknown) {
       if (isNotFound(err)) return
       throw err

--- a/sdks/ts/memory/src/ingest/state-store.ts
+++ b/sdks/ts/memory/src/ingest/state-store.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pipeline state store interface and file-based implementation.
+ *
+ * Tracks the progress of each document through the ingest pipeline so that
+ * crash recovery can resume from the last completed stage rather than
+ * re-processing from scratch or (worse) permanently skipping the document.
+ *
+ * The FilePipelineStateStore persists state as JSON files inside the brain's
+ * Store at `raw/.pipeline-state/{hash}.json`.
+ */
+
+import type { Store } from '../store/index.js'
+import { isNotFound, toPath } from '../store/index.js'
+
+/** Ordered stages a document passes through during ingestion. */
+export type PipelineStage =
+  | 'received'
+  | 'stored'
+  | 'chunked'
+  | 'embedded'
+  | 'indexed'
+  | 'completed'
+  | 'failed'
+
+/** Terminal stages that indicate a document is no longer in-flight. */
+const TERMINAL_STAGES: ReadonlySet<PipelineStage> = new Set(['completed', 'failed'])
+
+/** A single document's pipeline state record. */
+export type PipelineStateEntry = {
+  readonly documentHash: string
+  readonly brainId: string
+  readonly stage: PipelineStage
+  readonly retryCount: number
+  readonly lastError?: string
+  readonly createdAt: Date
+  readonly updatedAt: Date
+  readonly completedAt?: Date
+}
+
+/**
+ * Persistence interface for pipeline state tracking. Implementations must
+ * be safe for sequential use within a single pipeline run.
+ */
+export type PipelineStateStore = {
+  /** Retrieve state for a document. Returns undefined when no record exists. */
+  get(documentHash: string, signal?: AbortSignal): Promise<PipelineStateEntry | undefined>
+
+  /** Create or overwrite state for a document. */
+  set(entry: PipelineStateEntry, signal?: AbortSignal): Promise<void>
+
+  /** Return all entries not in a terminal stage, optionally filtered by brainId. */
+  listIncomplete(brainId: string, signal?: AbortSignal): Promise<readonly PipelineStateEntry[]>
+
+  /** Remove the state record for a document. No-op if the record does not exist. */
+  delete(documentHash: string, signal?: AbortSignal): Promise<void>
+}
+
+const STATE_PREFIX = 'raw/.pipeline-state'
+
+const statePath = (documentHash: string) => toPath(`${STATE_PREFIX}/${documentHash}.json`)
+
+/** JSON wire format for serialisation. Dates are stored as ISO strings. */
+type SerializedEntry = {
+  readonly documentHash: string
+  readonly brainId: string
+  readonly stage: PipelineStage
+  readonly retryCount: number
+  readonly lastError?: string
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly completedAt?: string
+}
+
+const serialize = (entry: PipelineStateEntry): Buffer => {
+  const wire: SerializedEntry = {
+    documentHash: entry.documentHash,
+    brainId: entry.brainId,
+    stage: entry.stage,
+    retryCount: entry.retryCount,
+    ...(entry.lastError !== undefined ? { lastError: entry.lastError } : {}),
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+    ...(entry.completedAt !== undefined ? { completedAt: entry.completedAt.toISOString() } : {}),
+  }
+  return Buffer.from(JSON.stringify(wire, null, 2), 'utf8')
+}
+
+const deserialize = (buf: Buffer): PipelineStateEntry => {
+  const raw: unknown = JSON.parse(buf.toString('utf8'))
+  const wire = raw as SerializedEntry
+  return {
+    documentHash: wire.documentHash,
+    brainId: wire.brainId,
+    stage: wire.stage,
+    retryCount: wire.retryCount,
+    ...(wire.lastError !== undefined ? { lastError: wire.lastError } : {}),
+    createdAt: new Date(wire.createdAt),
+    updatedAt: new Date(wire.updatedAt),
+    ...(wire.completedAt !== undefined ? { completedAt: new Date(wire.completedAt) } : {}),
+  }
+}
+
+/**
+ * File-based pipeline state store. Persists each document's state as a JSON
+ * file at `raw/.pipeline-state/{documentHash}.json` using the brain Store
+ * interface.
+ */
+export class FilePipelineStateStore implements PipelineStateStore {
+  private readonly store: Store
+
+  constructor(store: Store) {
+    this.store = store
+  }
+
+  async get(documentHash: string): Promise<PipelineStateEntry | undefined> {
+    try {
+      const buf = await this.store.read(statePath(documentHash))
+      return deserialize(buf)
+    } catch (err: unknown) {
+      if (isNotFound(err)) return undefined
+      throw err
+    }
+  }
+
+  async set(entry: PipelineStateEntry): Promise<void> {
+    await this.store.write(statePath(entry.documentHash), serialize(entry))
+  }
+
+  async listIncomplete(brainId: string): Promise<readonly PipelineStateEntry[]> {
+    const dir = toPath(STATE_PREFIX)
+    const exists = await this.store.exists(dir)
+    if (!exists) return []
+
+    const files = await this.store.list(dir, { recursive: false, glob: '*.json' })
+    const entries: PipelineStateEntry[] = []
+
+    for (const file of files) {
+      if (file.isDir) continue
+      const buf = await this.store.read(file.path)
+      const entry = deserialize(buf)
+      if (entry.brainId === brainId && !TERMINAL_STAGES.has(entry.stage)) {
+        entries.push(entry)
+      }
+    }
+
+    return entries
+  }
+
+  async delete(documentHash: string): Promise<void> {
+    try {
+      await this.store.delete(statePath(documentHash))
+    } catch (err: unknown) {
+      if (isNotFound(err)) return
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Defines `PipelineStateStore` interface (Get/Set/ListIncomplete/Delete) in both Go and TS
- Implements `FilePipelineStateStore` (JSON files at `raw/.pipeline-state/{hash}.json` via Store interface)
- Implements `PostgresPipelineStateStore` (parameterised queries, upsert semantics, proper NULL handling)
- Contract test suite runs identically against both backends
- Migration SQL: `0005_pipeline_state.sql` with partial index for ListIncomplete

## Test plan

- [ ] 18 TS contract tests pass (File + Postgres implementations)
- [ ] 9 Go contract tests pass (race detector enabled)
- [ ] Schema validation rejects invalid Postgres schema names
- [ ] ListIncomplete excludes completed/failed entries
- [ ] No `interface{}` or `any` types

Closes LLE-9779