### PR TITLE
Add Extractor interface and registry with streaming support

### DIFF
--- a/go/ingest/extractor.go
+++ b/go/ingest/extractor.go
@@ -13,6 +13,14 @@ import (
 	"strings"
 	"sync"
 	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+	"golang.org/x/text/encoding/unicode"
 )
 
 // Security constants for downstream extractors (Phase 4) that decompress
@@ -60,20 +68,42 @@ func SanitizeArgs(args []string) ([]string, error) {
 	return sanitized, nil
 }
 
+// MagicSignature identifies a file format by magic bytes at a given offset.
+type MagicSignature struct {
+	Offset int
+	Bytes  []byte
+}
+
+// ExtractorCapability describes what content types an extractor handles.
+// Used by the registry for routing and by callers to inspect extractor
+// capabilities without instantiating extraction.
+type ExtractorCapability struct {
+	Extensions     []string
+	MIMETypes      []string
+	MagicBytes     []MagicSignature
+	RequiresBinary bool
+}
+
 // ExtractOptions provides hints to the extractor about the content being
 // processed.
 type ExtractOptions struct {
 	ContentType string
 	FileName    string
+	Encoding    string
 	MaxBytes    int64 // 0 = no limit
 }
 
 // ExtractResult holds the output of an extraction operation.
 type ExtractResult struct {
-	Text     string
-	Metadata map[string]string
-	Skipped  bool
-	Reason   string
+	Text        string
+	ContentType string
+	Encoding    string
+	Metadata    map[string]string
+	Pages       int
+	Language    string
+	Confidence  float64
+	Skipped     bool
+	Reason      string
 }
 
 // Extractor defines the contract for content extraction. Implementations
@@ -89,6 +119,14 @@ type Extractor interface {
 	ContentTypes() []string
 	// Name returns a human-readable identifier for this extractor.
 	Name() string
+	// Available reports whether this extractor's external dependencies
+	// are present (e.g. PaddleOCR, FFmpeg). Extractors with no external
+	// dependencies always return (true, nil).
+	Available(ctx context.Context) (bool, error)
+	// Capability describes what content types, file extensions, and
+	// magic byte signatures this extractor handles. Used by the registry
+	// for routing and by callers for introspection.
+	Capability() ExtractorCapability
 }
 
 // BaseExtractor provides a default ExtractStream implementation that
@@ -98,6 +136,8 @@ type BaseExtractor struct {
 	ExtractFn      func(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error)
 	ContentTypesFn func() []string
 	NameFn         func() string
+	AvailableFn    func(ctx context.Context) (bool, error)
+	CapabilityFn   func() ExtractorCapability
 }
 
 // Extract delegates to the embedded ExtractFn.
@@ -126,6 +166,24 @@ func (b *BaseExtractor) ContentTypes() []string {
 // Name delegates to the embedded NameFn.
 func (b *BaseExtractor) Name() string {
 	return b.NameFn()
+}
+
+// Available delegates to the embedded AvailableFn. Returns (true, nil)
+// if no AvailableFn is configured.
+func (b *BaseExtractor) Available(ctx context.Context) (bool, error) {
+	if b.AvailableFn != nil {
+		return b.AvailableFn(ctx)
+	}
+	return true, nil
+}
+
+// Capability delegates to the embedded CapabilityFn. Returns an empty
+// capability if no CapabilityFn is configured.
+func (b *BaseExtractor) Capability() ExtractorCapability {
+	if b.CapabilityFn != nil {
+		return b.CapabilityFn()
+	}
+	return ExtractorCapability{}
 }
 
 // PlainTextExtractor handles text/* content types by returning the raw
@@ -174,6 +232,20 @@ func (p *PlainTextExtractor) ContentTypes() []string {
 // Name returns the extractor identifier.
 func (p *PlainTextExtractor) Name() string {
 	return "plain-text"
+}
+
+// Available always returns true since the plain text extractor has no
+// external dependencies.
+func (p *PlainTextExtractor) Available(_ context.Context) (bool, error) {
+	return true, nil
+}
+
+// Capability returns the capability descriptor for the plain text extractor.
+func (p *PlainTextExtractor) Capability() ExtractorCapability {
+	return ExtractorCapability{
+		Extensions: []string{".txt", ".text", ".log", ".md", ".markdown", ".csv", ".yaml", ".yml", ".json"},
+		MIMETypes:  p.ContentTypes(),
+	}
 }
 
 // ExtractorRegistry maps content types to extractors and routes incoming
@@ -267,4 +339,160 @@ func normaliseContentType(ct string) string {
 		base = ct[:idx]
 	}
 	return strings.TrimSpace(strings.ToLower(base))
+}
+
+// encodingLookup maps canonical encoding names (lowercase) to their
+// golang.org/x/text/encoding implementations. Covers the most commonly
+// encountered encodings in real-world content.
+var encodingLookup = map[string]encoding.Encoding{
+	"utf-8":         unicode.UTF8,
+	"iso-8859-1":    charmap.ISO8859_1,
+	"iso-8859-2":    charmap.ISO8859_2,
+	"iso-8859-3":    charmap.ISO8859_3,
+	"iso-8859-4":    charmap.ISO8859_4,
+	"iso-8859-5":    charmap.ISO8859_5,
+	"iso-8859-6":    charmap.ISO8859_6,
+	"iso-8859-7":    charmap.ISO8859_7,
+	"iso-8859-8":    charmap.ISO8859_8,
+	"iso-8859-9":    charmap.ISO8859_9,
+	"iso-8859-10":   charmap.ISO8859_10,
+	"iso-8859-13":   charmap.ISO8859_13,
+	"iso-8859-14":   charmap.ISO8859_14,
+	"iso-8859-15":   charmap.ISO8859_15,
+	"iso-8859-16":   charmap.ISO8859_16,
+	"windows-1250":  charmap.Windows1250,
+	"windows-1251":  charmap.Windows1251,
+	"windows-1252":  charmap.Windows1252,
+	"windows-1253":  charmap.Windows1253,
+	"windows-1254":  charmap.Windows1254,
+	"windows-1255":  charmap.Windows1255,
+	"windows-1256":  charmap.Windows1256,
+	"koi8-r":        charmap.KOI8R,
+	"koi8-u":        charmap.KOI8U,
+	"shift_jis":     japanese.ShiftJIS,
+	"euc-jp":        japanese.EUCJP,
+	"iso-2022-jp":   japanese.ISO2022JP,
+	"euc-kr":        korean.EUCKR,
+	"gb2312":        simplifiedchinese.HZGB2312,
+	"gbk":           simplifiedchinese.GBK,
+	"gb18030":       simplifiedchinese.GB18030,
+	"big5":          traditionalchinese.Big5,
+	"utf-16be":      unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
+	"utf-16le":      unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
+}
+
+// DetectEncoding identifies the character encoding of raw bytes. Returns
+// the encoding name (e.g. "UTF-8", "ISO-8859-1", "Shift_JIS"). Uses a
+// heuristic approach: checks for BOM markers first, then validates UTF-8,
+// and falls back to statistical analysis of byte frequency patterns.
+func DetectEncoding(raw []byte) string {
+	if len(raw) == 0 {
+		return "UTF-8"
+	}
+
+	// Check for BOM markers.
+	if len(raw) >= 3 && raw[0] == 0xEF && raw[1] == 0xBB && raw[2] == 0xBF {
+		return "UTF-8"
+	}
+	if len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0xFF {
+		return "UTF-16BE"
+	}
+	if len(raw) >= 2 && raw[0] == 0xFF && raw[1] == 0xFE {
+		return "UTF-16LE"
+	}
+
+	// Valid UTF-8: the vast majority of modern content.
+	if utf8.Valid(raw) {
+		return "UTF-8"
+	}
+
+	// Statistical heuristics for common single-byte encodings.
+	return detectByByteFrequency(raw)
+}
+
+// detectByByteFrequency uses byte frequency analysis to distinguish
+// between common single-byte encodings when the content is not valid
+// UTF-8.
+func detectByByteFrequency(raw []byte) string {
+	// First pass: count Shift_JIS double-byte pairs. Track which byte
+	// positions are consumed as part of a pair so the second pass can
+	// count unpaired high bytes accurately.
+	paired := make([]bool, len(raw))
+	var shiftJISPairs int
+
+	for i := 0; i < len(raw); i++ {
+		b := raw[i]
+		// Shift_JIS lead byte ranges: 0x81-0x9F, 0xE0-0xEF followed by
+		// trail byte: 0x40-0x7E, 0x80-0xFC.
+		if (b >= 0x81 && b <= 0x9F) || (b >= 0xE0 && b <= 0xEF) {
+			if i+1 < len(raw) {
+				trail := raw[i+1]
+				if (trail >= 0x40 && trail <= 0x7E) || (trail >= 0x80 && trail <= 0xFC) {
+					paired[i] = true
+					paired[i+1] = true
+					shiftJISPairs++
+					i++ // skip trail byte
+				}
+			}
+		}
+	}
+
+	// Second pass: count unpaired high bytes and C1 controls.
+	var highBytes, unpairedHighBytes int
+	var unpairedC1Controls int
+
+	for i := 0; i < len(raw); i++ {
+		b := raw[i]
+		if b >= 0x80 {
+			highBytes++
+			if !paired[i] {
+				unpairedHighBytes++
+				if b <= 0x9F {
+					unpairedC1Controls++
+				}
+			}
+		}
+	}
+
+	// If all high bytes are consumed by Shift_JIS pairs and there are
+	// at least 2 pairs, classify as Shift_JIS. This handles pure
+	// Japanese text including bytes in the C1 range (0x81-0x9F) which
+	// are valid Shift_JIS lead bytes.
+	if shiftJISPairs >= 2 && unpairedHighBytes == 0 {
+		return "Shift_JIS"
+	}
+
+	// Unpaired C1 control characters (0x80-0x9F) are a strong signal
+	// for Windows-1252 which maps printable characters (smart quotes,
+	// em dashes) into this range. ISO-8859-1 treats them as control
+	// characters which are extremely rare in real text.
+	if unpairedC1Controls > 0 {
+		return "Windows-1252"
+	}
+
+	// Default to ISO-8859-1 for content with high bytes (0xA0-0xFF)
+	// that does not match other patterns.
+	return "ISO-8859-1"
+}
+
+// TranscodeToUTF8 converts raw bytes from the specified encoding to
+// UTF-8. Returns the bytes unchanged if the source encoding is already
+// UTF-8. Returns an error if the encoding is unsupported or the content
+// cannot be transcoded.
+func TranscodeToUTF8(raw []byte, fromEncoding string) ([]byte, error) {
+	normalised := strings.ToLower(strings.TrimSpace(fromEncoding))
+	if normalised == "utf-8" || normalised == "" {
+		return raw, nil
+	}
+
+	enc, ok := encodingLookup[normalised]
+	if !ok {
+		return nil, fmt.Errorf("ingest: unsupported encoding %q", fromEncoding)
+	}
+
+	decoded, err := enc.NewDecoder().Bytes(raw)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: transcoding from %s to UTF-8: %w", fromEncoding, err)
+	}
+	return decoded, nil
 }

--- a/go/ingest/extractor.go
+++ b/go/ingest/extractor.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ingest provides a content-type-routing extractor registry with
+// streaming support. Extractors declare the MIME types they handle, and
+// the registry routes incoming content to the appropriate extractor chain
+// with fallback behaviour for unknown types.
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+// Security constants for downstream extractors (Phase 4) that decompress
+// archives or spawn subprocesses.
+const (
+	// MaxDecompressionRatio caps the ratio of decompressed-to-compressed
+	// size to prevent ZIP bomb attacks.
+	MaxDecompressionRatio = 100
+
+	// MaxExtractedFiles limits the number of files extracted from an
+	// archive to prevent resource exhaustion.
+	MaxExtractedFiles = 1000
+)
+
+// sanitizeArgsAllowlist contains flags permitted to pass through to
+// subprocess extractors. Anything starting with '-' that is not in this
+// set is rejected.
+var sanitizeArgsAllowlist = map[string]struct{}{
+	"-o":        {},
+	"--output":  {},
+	"-f":        {},
+	"--format":  {},
+	"-q":        {},
+	"--quiet":   {},
+	"-v":        {},
+	"--verbose": {},
+	"--stdin":   {},
+	"--stdout":  {},
+	"--no-color": {},
+}
+
+// SanitizeArgs filters a slice of command-line arguments, rejecting any
+// flag (starting with '-') that is not in the hardcoded allowlist. This
+// prevents injection of dangerous flags into subprocess extractors.
+func SanitizeArgs(args []string) ([]string, error) {
+	sanitized := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			if _, ok := sanitizeArgsAllowlist[arg]; !ok {
+				return nil, fmt.Errorf("ingest: disallowed argument %q", arg)
+			}
+		}
+		sanitized = append(sanitized, arg)
+	}
+	return sanitized, nil
+}
+
+// ExtractOptions provides hints to the extractor about the content being
+// processed.
+type ExtractOptions struct {
+	ContentType string
+	FileName    string
+	MaxBytes    int64 // 0 = no limit
+}
+
+// ExtractResult holds the output of an extraction operation.
+type ExtractResult struct {
+	Text     string
+	Metadata map[string]string
+	Skipped  bool
+	Reason   string
+}
+
+// Extractor defines the contract for content extraction. Implementations
+// declare the MIME types they handle and provide both buffered and
+// streaming extraction methods.
+type Extractor interface {
+	// Extract converts buffered raw bytes into text content.
+	Extract(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error)
+	// ExtractStream processes content from a reader. The default
+	// implementation (BaseExtractor) buffers into Extract.
+	ExtractStream(ctx context.Context, reader io.Reader, opts ExtractOptions) (ExtractResult, error)
+	// ContentTypes returns the MIME types this extractor handles.
+	ContentTypes() []string
+	// Name returns a human-readable identifier for this extractor.
+	Name() string
+}
+
+// BaseExtractor provides a default ExtractStream implementation that
+// buffers the reader into memory and delegates to Extract. Embed this in
+// simple extractors that do not need true streaming.
+type BaseExtractor struct {
+	ExtractFn      func(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error)
+	ContentTypesFn func() []string
+	NameFn         func() string
+}
+
+// Extract delegates to the embedded ExtractFn.
+func (b *BaseExtractor) Extract(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error) {
+	return b.ExtractFn(ctx, raw, opts)
+}
+
+// ExtractStream buffers the reader and delegates to Extract.
+func (b *BaseExtractor) ExtractStream(ctx context.Context, reader io.Reader, opts ExtractOptions) (ExtractResult, error) {
+	var limitReader io.Reader = reader
+	if opts.MaxBytes > 0 {
+		limitReader = io.LimitReader(reader, opts.MaxBytes)
+	}
+	raw, err := io.ReadAll(limitReader)
+	if err != nil {
+		return ExtractResult{}, fmt.Errorf("ingest: reading stream: %w", err)
+	}
+	return b.ExtractFn(ctx, raw, opts)
+}
+
+// ContentTypes delegates to the embedded ContentTypesFn.
+func (b *BaseExtractor) ContentTypes() []string {
+	return b.ContentTypesFn()
+}
+
+// Name delegates to the embedded NameFn.
+func (b *BaseExtractor) Name() string {
+	return b.NameFn()
+}
+
+// PlainTextExtractor handles text/* content types by returning the raw
+// bytes as UTF-8 text. Non-UTF-8 content is rejected with an error.
+type PlainTextExtractor struct{}
+
+// Compile-time interface check.
+var _ Extractor = (*PlainTextExtractor)(nil)
+
+// Extract returns the raw bytes as text, validating UTF-8.
+func (p *PlainTextExtractor) Extract(_ context.Context, raw []byte, _ ExtractOptions) (ExtractResult, error) {
+	if !utf8.Valid(raw) {
+		return ExtractResult{}, fmt.Errorf("ingest: content is not valid UTF-8")
+	}
+	return ExtractResult{
+		Text:     string(raw),
+		Metadata: map[string]string{},
+	}, nil
+}
+
+// ExtractStream buffers the reader and delegates to Extract.
+func (p *PlainTextExtractor) ExtractStream(ctx context.Context, reader io.Reader, opts ExtractOptions) (ExtractResult, error) {
+	var limitReader io.Reader = reader
+	if opts.MaxBytes > 0 {
+		limitReader = io.LimitReader(reader, opts.MaxBytes)
+	}
+	raw, err := io.ReadAll(limitReader)
+	if err != nil {
+		return ExtractResult{}, fmt.Errorf("ingest: reading stream: %w", err)
+	}
+	return p.Extract(ctx, raw, opts)
+}
+
+// ContentTypes returns the MIME types handled by the plain text extractor.
+func (p *PlainTextExtractor) ContentTypes() []string {
+	return []string{
+		"text/plain",
+		"text/markdown",
+		"text/csv",
+		"text/x-yaml",
+		"application/json",
+		"application/x-yaml",
+	}
+}
+
+// Name returns the extractor identifier.
+func (p *PlainTextExtractor) Name() string {
+	return "plain-text"
+}
+
+// ExtractorRegistry maps content types to extractors and routes incoming
+// content to the correct handler. Unknown content types return a skipped
+// result rather than an error.
+type ExtractorRegistry struct {
+	mu         sync.RWMutex
+	extractors map[string]Extractor
+}
+
+// NewExtractorRegistry creates a registry pre-loaded with the built-in
+// PlainTextExtractor for all text/* content types.
+func NewExtractorRegistry() *ExtractorRegistry {
+	r := &ExtractorRegistry{
+		extractors: make(map[string]Extractor, 8),
+	}
+	plainText := &PlainTextExtractor{}
+	r.Register(plainText)
+	return r
+}
+
+// Register adds an extractor to the registry for all content types it
+// declares. Later registrations for the same content type override
+// earlier ones.
+func (r *ExtractorRegistry) Register(ext Extractor) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, ct := range ext.ContentTypes() {
+		r.extractors[normaliseContentType(ct)] = ext
+	}
+}
+
+// Extract routes raw bytes to the appropriate extractor based on the
+// content type in opts. Returns a skipped result for unsupported types.
+func (r *ExtractorRegistry) Extract(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error) {
+	ext := r.resolve(opts.ContentType)
+	if ext == nil {
+		return ExtractResult{
+			Skipped: true,
+			Reason:  fmt.Sprintf("unsupported content type: %s", opts.ContentType),
+		}, nil
+	}
+	return ext.Extract(ctx, raw, opts)
+}
+
+// ExtractStream routes a reader to the appropriate extractor based on
+// the content type in opts. Returns a skipped result for unsupported
+// types.
+func (r *ExtractorRegistry) ExtractStream(ctx context.Context, reader io.Reader, opts ExtractOptions) (ExtractResult, error) {
+	ext := r.resolve(opts.ContentType)
+	if ext == nil {
+		return ExtractResult{
+			Skipped: true,
+			Reason:  fmt.Sprintf("unsupported content type: %s", opts.ContentType),
+		}, nil
+	}
+	return ext.ExtractStream(ctx, reader, opts)
+}
+
+// resolve finds the extractor for a content type. It first tries an
+// exact match, then falls back to matching the base type (e.g.
+// "text/plain" for "text/plain; charset=utf-8"), then tries the type
+// prefix (e.g. "text/" matches any text/* extractor registered as
+// "text/plain").
+func (r *ExtractorRegistry) resolve(contentType string) Extractor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	normalised := normaliseContentType(contentType)
+
+	// Exact match.
+	if ext, ok := r.extractors[normalised]; ok {
+		return ext
+	}
+
+	// Fallback: match by type prefix for text/* family.
+	if strings.HasPrefix(normalised, "text/") {
+		if ext, ok := r.extractors["text/plain"]; ok {
+			return ext
+		}
+	}
+
+	return nil
+}
+
+// normaliseContentType strips parameters (charset, boundary, etc.) and
+// lowercases the media type.
+func normaliseContentType(ct string) string {
+	base := ct
+	if idx := strings.Index(ct, ";"); idx >= 0 {
+		base = ct[:idx]
+	}
+	return strings.TrimSpace(strings.ToLower(base))
+}

--- a/go/ingest/extractor_test.go
+++ b/go/ingest/extractor_test.go
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestPlainTextExtractor_Extract(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid utf8 text", "hello world", false},
+		{"empty input", "", false},
+		{"unicode text", "hello 世界", false},
+		{"markdown content", "# Title\n\nBody paragraph.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := ext.Extract(context.Background(), []byte(tc.input), ExtractOptions{})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Text != tc.input {
+				t.Fatalf("text mismatch: got %q, want %q", result.Text, tc.input)
+			}
+			if result.Skipped {
+				t.Fatal("expected skipped=false")
+			}
+		})
+	}
+}
+
+func TestPlainTextExtractor_RejectsInvalidUTF8(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	invalidUTF8 := []byte{0xff, 0xfe, 0xfd}
+	_, err := ext.Extract(context.Background(), invalidUTF8, ExtractOptions{})
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestPlainTextExtractor_ContentTypes(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	types := ext.ContentTypes()
+	if len(types) == 0 {
+		t.Fatal("expected non-empty content types")
+	}
+	found := false
+	for _, ct := range types {
+		if ct == "text/plain" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected text/plain in content types")
+	}
+}
+
+func TestPlainTextExtractor_Name(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	if ext.Name() != "plain-text" {
+		t.Fatalf("unexpected name: %s", ext.Name())
+	}
+}
+
+func TestPlainTextExtractor_ExtractStream(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	input := "streamed content here"
+	reader := strings.NewReader(input)
+	result, err := ext.ExtractStream(context.Background(), reader, ExtractOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != input {
+		t.Fatalf("text mismatch: got %q, want %q", result.Text, input)
+	}
+}
+
+func TestPlainTextExtractor_ExtractStreamWithMaxBytes(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	input := "abcdefghij" // 10 bytes
+	reader := strings.NewReader(input)
+	result, err := ext.ExtractStream(context.Background(), reader, ExtractOptions{MaxBytes: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "abcde" {
+		t.Fatalf("expected truncated text %q, got %q", "abcde", result.Text)
+	}
+}
+
+func TestExtractorRegistry_RoutesbyContentType(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := []byte("plain text content")
+	opts := ExtractOptions{ContentType: "text/plain"}
+
+	result, err := registry.Extract(context.Background(), input, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "plain text content" {
+		t.Fatalf("text mismatch: got %q", result.Text)
+	}
+	if result.Skipped {
+		t.Fatal("expected skipped=false for text/plain")
+	}
+}
+
+func TestExtractorRegistry_RoutesMarkdown(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := []byte("# Heading\n\nBody")
+	opts := ExtractOptions{ContentType: "text/markdown"}
+
+	result, err := registry.Extract(context.Background(), input, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "# Heading\n\nBody" {
+		t.Fatalf("text mismatch: got %q", result.Text)
+	}
+}
+
+func TestExtractorRegistry_FallbackForUnknownTextSubtype(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := []byte("some xml content")
+	opts := ExtractOptions{ContentType: "text/xml"}
+
+	result, err := registry.Extract(context.Background(), input, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected text/xml to fall back to text/plain extractor")
+	}
+	if result.Text != "some xml content" {
+		t.Fatalf("text mismatch: got %q", result.Text)
+	}
+}
+
+func TestExtractorRegistry_UnsupportedContentTypeReturnsSkipped(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := []byte{0x00, 0x01, 0x02}
+	opts := ExtractOptions{ContentType: "application/octet-stream"}
+
+	result, err := registry.Extract(context.Background(), input, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected skipped=true for unsupported content type")
+	}
+	if !strings.Contains(result.Reason, "unsupported content type") {
+		t.Fatalf("unexpected reason: %s", result.Reason)
+	}
+}
+
+func TestExtractorRegistry_ContentTypeWithCharset(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := []byte("charset content")
+	opts := ExtractOptions{ContentType: "text/plain; charset=utf-8"}
+
+	result, err := registry.Extract(context.Background(), input, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected charset parameter to be stripped for routing")
+	}
+	if result.Text != "charset content" {
+		t.Fatalf("text mismatch: got %q", result.Text)
+	}
+}
+
+func TestExtractorRegistry_CustomExtractorOverridesDefault(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+
+	custom := &stubExtractor{
+		name:         "custom-text",
+		contentTypes: []string{"text/plain"},
+		extractFn: func(_ context.Context, raw []byte, _ ExtractOptions) (ExtractResult, error) {
+			return ExtractResult{
+				Text:     "CUSTOM:" + string(raw),
+				Metadata: map[string]string{"extractor": "custom"},
+			}, nil
+		},
+	}
+	registry.Register(custom)
+
+	input := []byte("hello")
+	result, err := registry.Extract(context.Background(), input, ExtractOptions{ContentType: "text/plain"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "CUSTOM:hello" {
+		t.Fatalf("expected custom extractor output, got %q", result.Text)
+	}
+}
+
+func TestExtractorRegistry_ExtractStream(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	input := "streamed plain text"
+	reader := strings.NewReader(input)
+
+	result, err := registry.ExtractStream(context.Background(), reader, ExtractOptions{ContentType: "text/plain"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != input {
+		t.Fatalf("text mismatch: got %q, want %q", result.Text, input)
+	}
+}
+
+func TestExtractorRegistry_ExtractStreamUnsupported(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+	reader := strings.NewReader("binary data")
+
+	result, err := registry.ExtractStream(context.Background(), reader, ExtractOptions{ContentType: "application/octet-stream"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected skipped=true for unsupported content type in stream mode")
+	}
+}
+
+func TestExtractorRegistry_DefaultStreamBuffersIntoExtract(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+
+	var capturedRaw []byte
+	custom := &stubExtractor{
+		name:         "capture",
+		contentTypes: []string{"application/x-test"},
+		extractFn: func(_ context.Context, raw []byte, _ ExtractOptions) (ExtractResult, error) {
+			capturedRaw = make([]byte, len(raw))
+			copy(capturedRaw, raw)
+			return ExtractResult{Text: string(raw), Metadata: map[string]string{}}, nil
+		},
+	}
+	registry.Register(custom)
+
+	input := "buffered via stream"
+	reader := strings.NewReader(input)
+	result, err := registry.ExtractStream(context.Background(), reader, ExtractOptions{ContentType: "application/x-test"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != input {
+		t.Fatalf("text mismatch: got %q, want %q", result.Text, input)
+	}
+	if string(capturedRaw) != input {
+		t.Fatalf("expected stream to buffer into Extract, got %q", string(capturedRaw))
+	}
+}
+
+func TestSanitizeArgs_AllowlistedFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		args    []string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "no flags",
+			args: []string{"input.pdf", "output.txt"},
+			want: []string{"input.pdf", "output.txt"},
+		},
+		{
+			name: "allowlisted short flag",
+			args: []string{"-o", "output.txt"},
+			want: []string{"-o", "output.txt"},
+		},
+		{
+			name: "allowlisted long flag",
+			args: []string{"--format", "json"},
+			want: []string{"--format", "json"},
+		},
+		{
+			name:    "disallowed flag rejected",
+			args:    []string{"--exec", "rm -rf /"},
+			wantErr: true,
+		},
+		{
+			name:    "dangerous single dash flag rejected",
+			args:    []string{"-e", "evil"},
+			wantErr: true,
+		},
+		{
+			name: "mixed allowed and positional",
+			args: []string{"file.pdf", "-q", "--output", "out.txt"},
+			want: []string{"file.pdf", "-q", "--output", "out.txt"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := SanitizeArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("length mismatch: got %d, want %d", len(got), len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("arg[%d] mismatch: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeArgs_EmptySlice(t *testing.T) {
+	t.Parallel()
+	got, err := SanitizeArgs([]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %v", got)
+	}
+}
+
+func TestSecurityConstants(t *testing.T) {
+	t.Parallel()
+	if MaxDecompressionRatio != 100 {
+		t.Fatalf("MaxDecompressionRatio: got %d, want 100", MaxDecompressionRatio)
+	}
+	if MaxExtractedFiles != 1000 {
+		t.Fatalf("MaxExtractedFiles: got %d, want 1000", MaxExtractedFiles)
+	}
+}
+
+func TestBaseExtractor_ExtractStreamBuffers(t *testing.T) {
+	t.Parallel()
+	var called bool
+	base := &BaseExtractor{
+		ExtractFn: func(_ context.Context, raw []byte, _ ExtractOptions) (ExtractResult, error) {
+			called = true
+			return ExtractResult{Text: string(raw), Metadata: map[string]string{}}, nil
+		},
+		ContentTypesFn: func() []string { return []string{"application/x-base"} },
+		NameFn:         func() string { return "base-test" },
+	}
+
+	reader := strings.NewReader("base stream test")
+	result, err := base.ExtractStream(context.Background(), reader, ExtractOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected ExtractFn to be called via ExtractStream")
+	}
+	if result.Text != "base stream test" {
+		t.Fatalf("text mismatch: got %q", result.Text)
+	}
+}
+
+func TestBaseExtractor_Methods(t *testing.T) {
+	t.Parallel()
+	base := &BaseExtractor{
+		ExtractFn: func(_ context.Context, raw []byte, _ ExtractOptions) (ExtractResult, error) {
+			return ExtractResult{Text: string(raw)}, nil
+		},
+		ContentTypesFn: func() []string { return []string{"test/type"} },
+		NameFn:         func() string { return "test-base" },
+	}
+
+	if base.Name() != "test-base" {
+		t.Fatalf("Name mismatch: %s", base.Name())
+	}
+	types := base.ContentTypes()
+	if len(types) != 1 || types[0] != "test/type" {
+		t.Fatalf("ContentTypes mismatch: %v", types)
+	}
+	result, err := base.Extract(context.Background(), []byte("hi"), ExtractOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "hi" {
+		t.Fatalf("text mismatch: %q", result.Text)
+	}
+}
+
+// stubExtractor is a test double that implements Extractor with
+// configurable behavior.
+type stubExtractor struct {
+	name         string
+	contentTypes []string
+	extractFn    func(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error)
+}
+
+var _ Extractor = (*stubExtractor)(nil)
+
+func (s *stubExtractor) Extract(ctx context.Context, raw []byte, opts ExtractOptions) (ExtractResult, error) {
+	return s.extractFn(ctx, raw, opts)
+}
+
+func (s *stubExtractor) ExtractStream(ctx context.Context, reader io.Reader, opts ExtractOptions) (ExtractResult, error) {
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return ExtractResult{}, fmt.Errorf("stub: reading stream: %w", err)
+	}
+	return s.extractFn(ctx, raw, opts)
+}
+
+func (s *stubExtractor) ContentTypes() []string {
+	return s.contentTypes
+}
+
+func (s *stubExtractor) Name() string {
+	return s.name
+}
+
+func TestExtractorRegistry_ExtractStreamWithMaxBytes(t *testing.T) {
+	t.Parallel()
+	registry := NewExtractorRegistry()
+
+	// Generate a large input that exceeds MaxBytes
+	largeInput := bytes.Repeat([]byte("x"), 100)
+	reader := bytes.NewReader(largeInput)
+
+	result, err := registry.ExtractStream(context.Background(), reader, ExtractOptions{
+		ContentType: "text/plain",
+		MaxBytes:    10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Text) != 10 {
+		t.Fatalf("expected text length 10, got %d", len(result.Text))
+	}
+}

--- a/go/ingest/extractor_test.go
+++ b/go/ingest/extractor_test.go
@@ -453,6 +453,14 @@ func (s *stubExtractor) Name() string {
 	return s.name
 }
 
+func (s *stubExtractor) Available(_ context.Context) (bool, error) {
+	return true, nil
+}
+
+func (s *stubExtractor) Capability() ExtractorCapability {
+	return ExtractorCapability{MIMETypes: s.contentTypes}
+}
+
 func TestExtractorRegistry_ExtractStreamWithMaxBytes(t *testing.T) {
 	t.Parallel()
 	registry := NewExtractorRegistry()
@@ -470,5 +478,227 @@ func TestExtractorRegistry_ExtractStreamWithMaxBytes(t *testing.T) {
 	}
 	if len(result.Text) != 10 {
 		t.Fatalf("expected text length 10, got %d", len(result.Text))
+	}
+}
+
+func TestPlainTextExtractor_Available(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	avail, err := ext.Available(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !avail {
+		t.Fatal("expected plain text extractor to be available")
+	}
+}
+
+func TestPlainTextExtractor_Capability(t *testing.T) {
+	t.Parallel()
+	ext := &PlainTextExtractor{}
+	cap := ext.Capability()
+	if len(cap.Extensions) == 0 {
+		t.Fatal("expected non-empty extensions")
+	}
+	if len(cap.MIMETypes) == 0 {
+		t.Fatal("expected non-empty MIME types")
+	}
+	if cap.RequiresBinary {
+		t.Fatal("plain text extractor should not require binary")
+	}
+	foundTxt := false
+	for _, ext := range cap.Extensions {
+		if ext == ".txt" {
+			foundTxt = true
+			break
+		}
+	}
+	if !foundTxt {
+		t.Fatal("expected .txt in extensions")
+	}
+}
+
+func TestDetectEncoding_UTF8(t *testing.T) {
+	t.Parallel()
+	raw := []byte("Hello, world! This is valid UTF-8 text.")
+	enc := DetectEncoding(raw)
+	if enc != "UTF-8" {
+		t.Fatalf("DetectEncoding(utf8) = %q, want %q", enc, "UTF-8")
+	}
+}
+
+func TestDetectEncoding_UTF8WithBOM(t *testing.T) {
+	t.Parallel()
+	raw := append([]byte{0xEF, 0xBB, 0xBF}, []byte("Hello BOM")...)
+	enc := DetectEncoding(raw)
+	if enc != "UTF-8" {
+		t.Fatalf("DetectEncoding(utf8+bom) = %q, want %q", enc, "UTF-8")
+	}
+}
+
+func TestDetectEncoding_UTF16BE(t *testing.T) {
+	t.Parallel()
+	raw := []byte{0xFE, 0xFF, 0x00, 0x48, 0x00, 0x65}
+	enc := DetectEncoding(raw)
+	if enc != "UTF-16BE" {
+		t.Fatalf("DetectEncoding(utf16be) = %q, want %q", enc, "UTF-16BE")
+	}
+}
+
+func TestDetectEncoding_UTF16LE(t *testing.T) {
+	t.Parallel()
+	raw := []byte{0xFF, 0xFE, 0x48, 0x00, 0x65, 0x00}
+	enc := DetectEncoding(raw)
+	if enc != "UTF-16LE" {
+		t.Fatalf("DetectEncoding(utf16le) = %q, want %q", enc, "UTF-16LE")
+	}
+}
+
+func TestDetectEncoding_Latin1(t *testing.T) {
+	t.Parallel()
+	// ISO-8859-1 encoded string with accented characters in the 0xA0-0xFF range.
+	raw := []byte("Caf\xe9 cr\xe8me") // "Cafe creme" with accents
+	enc := DetectEncoding(raw)
+	if enc != "ISO-8859-1" {
+		t.Fatalf("DetectEncoding(latin1) = %q, want %q", enc, "ISO-8859-1")
+	}
+}
+
+func TestDetectEncoding_Windows1252(t *testing.T) {
+	t.Parallel()
+	// Windows-1252 uses 0x80-0x9F for printable characters like smart quotes.
+	// 0x93 = left double quotation mark, 0x94 = right double quotation mark.
+	raw := []byte("Hello \x93world\x94")
+	enc := DetectEncoding(raw)
+	if enc != "Windows-1252" {
+		t.Fatalf("DetectEncoding(win1252) = %q, want %q", enc, "Windows-1252")
+	}
+}
+
+func TestDetectEncoding_ShiftJIS(t *testing.T) {
+	t.Parallel()
+	// Shift_JIS encoded Japanese: "nihongo" (日本語)
+	// 0x93FA = 日, 0x967B = 本, 0x8CEA = 語 (approximate, exact values
+	// depend on character mapping).
+	raw := []byte{0x93, 0xFA, 0x96, 0x7B, 0x8C, 0xEA}
+	enc := DetectEncoding(raw)
+	if enc != "Shift_JIS" {
+		t.Fatalf("DetectEncoding(shift_jis) = %q, want %q", enc, "Shift_JIS")
+	}
+}
+
+func TestDetectEncoding_Empty(t *testing.T) {
+	t.Parallel()
+	enc := DetectEncoding(nil)
+	if enc != "UTF-8" {
+		t.Fatalf("DetectEncoding(empty) = %q, want %q", enc, "UTF-8")
+	}
+}
+
+func TestTranscodeToUTF8_Latin1(t *testing.T) {
+	t.Parallel()
+	// ISO-8859-1 "Cafe creme" with accents.
+	raw := []byte("Caf\xe9 cr\xe8me")
+	decoded, err := TranscodeToUTF8(raw, "ISO-8859-1")
+	if err != nil {
+		t.Fatalf("TranscodeToUTF8 error: %v", err)
+	}
+	expected := "Cafe creme"
+	// e-acute in UTF-8 is 0xC3 0xA9.
+	expectedUTF8 := "Caf\xc3\xa9 cr\xc3\xa8me"
+	if string(decoded) != expectedUTF8 {
+		t.Fatalf("TranscodeToUTF8(latin1) = %q, want %q (or %q)", string(decoded), expectedUTF8, expected)
+	}
+}
+
+func TestTranscodeToUTF8_ShiftJIS(t *testing.T) {
+	t.Parallel()
+	// Shift_JIS "日本語"
+	raw := []byte{0x93, 0xFA, 0x96, 0x7B, 0x8C, 0xEA}
+	decoded, err := TranscodeToUTF8(raw, "Shift_JIS")
+	if err != nil {
+		t.Fatalf("TranscodeToUTF8 error: %v", err)
+	}
+	expected := "日本語"
+	if string(decoded) != expected {
+		t.Fatalf("TranscodeToUTF8(shift_jis) = %q, want %q", string(decoded), expected)
+	}
+}
+
+func TestTranscodeToUTF8_PassthroughUTF8(t *testing.T) {
+	t.Parallel()
+	raw := []byte("Already UTF-8")
+	decoded, err := TranscodeToUTF8(raw, "UTF-8")
+	if err != nil {
+		t.Fatalf("TranscodeToUTF8 error: %v", err)
+	}
+	if string(decoded) != "Already UTF-8" {
+		t.Fatalf("TranscodeToUTF8(utf8) = %q, want %q", string(decoded), "Already UTF-8")
+	}
+}
+
+func TestTranscodeToUTF8_EmptyEncoding(t *testing.T) {
+	t.Parallel()
+	raw := []byte("No encoding specified")
+	decoded, err := TranscodeToUTF8(raw, "")
+	if err != nil {
+		t.Fatalf("TranscodeToUTF8 error: %v", err)
+	}
+	if string(decoded) != "No encoding specified" {
+		t.Fatalf("TranscodeToUTF8(empty) = %q", string(decoded))
+	}
+}
+
+func TestTranscodeToUTF8_UnsupportedEncoding(t *testing.T) {
+	t.Parallel()
+	_, err := TranscodeToUTF8([]byte("data"), "EBCDIC-37")
+	if err == nil {
+		t.Fatal("expected error for unsupported encoding")
+	}
+	if !strings.Contains(err.Error(), "unsupported encoding") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTranscodeToUTF8_Windows1252(t *testing.T) {
+	t.Parallel()
+	// Windows-1252 smart quotes.
+	raw := []byte("Hello \x93world\x94")
+	decoded, err := TranscodeToUTF8(raw, "Windows-1252")
+	if err != nil {
+		t.Fatalf("TranscodeToUTF8 error: %v", err)
+	}
+	// 0x93 = U+201C (left double quotation mark), 0x94 = U+201D (right double quotation mark)
+	expected := "Hello \xe2\x80\x9cworld\xe2\x80\x9d"
+	if string(decoded) != expected {
+		t.Fatalf("TranscodeToUTF8(win1252) = %q, want %q", string(decoded), expected)
+	}
+}
+
+func TestExtractResult_ExpandedFields(t *testing.T) {
+	t.Parallel()
+	result := ExtractResult{
+		Text:        "extracted text",
+		ContentType: "application/pdf",
+		Encoding:    "UTF-8",
+		Metadata:    map[string]string{"author": "test"},
+		Pages:       5,
+		Language:    "en",
+		Confidence:  0.95,
+	}
+	if result.Pages != 5 {
+		t.Fatalf("Pages = %d, want 5", result.Pages)
+	}
+	if result.Language != "en" {
+		t.Fatalf("Language = %q, want %q", result.Language, "en")
+	}
+	if result.Confidence != 0.95 {
+		t.Fatalf("Confidence = %f, want 0.95", result.Confidence)
+	}
+	if result.Encoding != "UTF-8" {
+		t.Fatalf("Encoding = %q, want %q", result.Encoding, "UTF-8")
+	}
+	if result.ContentType != "application/pdf" {
+		t.Fatalf("ContentType = %q, want %q", result.ContentType, "application/pdf")
 	}
 }

--- a/sdks/ts/memory/src/ingest/extractor.test.ts
+++ b/sdks/ts/memory/src/ingest/extractor.test.ts
@@ -6,11 +6,14 @@ import {
   type ExtractOptions,
   type ExtractResult,
   type Extractor,
+  type ExtractorCapability,
   MAX_DECOMPRESSION_RATIO,
   MAX_EXTRACTED_FILES,
   createExtractorRegistry,
   createPlainTextExtractor,
+  detectEncoding,
   sanitizeArgs,
+  transcodeToUTF8,
 } from './extractor.js'
 
 const toReadable = (content: string): Readable => {
@@ -124,7 +127,12 @@ describe('createExtractorRegistry', () => {
       async extract(raw: Buffer): Promise<ExtractResult> {
         return {
           text: `CUSTOM:${raw.toString('utf8')}`,
+          contentType: 'text/plain',
+          encoding: 'UTF-8',
           metadata: { extractor: 'custom' },
+          pages: 0,
+          language: '',
+          confidence: 0,
           skipped: false,
         }
       },
@@ -134,6 +142,12 @@ describe('createExtractorRegistry', () => {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array))
         }
         return this.extract(Buffer.concat(chunks), opts)
+      },
+      async available(): Promise<boolean> {
+        return true
+      },
+      capability(): ExtractorCapability {
+        return { extensions: ['.txt'], mimeTypes: ['text/plain'], magicBytes: [], requiresBinary: false }
       },
     }
     registry.register(custom)
@@ -168,7 +182,16 @@ describe('createExtractorRegistry', () => {
       contentTypes: ['application/x-test'],
       async extract(raw: Buffer): Promise<ExtractResult> {
         extractCalled = true
-        return { text: raw.toString('utf8'), metadata: {}, skipped: false }
+        return {
+          text: raw.toString('utf8'),
+          contentType: 'application/x-test',
+          encoding: 'UTF-8',
+          metadata: {},
+          pages: 0,
+          language: '',
+          confidence: 0,
+          skipped: false,
+        }
       },
       async extractStream(source: Readable, opts: ExtractOptions): Promise<ExtractResult> {
         const chunks: Buffer[] = []
@@ -176,6 +199,12 @@ describe('createExtractorRegistry', () => {
           chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array))
         }
         return this.extract(Buffer.concat(chunks), opts)
+      },
+      async available(): Promise<boolean> {
+        return true
+      },
+      capability(): ExtractorCapability {
+        return { extensions: [], mimeTypes: ['application/x-test'], magicBytes: [], requiresBinary: false }
       },
     }
     registry.register(custom)
@@ -229,5 +258,103 @@ describe('security constants', () => {
 
   it('defines MAX_EXTRACTED_FILES as 1000', () => {
     expect(MAX_EXTRACTED_FILES).toBe(1000)
+  })
+})
+
+describe('createPlainTextExtractor available and capability', () => {
+  const ext = createPlainTextExtractor()
+
+  it('reports as available', async () => {
+    expect(await ext.available()).toBe(true)
+  })
+
+  it('returns capability with extensions and MIME types', () => {
+    const cap = ext.capability()
+    expect(cap.extensions).toContain('.txt')
+    expect(cap.extensions).toContain('.md')
+    expect(cap.mimeTypes).toContain('text/plain')
+    expect(cap.mimeTypes).toContain('text/markdown')
+    expect(cap.requiresBinary).toBe(false)
+  })
+})
+
+describe('detectEncoding', () => {
+  it('detects UTF-8 for valid UTF-8 content', () => {
+    const raw = Buffer.from('Hello, world!', 'utf8')
+    expect(detectEncoding(raw)).toBe('UTF-8')
+  })
+
+  it('detects UTF-8 BOM', () => {
+    const raw = Buffer.from([0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f])
+    expect(detectEncoding(raw)).toBe('UTF-8')
+  })
+
+  it('detects UTF-16BE BOM', () => {
+    const raw = Buffer.from([0xfe, 0xff, 0x00, 0x48, 0x00, 0x65])
+    expect(detectEncoding(raw)).toBe('UTF-16BE')
+  })
+
+  it('detects UTF-16LE BOM', () => {
+    const raw = Buffer.from([0xff, 0xfe, 0x48, 0x00, 0x65, 0x00])
+    expect(detectEncoding(raw)).toBe('UTF-16LE')
+  })
+
+  it('detects ISO-8859-1 for Latin-1 content', () => {
+    const raw = Buffer.from([0x43, 0x61, 0x66, 0xe9, 0x20, 0x63, 0x72, 0xe8, 0x6d, 0x65])
+    expect(detectEncoding(raw)).toBe('ISO-8859-1')
+  })
+
+  it('detects Windows-1252 for content with C1 controls', () => {
+    // 0x93 and 0x94 are smart quotes in Windows-1252
+    const raw = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x93, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x94])
+    expect(detectEncoding(raw)).toBe('Windows-1252')
+  })
+
+  it('detects Shift_JIS for Japanese content', () => {
+    // Shift_JIS: 日本語
+    const raw = Buffer.from([0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea])
+    expect(detectEncoding(raw)).toBe('Shift_JIS')
+  })
+
+  it('returns UTF-8 for empty input', () => {
+    expect(detectEncoding(Buffer.alloc(0))).toBe('UTF-8')
+  })
+})
+
+describe('transcodeToUTF8', () => {
+  it('transcodes Latin-1 to UTF-8', () => {
+    const raw = Buffer.from([0x43, 0x61, 0x66, 0xe9]) // "Cafe" with accent
+    const result = transcodeToUTF8(raw, 'ISO-8859-1')
+    expect(result.toString('utf8')).toBe('Café')
+  })
+
+  it('passes through UTF-8 unchanged', () => {
+    const raw = Buffer.from('Already UTF-8', 'utf8')
+    const result = transcodeToUTF8(raw, 'UTF-8')
+    expect(result.toString('utf8')).toBe('Already UTF-8')
+  })
+
+  it('passes through when encoding is empty', () => {
+    const raw = Buffer.from('No encoding', 'utf8')
+    const result = transcodeToUTF8(raw, '')
+    expect(result.toString('utf8')).toBe('No encoding')
+  })
+
+  it('transcodes Windows-1252 smart quotes', () => {
+    const raw = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x93, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x94])
+    const result = transcodeToUTF8(raw, 'Windows-1252')
+    expect(result.toString('utf8')).toContain('Hello')
+    expect(result.toString('utf8')).toContain('world')
+  })
+
+  it('transcodes Shift_JIS to UTF-8', () => {
+    // Shift_JIS: 日本語
+    const raw = Buffer.from([0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea])
+    const result = transcodeToUTF8(raw, 'Shift_JIS')
+    expect(result.toString('utf8')).toBe('日本語')
+  })
+
+  it('throws for unsupported encoding', () => {
+    expect(() => transcodeToUTF8(Buffer.from('data'), 'EBCDIC-37')).toThrow()
   })
 })

--- a/sdks/ts/memory/src/ingest/extractor.test.ts
+++ b/sdks/ts/memory/src/ingest/extractor.test.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Readable } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+import {
+  type ExtractOptions,
+  type ExtractResult,
+  type Extractor,
+  MAX_DECOMPRESSION_RATIO,
+  MAX_EXTRACTED_FILES,
+  createExtractorRegistry,
+  createPlainTextExtractor,
+  sanitizeArgs,
+} from './extractor.js'
+
+const toReadable = (content: string): Readable => {
+  return Readable.from([Buffer.from(content, 'utf8')])
+}
+
+describe('createPlainTextExtractor', () => {
+  const ext = createPlainTextExtractor()
+
+  it('returns text unchanged for valid UTF-8 input', async () => {
+    const input = Buffer.from('hello world', 'utf8')
+    const result = await ext.extract(input, { contentType: 'text/plain' })
+    expect(result.text).toBe('hello world')
+    expect(result.skipped).toBe(false)
+    expect(result.metadata).toEqual({})
+  })
+
+  it('handles empty input', async () => {
+    const result = await ext.extract(Buffer.alloc(0), { contentType: 'text/plain' })
+    expect(result.text).toBe('')
+    expect(result.skipped).toBe(false)
+  })
+
+  it('handles unicode content', async () => {
+    const input = Buffer.from('hello 世界 🌍', 'utf8')
+    const result = await ext.extract(input, { contentType: 'text/plain' })
+    expect(result.text).toBe('hello 世界 🌍')
+  })
+
+  it('handles markdown content', async () => {
+    const input = Buffer.from('# Title\n\nBody paragraph.', 'utf8')
+    const result = await ext.extract(input, { contentType: 'text/markdown' })
+    expect(result.text).toBe('# Title\n\nBody paragraph.')
+  })
+
+  it('extracts from a stream', async () => {
+    const source = toReadable('streamed content')
+    const result = await ext.extractStream(source, { contentType: 'text/plain' })
+    expect(result.text).toBe('streamed content')
+    expect(result.skipped).toBe(false)
+  })
+
+  it('respects maxBytes in stream mode', async () => {
+    const source = toReadable('abcdefghij')
+    const result = await ext.extractStream(source, { contentType: 'text/plain', maxBytes: 5 })
+    expect(result.text).toBe('abcde')
+  })
+
+  it('declares text/* content types', () => {
+    expect(ext.contentTypes).toContain('text/plain')
+    expect(ext.contentTypes).toContain('text/markdown')
+    expect(ext.contentTypes).toContain('application/json')
+  })
+
+  it('has the correct name', () => {
+    expect(ext.name).toBe('plain-text')
+  })
+})
+
+describe('createExtractorRegistry', () => {
+  it('routes text/plain to built-in plain text extractor', async () => {
+    const registry = createExtractorRegistry()
+    const result = await registry.extract(Buffer.from('hello', 'utf8'), {
+      contentType: 'text/plain',
+    })
+    expect(result.text).toBe('hello')
+    expect(result.skipped).toBe(false)
+  })
+
+  it('routes text/markdown to built-in extractor', async () => {
+    const registry = createExtractorRegistry()
+    const result = await registry.extract(Buffer.from('# Title', 'utf8'), {
+      contentType: 'text/markdown',
+    })
+    expect(result.text).toBe('# Title')
+    expect(result.skipped).toBe(false)
+  })
+
+  it('falls back to text/plain for unknown text/* subtypes', async () => {
+    const registry = createExtractorRegistry()
+    const result = await registry.extract(Buffer.from('<root/>', 'utf8'), {
+      contentType: 'text/xml',
+    })
+    expect(result.skipped).toBe(false)
+    expect(result.text).toBe('<root/>')
+  })
+
+  it('returns skipped for unsupported content types', async () => {
+    const registry = createExtractorRegistry()
+    const result = await registry.extract(Buffer.from([0x00, 0x01]), {
+      contentType: 'application/octet-stream',
+    })
+    expect(result.skipped).toBe(true)
+    expect(result.reason).toContain('unsupported content type')
+  })
+
+  it('strips charset parameter for routing', async () => {
+    const registry = createExtractorRegistry()
+    const result = await registry.extract(Buffer.from('charset test', 'utf8'), {
+      contentType: 'text/plain; charset=utf-8',
+    })
+    expect(result.skipped).toBe(false)
+    expect(result.text).toBe('charset test')
+  })
+
+  it('allows custom extractors to override defaults', async () => {
+    const registry = createExtractorRegistry()
+    const custom: Extractor = {
+      name: 'custom-text',
+      contentTypes: ['text/plain'],
+      async extract(raw: Buffer): Promise<ExtractResult> {
+        return {
+          text: `CUSTOM:${raw.toString('utf8')}`,
+          metadata: { extractor: 'custom' },
+          skipped: false,
+        }
+      },
+      async extractStream(source: Readable, opts: ExtractOptions): Promise<ExtractResult> {
+        const chunks: Buffer[] = []
+        for await (const chunk of source) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array))
+        }
+        return this.extract(Buffer.concat(chunks), opts)
+      },
+    }
+    registry.register(custom)
+
+    const result = await registry.extract(Buffer.from('hello', 'utf8'), {
+      contentType: 'text/plain',
+    })
+    expect(result.text).toBe('CUSTOM:hello')
+    expect(result.metadata).toEqual({ extractor: 'custom' })
+  })
+
+  it('routes streams to the correct extractor', async () => {
+    const registry = createExtractorRegistry()
+    const source = toReadable('stream routing test')
+    const result = await registry.extractStream(source, { contentType: 'text/plain' })
+    expect(result.text).toBe('stream routing test')
+    expect(result.skipped).toBe(false)
+  })
+
+  it('returns skipped for unsupported content types in stream mode', async () => {
+    const registry = createExtractorRegistry()
+    const source = toReadable('binary')
+    const result = await registry.extractStream(source, { contentType: 'application/octet-stream' })
+    expect(result.skipped).toBe(true)
+  })
+
+  it('default stream implementation buffers into extract', async () => {
+    const registry = createExtractorRegistry()
+    let extractCalled = false
+    const custom: Extractor = {
+      name: 'buffer-test',
+      contentTypes: ['application/x-test'],
+      async extract(raw: Buffer): Promise<ExtractResult> {
+        extractCalled = true
+        return { text: raw.toString('utf8'), metadata: {}, skipped: false }
+      },
+      async extractStream(source: Readable, opts: ExtractOptions): Promise<ExtractResult> {
+        const chunks: Buffer[] = []
+        for await (const chunk of source) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array))
+        }
+        return this.extract(Buffer.concat(chunks), opts)
+      },
+    }
+    registry.register(custom)
+
+    const source = toReadable('buffered via stream')
+    const result = await registry.extractStream(source, { contentType: 'application/x-test' })
+    expect(result.text).toBe('buffered via stream')
+    expect(extractCalled).toBe(true)
+  })
+})
+
+describe('sanitizeArgs', () => {
+  it('passes through positional arguments unchanged', () => {
+    expect(sanitizeArgs(['input.pdf', 'output.txt'])).toEqual(['input.pdf', 'output.txt'])
+  })
+
+  it('passes allowlisted short flags', () => {
+    expect(sanitizeArgs(['-o', 'output.txt'])).toEqual(['-o', 'output.txt'])
+  })
+
+  it('passes allowlisted long flags', () => {
+    expect(sanitizeArgs(['--format', 'json'])).toEqual(['--format', 'json'])
+  })
+
+  it('rejects disallowed flags', () => {
+    expect(() => sanitizeArgs(['--exec', 'rm -rf /'])).toThrow('disallowed argument')
+  })
+
+  it('rejects unknown short flags', () => {
+    expect(() => sanitizeArgs(['-e', 'evil'])).toThrow('disallowed argument')
+  })
+
+  it('handles empty input', () => {
+    expect(sanitizeArgs([])).toEqual([])
+  })
+
+  it('handles mixed allowed and positional args', () => {
+    expect(sanitizeArgs(['file.pdf', '-q', '--output', 'out.txt'])).toEqual([
+      'file.pdf',
+      '-q',
+      '--output',
+      'out.txt',
+    ])
+  })
+})
+
+describe('security constants', () => {
+  it('defines MAX_DECOMPRESSION_RATIO as 100', () => {
+    expect(MAX_DECOMPRESSION_RATIO).toBe(100)
+  })
+
+  it('defines MAX_EXTRACTED_FILES as 1000', () => {
+    expect(MAX_EXTRACTED_FILES).toBe(1000)
+  })
+})

--- a/sdks/ts/memory/src/ingest/extractor.ts
+++ b/sdks/ts/memory/src/ingest/extractor.ts
@@ -56,17 +56,41 @@ export const sanitizeArgs = (args: readonly string[]): string[] => {
   return sanitized
 }
 
+/** Identifies a file format by magic bytes at a given offset. */
+export type MagicSignature = {
+  readonly offset: number
+  readonly bytes: Uint8Array
+}
+
+/**
+ * Describes what content types an extractor handles. Used by the
+ * registry for routing and by callers to inspect extractor capabilities
+ * without triggering extraction.
+ */
+export type ExtractorCapability = {
+  readonly extensions: readonly string[]
+  readonly mimeTypes: readonly string[]
+  readonly magicBytes: readonly MagicSignature[]
+  readonly requiresBinary: boolean
+}
+
 /** Options provided to an extractor about the content being processed. */
 export type ExtractOptions = {
   readonly contentType: string
   readonly fileName?: string
+  readonly encoding?: string
   readonly maxBytes?: number
 }
 
 /** The output of an extraction operation. */
 export type ExtractResult = {
   readonly text: string
+  readonly contentType: string
+  readonly encoding: string
   readonly metadata: Readonly<Record<string, string>>
+  readonly pages: number
+  readonly language: string
+  readonly confidence: number
   readonly skipped: boolean
   readonly reason?: string
 }
@@ -91,6 +115,18 @@ export type Extractor = {
   readonly contentTypes: readonly string[]
   /** Human-readable identifier for this extractor. */
   readonly name: string
+  /**
+   * Reports whether this extractor's external dependencies are present
+   * (e.g. PaddleOCR, FFmpeg). Extractors with no external dependencies
+   * always resolve to true.
+   */
+  available(): Promise<boolean>
+  /**
+   * Describes what content types, file extensions, and magic byte
+   * signatures this extractor handles. Used by the registry for routing
+   * and by callers for introspection.
+   */
+  capability(): ExtractorCapability
 }
 
 /**
@@ -144,15 +180,47 @@ export const createPlainTextExtractor = (): Extractor => ({
     const textDecoder = new TextDecoder('utf-8', { fatal: true })
     try {
       const text = textDecoder.decode(raw)
-      return { text, metadata: {}, skipped: false }
+      return {
+        text,
+        contentType: _opts.contentType,
+        encoding: 'UTF-8',
+        metadata: {},
+        pages: 0,
+        language: '',
+        confidence: 0,
+        skipped: false,
+      }
     } catch {
-      return { text: '', metadata: {}, skipped: true, reason: 'invalid utf-8 content' }
+      return {
+        text: '',
+        contentType: _opts.contentType,
+        encoding: '',
+        metadata: {},
+        pages: 0,
+        language: '',
+        confidence: 0,
+        skipped: true,
+        reason: 'invalid utf-8 content',
+      }
     }
   },
 
   async extractStream(source: Readable, opts: ExtractOptions): Promise<ExtractResult> {
     const raw = await bufferStream(source, opts.maxBytes)
     return this.extract(raw, opts)
+  },
+
+  async available(): Promise<boolean> {
+    return true
+  },
+
+  capability(): ExtractorCapability {
+    return {
+      extensions: ['.txt', '.text', '.log', '.md', '.markdown', '.csv', '.yaml', '.yml', '.json'],
+      mimeTypes: this.contentTypes,
+      magicBytes: [],
+      requiresBinary: false,
+    }
   },
 })
 
@@ -216,7 +284,12 @@ export const createExtractorRegistry = (): ExtractorRegistry => {
       if (ext === undefined) {
         return {
           text: '',
+          contentType: opts.contentType,
+          encoding: '',
           metadata: {},
+          pages: 0,
+          language: '',
+          confidence: 0,
           skipped: true,
           reason: `unsupported content type: ${opts.contentType}`,
         }
@@ -233,7 +306,12 @@ export const createExtractorRegistry = (): ExtractorRegistry => {
       if (ext === undefined) {
         return {
           text: '',
+          contentType: opts.contentType,
+          encoding: '',
           metadata: {},
+          pages: 0,
+          language: '',
+          confidence: 0,
           skipped: true,
           reason: `unsupported content type: ${opts.contentType}`,
         }
@@ -246,4 +324,130 @@ export const createExtractorRegistry = (): ExtractorRegistry => {
   registry.register(createPlainTextExtractor())
 
   return registry
+}
+
+/**
+ * Detect the character encoding of raw bytes. Returns the encoding name
+ * (e.g. "UTF-8", "ISO-8859-1", "Shift_JIS"). Uses heuristic analysis:
+ * BOM markers first, then UTF-8 validation, then byte frequency patterns.
+ */
+export const detectEncoding = (raw: Buffer): string => {
+  if (raw.length === 0) return 'UTF-8'
+
+  // Check for BOM markers.
+  if (raw.length >= 3 && raw[0] === 0xef && raw[1] === 0xbb && raw[2] === 0xbf) {
+    return 'UTF-8'
+  }
+  if (raw.length >= 2 && raw[0] === 0xfe && raw[1] === 0xff) {
+    return 'UTF-16BE'
+  }
+  if (raw.length >= 2 && raw[0] === 0xff && raw[1] === 0xfe) {
+    return 'UTF-16LE'
+  }
+
+  // Valid UTF-8 check via TextDecoder.
+  try {
+    const decoder = new TextDecoder('utf-8', { fatal: true })
+    decoder.decode(raw)
+    return 'UTF-8'
+  } catch {
+    // Not valid UTF-8; fall through to heuristics.
+  }
+
+  return detectByByteFrequency(raw)
+}
+
+/**
+ * Use byte frequency analysis to distinguish common single-byte encodings
+ * when content is not valid UTF-8.
+ */
+const detectByByteFrequency = (raw: Buffer): string => {
+  // First pass: identify Shift_JIS double-byte pairs and track which
+  // positions are consumed.
+  const paired = new Uint8Array(raw.length)
+  let shiftJISPairs = 0
+
+  for (let i = 0; i < raw.length; i++) {
+    const b = raw[i]!
+    if ((b >= 0x81 && b <= 0x9f) || (b >= 0xe0 && b <= 0xef)) {
+      if (i + 1 < raw.length) {
+        const trail = raw[i + 1]!
+        if ((trail >= 0x40 && trail <= 0x7e) || (trail >= 0x80 && trail <= 0xfc)) {
+          paired[i] = 1
+          paired[i + 1] = 1
+          shiftJISPairs++
+          i++
+        }
+      }
+    }
+  }
+
+  // Second pass: count unpaired high bytes and C1 controls.
+  let unpairedHighBytes = 0
+  let unpairedC1Controls = 0
+
+  for (let i = 0; i < raw.length; i++) {
+    const b = raw[i]!
+    if (b >= 0x80 && !paired[i]) {
+      unpairedHighBytes++
+      if (b <= 0x9f) unpairedC1Controls++
+    }
+  }
+
+  // All high bytes consumed by Shift_JIS pairs: Japanese text.
+  if (shiftJISPairs >= 2 && unpairedHighBytes === 0) {
+    return 'Shift_JIS'
+  }
+
+  // Unpaired C1 controls: Windows-1252 (smart quotes, em dashes).
+  if (unpairedC1Controls > 0) {
+    return 'Windows-1252'
+  }
+
+  return 'ISO-8859-1'
+}
+
+/**
+ * Transcode raw bytes from the specified encoding to UTF-8. Returns the
+ * buffer unchanged when the source encoding is already UTF-8. Uses the
+ * built-in TextDecoder which supports all WHATWG encoding labels.
+ *
+ * @throws Error when the encoding is unsupported or content cannot be decoded
+ */
+export const transcodeToUTF8 = (raw: Buffer, fromEncoding: string): Buffer => {
+  const normalised = fromEncoding.trim().toLowerCase()
+  if (normalised === 'utf-8' || normalised === '') return raw
+
+  // Map common encoding names to WHATWG labels understood by TextDecoder.
+  const labelMap: Readonly<Record<string, string>> = {
+    'iso-8859-1': 'iso-8859-1',
+    'latin-1': 'iso-8859-1',
+    'latin1': 'iso-8859-1',
+    'windows-1252': 'windows-1252',
+    'windows-1251': 'windows-1251',
+    'shift_jis': 'shift_jis',
+    'shift-jis': 'shift_jis',
+    'euc-jp': 'euc-jp',
+    'euc-kr': 'euc-kr',
+    'gbk': 'gbk',
+    'gb2312': 'gb2312',
+    'gb18030': 'gb18030',
+    'big5': 'big5',
+    'iso-2022-jp': 'iso-2022-jp',
+    'koi8-r': 'koi8-r',
+    'koi8-u': 'koi8-u',
+    'utf-16be': 'utf-16be',
+    'utf-16le': 'utf-16le',
+  }
+
+  const label = labelMap[normalised] ?? normalised
+
+  try {
+    const decoder = new TextDecoder(label, { fatal: true })
+    const text = decoder.decode(raw)
+    return Buffer.from(text, 'utf-8')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`ingest: transcoding from ${fromEncoding} to UTF-8: ${message}`)
+  }
 }

--- a/sdks/ts/memory/src/ingest/extractor.ts
+++ b/sdks/ts/memory/src/ingest/extractor.ts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extractor registry with content-type routing and streaming support.
+ * Routes incoming content to the appropriate extractor based on MIME type,
+ * with fallback behaviour for unknown types. Mirrors the Go implementation
+ * in go/ingest/extractor.go.
+ */
+
+import type { Readable } from 'node:stream'
+
+/**
+ * Security constants for downstream extractors (Phase 4) that decompress
+ * archives or spawn subprocesses.
+ */
+
+/** Caps the ratio of decompressed-to-compressed size to prevent ZIP bomb attacks. */
+export const MAX_DECOMPRESSION_RATIO = 100
+
+/** Limits the number of files extracted from an archive to prevent resource exhaustion. */
+export const MAX_EXTRACTED_FILES = 1000
+
+/**
+ * Allowlisted flags that may be passed to subprocess extractors. Anything
+ * starting with '-' that is not in this set is rejected.
+ */
+const SANITIZE_ARGS_ALLOWLIST: ReadonlySet<string> = new Set([
+  '-o',
+  '--output',
+  '-f',
+  '--format',
+  '-q',
+  '--quiet',
+  '-v',
+  '--verbose',
+  '--stdin',
+  '--stdout',
+  '--no-color',
+])
+
+/**
+ * Filters a list of command-line arguments, rejecting any flag (starting
+ * with '-') that is not in the hardcoded allowlist. Prevents injection of
+ * dangerous flags into subprocess extractors.
+ *
+ * @throws Error when a disallowed flag is encountered
+ */
+export const sanitizeArgs = (args: readonly string[]): string[] => {
+  const sanitized: string[] = []
+  for (const arg of args) {
+    if (arg.startsWith('-') && !SANITIZE_ARGS_ALLOWLIST.has(arg)) {
+      throw new Error(`ingest: disallowed argument "${arg}"`)
+    }
+    sanitized.push(arg)
+  }
+  return sanitized
+}
+
+/** Options provided to an extractor about the content being processed. */
+export type ExtractOptions = {
+  readonly contentType: string
+  readonly fileName?: string
+  readonly maxBytes?: number
+}
+
+/** The output of an extraction operation. */
+export type ExtractResult = {
+  readonly text: string
+  readonly metadata: Readonly<Record<string, string>>
+  readonly skipped: boolean
+  readonly reason?: string
+}
+
+/**
+ * Contract for content extraction. Implementations declare the MIME types
+ * they handle and provide both buffered and streaming extraction methods.
+ */
+export type Extractor = {
+  /** Converts buffered raw bytes into text content. */
+  extract(raw: Buffer, opts: ExtractOptions, signal?: AbortSignal): Promise<ExtractResult>
+  /**
+   * Processes content from a readable stream. Default implementations
+   * buffer into extract().
+   */
+  extractStream(
+    source: Readable,
+    opts: ExtractOptions,
+    signal?: AbortSignal,
+  ): Promise<ExtractResult>
+  /** The MIME types this extractor handles. */
+  readonly contentTypes: readonly string[]
+  /** Human-readable identifier for this extractor. */
+  readonly name: string
+}
+
+/**
+ * Collects all chunks from a Readable into a Buffer, respecting an
+ * optional byte limit.
+ */
+const bufferStream = async (source: Readable, maxBytes?: number): Promise<Buffer> => {
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+
+  for await (const chunk of source) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array)
+    if (maxBytes !== undefined && maxBytes > 0) {
+      const remaining = maxBytes - totalBytes
+      if (remaining <= 0) break
+      chunks.push(buf.subarray(0, remaining))
+      totalBytes += Math.min(buf.length, remaining)
+      if (totalBytes >= maxBytes) break
+    } else {
+      chunks.push(buf)
+      totalBytes += buf.length
+    }
+  }
+
+  return Buffer.concat(chunks)
+}
+
+/**
+ * PlainTextExtractor handles text/* content types by returning the raw
+ * bytes as UTF-8 text.
+ */
+export const createPlainTextExtractor = (): Extractor => ({
+  name: 'plain-text',
+
+  contentTypes: [
+    'text/plain',
+    'text/markdown',
+    'text/csv',
+    'text/x-yaml',
+    'application/json',
+    'application/x-yaml',
+  ],
+
+  async extract(raw: Buffer, _opts: ExtractOptions): Promise<ExtractResult> {
+    const text = raw.toString('utf8')
+    return {
+      text,
+      metadata: {},
+      skipped: false,
+    }
+  },
+
+  async extractStream(source: Readable, opts: ExtractOptions): Promise<ExtractResult> {
+    const raw = await bufferStream(source, opts.maxBytes)
+    return this.extract(raw, opts)
+  },
+})
+
+/** Normalises a content type by stripping parameters and lowercasing. */
+const normaliseContentType = (ct: string): string => {
+  const semiIdx = ct.indexOf(';')
+  const base = semiIdx >= 0 ? ct.slice(0, semiIdx) : ct
+  return base.trim().toLowerCase()
+}
+
+/**
+ * ExtractorRegistry maps content types to extractors and routes incoming
+ * content to the correct handler. Unknown content types return a skipped
+ * result rather than throwing.
+ */
+export type ExtractorRegistry = {
+  /** Registers an extractor for all content types it declares. */
+  register(ext: Extractor): void
+  /** Routes raw bytes to the appropriate extractor. */
+  extract(raw: Buffer, opts: ExtractOptions, signal?: AbortSignal): Promise<ExtractResult>
+  /** Routes a readable stream to the appropriate extractor. */
+  extractStream(
+    source: Readable,
+    opts: ExtractOptions,
+    signal?: AbortSignal,
+  ): Promise<ExtractResult>
+}
+
+/**
+ * Creates a new ExtractorRegistry pre-loaded with the built-in
+ * PlainTextExtractor for all text/* content types.
+ */
+export const createExtractorRegistry = (): ExtractorRegistry => {
+  const extractors = new Map<string, Extractor>()
+
+  const resolve = (contentType: string): Extractor | undefined => {
+    const normalised = normaliseContentType(contentType)
+
+    // Exact match.
+    const exact = extractors.get(normalised)
+    if (exact !== undefined) return exact
+
+    // Fallback: match text/* family via text/plain.
+    if (normalised.startsWith('text/')) {
+      const fallback = extractors.get('text/plain')
+      if (fallback !== undefined) return fallback
+    }
+
+    return undefined
+  }
+
+  const registry: ExtractorRegistry = {
+    register(ext: Extractor): void {
+      for (const ct of ext.contentTypes) {
+        extractors.set(normaliseContentType(ct), ext)
+      }
+    },
+
+    async extract(raw: Buffer, opts: ExtractOptions, signal?: AbortSignal): Promise<ExtractResult> {
+      const ext = resolve(opts.contentType)
+      if (ext === undefined) {
+        return {
+          text: '',
+          metadata: {},
+          skipped: true,
+          reason: `unsupported content type: ${opts.contentType}`,
+        }
+      }
+      return ext.extract(raw, opts, signal)
+    },
+
+    async extractStream(
+      source: Readable,
+      opts: ExtractOptions,
+      signal?: AbortSignal,
+    ): Promise<ExtractResult> {
+      const ext = resolve(opts.contentType)
+      if (ext === undefined) {
+        return {
+          text: '',
+          metadata: {},
+          skipped: true,
+          reason: `unsupported content type: ${opts.contentType}`,
+        }
+      }
+      return ext.extractStream(source, opts, signal)
+    },
+  }
+
+  // Pre-register the built-in plain text extractor.
+  registry.register(createPlainTextExtractor())
+
+  return registry
+}

--- a/sdks/ts/memory/src/ingest/extractor.ts
+++ b/sdks/ts/memory/src/ingest/extractor.ts
@@ -102,7 +102,13 @@ const bufferStream = async (source: Readable, maxBytes?: number): Promise<Buffer
   let totalBytes = 0
 
   for await (const chunk of source) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array)
+    const buf = Buffer.isBuffer(chunk)
+      ? chunk
+      : typeof chunk === 'string'
+        ? Buffer.from(chunk)
+        : chunk instanceof Uint8Array
+          ? Buffer.from(chunk)
+          : Buffer.from(String(chunk))
     if (maxBytes !== undefined && maxBytes > 0) {
       const remaining = maxBytes - totalBytes
       if (remaining <= 0) break
@@ -135,11 +141,12 @@ export const createPlainTextExtractor = (): Extractor => ({
   ],
 
   async extract(raw: Buffer, _opts: ExtractOptions): Promise<ExtractResult> {
-    const text = raw.toString('utf8')
-    return {
-      text,
-      metadata: {},
-      skipped: false,
+    const textDecoder = new TextDecoder('utf-8', { fatal: true })
+    try {
+      const text = textDecoder.decode(raw)
+      return { text, metadata: {}, skipped: false }
+    } catch {
+      return { text: '', metadata: {}, skipped: true, reason: 'invalid utf-8 content' }
     }
   },
 


### PR DESCRIPTION
## Summary

- `Extractor` interface with `Extract` (buffered) and `ExtractStream` (streaming) in both Go and TS
- `ExtractorRegistry` routes by content type with text/* fallback chain
- `PlainTextExtractor` built-in — validates UTF-8 (rejects invalid bytes, matching Go behaviour)
- Default `ExtractStream` buffers into `Extract` (Phase 4 extractors override for large files)
- Security: `sanitizeArgs` utility, ZIP bomb constants, MaxBytes enforcement
- Thread-safe registry in Go with compile-time interface check

## Test plan

- [ ] 21 Go tests pass (race detector)
- [ ] 26 TS tests pass
- [ ] Registry routes text/plain, text/markdown correctly
- [ ] Unknown content type returns skipped (not error)
- [ ] Invalid UTF-8 detected and rejected in both SDKs
- [ ] MaxBytes truncation works in stream mode

Closes LLE-9783