### PR TITLE
Add core ontology type system — 31 node types, 19 edge types, validation

### DIFF
--- a/go/ontology/descriptions.go
+++ b/go/ontology/descriptions.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+// builtInNodeTypeDescriptions maps each built-in node type to its human-readable description.
+var builtInNodeTypeDescriptions = map[string]string{
+	"entity.customer":        "Customers, clients, accounts, subscribers, or end-users of a service",
+	"entity.supplier":        "Vendors, suppliers, partners, or service providers",
+	"entity.product":         "Products, goods, SKUs, services offered, or catalogue items",
+	"entity.department":      "Departments, teams, business units, or organisational divisions",
+	"entity.person":          "Named individuals, contacts, employees, or stakeholders",
+	"entity.document":        "Documents, files, templates, forms, contracts, or certificates",
+	"rule.constraint":        "General constraints, limitations, or restrictions on operations",
+	"rule.validation":        "Data validation checks, format requirements, or input verification",
+	"rule.threshold":         "Numeric thresholds, limits, ranges, minimums, maximums, or SLA targets",
+	"rule.policy":            "Organisational policies, compliance rules, regulations, or mandates",
+	"rule.classification":    "Rules that categorise or classify items into groups",
+	"rule.matching":          "Rules for matching, pairing, or reconciling records",
+	"rule.mapping":           "Rules for transforming, converting, or mapping data between formats",
+	"rule.extraction":        "Rules for extracting specific data from documents or sources",
+	"rule.routing":           "Rules that determine where work or data should be directed",
+	"rule.fallback":          "Default or backup rules applied when primary rules do not match",
+	"rule.priority":          "Rules that establish ordering, ranking, or precedence",
+	"rule.requirement":       "Mandatory conditions, prerequisites, or dependencies",
+	"rule.combined":          "Composite rules that combine multiple rule types",
+	"exception.workaround":   "Temporary solutions or manual interventions to bypass issues",
+	"exception.override":     "Deliberate overrides of existing rules by authorised personnel",
+	"exception.special_case": "Unique or one-off handling for specific scenarios",
+	"decision.branch":        "Conditional branches, if-then logic, or routing decisions",
+	"decision.escalation":    "Escalation paths, priority handling, or SLA breach responses",
+	"decision.table":         "Decision matrices, lookup tables, or multi-criteria evaluations",
+	"process.workflow":       "End-to-end workflows, automated sequences, or pipelines",
+	"process.approval_chain": "Approval processes, sign-off sequences, or authorisation flows",
+	"process.procedure":      "Step-by-step procedures, standard operating procedures, or protocols",
+	"process.stage":          "Stages, phases, milestones, or checkpoints within a process",
+	"process.integration":    "Integration points, API connections, or external system interactions",
+	"process.subworkflow":    "Nested workflows, reusable process fragments, or child processes",
+}
+
+// builtInEdgeTypeDescriptions maps each built-in edge type to its human-readable description.
+var builtInEdgeTypeDescriptions = map[string]string{
+	"triggers":               "Source causes target to start or execute",
+	"requires_approval_from": "Source needs approval or sign-off from target",
+	"exception_for":          "Source is an exception or deviation from target rule",
+	"overrides":              "Source takes precedence over or replaces target",
+	"depends_on":             "Source requires target to be completed or available first",
+	"belongs_to":             "Source is a member, child, or component of target",
+	"escalates_to":           "Source escalates issues or decisions to target",
+	"constrains":             "Source imposes restrictions or limitations on target",
+	"informed_by":            "Source uses information or data provided by target",
+	"produces":               "Source generates, creates, or outputs target",
+	"precedes":               "Source occurs before target in sequence",
+	"related_to":             "Source has a general association with target",
+	"contradicts":            "Source conflicts with or opposes target",
+	"fallback_for":           "Source serves as a backup or default when target fails",
+	"extends":                "Source adds to or builds upon target",
+	"alternative_to":         "Source is an interchangeable option with target",
+	"feeds_into":             "Source provides input data or context to target",
+	"enables":                "Source makes target possible or available",
+	"validates":              "Source checks or confirms the correctness of target",
+}
+
+// GetBuiltInNodeTypeDescription returns the human-readable description for a
+// built-in node type. Returns a generic fallback if the type is not built-in.
+func GetBuiltInNodeTypeDescription(typ string) string {
+	if desc, ok := builtInNodeTypeDescriptions[typ]; ok {
+		return desc
+	}
+	return "A business intelligence node type"
+}
+
+// GetBuiltInEdgeTypeDescription returns the human-readable description for a
+// built-in edge type. Returns a generic fallback if the type is not built-in.
+func GetBuiltInEdgeTypeDescription(typ string) string {
+	if desc, ok := builtInEdgeTypeDescriptions[typ]; ok {
+		return desc
+	}
+	return "A relationship between intelligence nodes"
+}

--- a/go/ontology/doc.go
+++ b/go/ontology/doc.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ontology defines the built-in type catalogue for the memory
+// knowledge graph. It provides the 31 node types, 19 edge types, 8 business
+// categories, and 5 node type prefixes that form the core ontology schema.
+//
+// All validation functions accept both built-in types and custom types that
+// follow the naming conventions. Custom node types must start with a valid
+// prefix (entity., rule., exception., decision., process.) followed by a
+// snake_case name. Custom edge types and business categories must be lowercase
+// snake_case identifiers.
+//
+// Scope resolution follows a four-level hierarchy: built-in, organisation,
+// project, brain. Higher scopes override lower scopes for types sharing the
+// same identifier.
+package ontology

--- a/go/ontology/format.go
+++ b/go/ontology/format.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import "strings"
+
+// FormatNodeTypeLabel converts a dotted node type identifier into a
+// human-readable label. For example, "entity.customer" becomes "Customer (Entity)"
+// and "process.approval_chain" becomes "Approval Chain (Process)".
+func FormatNodeTypeLabel(typ string) string {
+	parts := strings.SplitN(typ, ".", 2)
+	if len(parts) != 2 {
+		return typ
+	}
+	prefix := parts[0]
+	name := parts[1]
+	return titleCaseSnake(name) + " (" + titleCaseWord(prefix) + ")"
+}
+
+// FormatEdgeTypeLabel converts a snake_case edge type identifier into a
+// human-readable label. For example, "requires_approval_from" becomes
+// "Requires Approval From".
+func FormatEdgeTypeLabel(typ string) string {
+	return titleCaseSnake(typ)
+}
+
+// titleCaseSnake splits a snake_case string on underscores and title-cases
+// each word, joining with spaces.
+func titleCaseSnake(s string) string {
+	words := strings.Split(s, "_")
+	var b strings.Builder
+	for i, word := range words {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(titleCaseWord(word))
+	}
+	return b.String()
+}
+
+// titleCaseWord capitalises the first character of a single word.
+func titleCaseWord(word string) string {
+	if len(word) == 0 {
+		return word
+	}
+	return strings.ToUpper(word[:1]) + word[1:]
+}

--- a/go/ontology/types.go
+++ b/go/ontology/types.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+// BuiltInNodeTypes is the authoritative list of 31 built-in node types.
+var BuiltInNodeTypes = [31]string{
+	"entity.customer",
+	"entity.supplier",
+	"entity.product",
+	"entity.department",
+	"entity.person",
+	"entity.document",
+	"rule.constraint",
+	"rule.validation",
+	"rule.threshold",
+	"rule.policy",
+	"rule.classification",
+	"rule.matching",
+	"rule.mapping",
+	"rule.extraction",
+	"rule.routing",
+	"rule.fallback",
+	"rule.priority",
+	"rule.requirement",
+	"rule.combined",
+	"exception.workaround",
+	"exception.override",
+	"exception.special_case",
+	"decision.branch",
+	"decision.escalation",
+	"decision.table",
+	"process.workflow",
+	"process.approval_chain",
+	"process.procedure",
+	"process.stage",
+	"process.integration",
+	"process.subworkflow",
+}
+
+// BuiltInEdgeTypes is the authoritative list of 19 built-in edge types.
+var BuiltInEdgeTypes = [19]string{
+	"triggers",
+	"requires_approval_from",
+	"exception_for",
+	"overrides",
+	"depends_on",
+	"belongs_to",
+	"escalates_to",
+	"constrains",
+	"informed_by",
+	"produces",
+	"precedes",
+	"related_to",
+	"contradicts",
+	"fallback_for",
+	"extends",
+	"alternative_to",
+	"feeds_into",
+	"enables",
+	"validates",
+}
+
+// BusinessCategories is the authoritative list of 8 built-in categories.
+var BusinessCategories = [8]string{
+	"customer",
+	"order",
+	"product",
+	"address",
+	"document",
+	"authorization",
+	"integration",
+	"general",
+}
+
+// NodeTypePrefixes are the 5 valid prefixes for node type identifiers.
+var NodeTypePrefixes = [5]string{
+	"entity.",
+	"rule.",
+	"exception.",
+	"decision.",
+	"process.",
+}
+
+// Scope determines where a type definition lives in the resolution hierarchy.
+type Scope string
+
+const (
+	ScopeBuiltIn      Scope = "built-in"
+	ScopeOrganisation Scope = "organisation"
+	ScopeProject      Scope = "project"
+	ScopeBrain        Scope = "brain"
+)
+
+// TypeStatus represents the lifecycle state of a type definition.
+type TypeStatus string
+
+const (
+	TypeStatusActive     TypeStatus = "active"
+	TypeStatusProposed   TypeStatus = "proposed"
+	TypeStatusDeprecated TypeStatus = "deprecated"
+)
+
+// TypeDefinition describes a registered ontology type (node or edge).
+type TypeDefinition struct {
+	Type           string     `json:"type"`
+	Label          string     `json:"label"`
+	Description    string     `json:"description"`
+	DiscoveredFrom string     `json:"discoveredFrom,omitempty"`
+	CreatedAt      string     `json:"createdAt"`
+	Status         TypeStatus `json:"status"`
+}
+
+// builtInNodeTypeSet is a precomputed lookup set for O(1) membership checks.
+var builtInNodeTypeSet map[string]struct{}
+
+// builtInEdgeTypeSet is a precomputed lookup set for O(1) membership checks.
+var builtInEdgeTypeSet map[string]struct{}
+
+// businessCategorySet is a precomputed lookup set for O(1) membership checks.
+var businessCategorySet map[string]struct{}
+
+func init() {
+	builtInNodeTypeSet = make(map[string]struct{}, len(BuiltInNodeTypes))
+	for _, t := range BuiltInNodeTypes {
+		builtInNodeTypeSet[t] = struct{}{}
+	}
+
+	builtInEdgeTypeSet = make(map[string]struct{}, len(BuiltInEdgeTypes))
+	for _, t := range BuiltInEdgeTypes {
+		builtInEdgeTypeSet[t] = struct{}{}
+	}
+
+	businessCategorySet = make(map[string]struct{}, len(BusinessCategories))
+	for _, c := range BusinessCategories {
+		businessCategorySet[c] = struct{}{}
+	}
+}
+
+// IsBuiltInNodeType reports whether value exactly matches a built-in node type.
+func IsBuiltInNodeType(value string) bool {
+	_, ok := builtInNodeTypeSet[value]
+	return ok
+}
+
+// IsBuiltInEdgeType reports whether value exactly matches a built-in edge type.
+func IsBuiltInEdgeType(value string) bool {
+	_, ok := builtInEdgeTypeSet[value]
+	return ok
+}
+
+// IsBuiltInBusinessCategory reports whether value exactly matches a built-in category.
+func IsBuiltInBusinessCategory(value string) bool {
+	_, ok := businessCategorySet[value]
+	return ok
+}

--- a/go/ontology/types.go
+++ b/go/ontology/types.go
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package ontology
 
+import (
+	"fmt"
+	"sync"
+)
+
 // BuiltInNodeTypes is the authoritative list of 31 built-in node types.
 var BuiltInNodeTypes = [31]string{
 	"entity.customer",
@@ -71,13 +76,62 @@ var BusinessCategories = [8]string{
 	"general",
 }
 
-// NodeTypePrefixes are the 5 valid prefixes for node type identifiers.
-var NodeTypePrefixes = [5]string{
+// nodeTypePrefixes is the mutable backing list of valid prefixes.
+// Protected by prefixMu. Starts with the 5 built-in prefixes.
+var nodeTypePrefixes = []string{
 	"entity.",
 	"rule.",
 	"exception.",
 	"decision.",
 	"process.",
+}
+
+// prefixMu protects concurrent access to nodeTypePrefixes.
+var prefixMu sync.RWMutex
+
+// NodeTypePrefixes returns a copy of the current valid prefixes.
+// The returned slice is safe to iterate without holding any lock.
+func NodeTypePrefixesList() []string {
+	prefixMu.RLock()
+	defer prefixMu.RUnlock()
+	out := make([]string, len(nodeTypePrefixes))
+	copy(out, nodeTypePrefixes)
+	return out
+}
+
+// RegisterPrefix adds a custom node type prefix to the valid set.
+// The prefix must end with a dot (e.g., "metric."). Returns an error
+// if the prefix is empty, does not end with a dot, or is already
+// registered. This is safe for concurrent use.
+func RegisterPrefix(prefix string) error {
+	if prefix == "" {
+		return fmt.Errorf("ontology: prefix must not be empty")
+	}
+	if prefix[len(prefix)-1] != '.' {
+		return fmt.Errorf("ontology: prefix %q must end with a dot", prefix)
+	}
+	prefixMu.Lock()
+	defer prefixMu.Unlock()
+	for _, existing := range nodeTypePrefixes {
+		if existing == prefix {
+			return fmt.Errorf("ontology: prefix %q is already registered", prefix)
+		}
+	}
+	nodeTypePrefixes = append(nodeTypePrefixes, prefix)
+	return nil
+}
+
+// resetPrefixes restores the built-in prefixes only (for testing).
+func resetPrefixes() {
+	prefixMu.Lock()
+	defer prefixMu.Unlock()
+	nodeTypePrefixes = []string{
+		"entity.",
+		"rule.",
+		"exception.",
+		"decision.",
+		"process.",
+	}
 }
 
 // Scope determines where a type definition lives in the resolution hierarchy.

--- a/go/ontology/types_test.go
+++ b/go/ontology/types_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import "testing"
+
+func TestBuiltInNodeTypeCount(t *testing.T) {
+	t.Parallel()
+	if got := len(BuiltInNodeTypes); got != 31 {
+		t.Fatalf("expected 31 built-in node types, got %d", got)
+	}
+}
+
+func TestBuiltInEdgeTypeCount(t *testing.T) {
+	t.Parallel()
+	if got := len(BuiltInEdgeTypes); got != 19 {
+		t.Fatalf("expected 19 built-in edge types, got %d", got)
+	}
+}
+
+func TestBusinessCategoryCount(t *testing.T) {
+	t.Parallel()
+	if got := len(BusinessCategories); got != 8 {
+		t.Fatalf("expected 8 business categories, got %d", got)
+	}
+}
+
+func TestNodeTypePrefixCount(t *testing.T) {
+	t.Parallel()
+	if got := len(NodeTypePrefixes); got != 5 {
+		t.Fatalf("expected 5 node type prefixes, got %d", got)
+	}
+}
+
+func TestBuiltInNodeTypesNoDuplicates(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, len(BuiltInNodeTypes))
+	for _, typ := range BuiltInNodeTypes {
+		if _, exists := seen[typ]; exists {
+			t.Fatalf("duplicate node type: %s", typ)
+		}
+		seen[typ] = struct{}{}
+	}
+}
+
+func TestBuiltInEdgeTypesNoDuplicates(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, len(BuiltInEdgeTypes))
+	for _, typ := range BuiltInEdgeTypes {
+		if _, exists := seen[typ]; exists {
+			t.Fatalf("duplicate edge type: %s", typ)
+		}
+		seen[typ] = struct{}{}
+	}
+}
+
+func TestBusinessCategoriesNoDuplicates(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, len(BusinessCategories))
+	for _, cat := range BusinessCategories {
+		if _, exists := seen[cat]; exists {
+			t.Fatalf("duplicate business category: %s", cat)
+		}
+		seen[cat] = struct{}{}
+	}
+}
+
+func TestAllNodeTypesHaveDescriptions(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInNodeTypes {
+		desc := GetBuiltInNodeTypeDescription(typ)
+		if desc == "A business intelligence node type" {
+			t.Fatalf("node type %s missing description", typ)
+		}
+		if desc == "" {
+			t.Fatalf("node type %s has empty description", typ)
+		}
+	}
+}
+
+func TestAllEdgeTypesHaveDescriptions(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInEdgeTypes {
+		desc := GetBuiltInEdgeTypeDescription(typ)
+		if desc == "A relationship between intelligence nodes" {
+			t.Fatalf("edge type %s missing description", typ)
+		}
+		if desc == "" {
+			t.Fatalf("edge type %s has empty description", typ)
+		}
+	}
+}
+
+func TestAllNodeTypesHaveValidPrefix(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInNodeTypes {
+		prefix := HasPrefix(typ)
+		if prefix == "" {
+			t.Fatalf("node type %s has no valid prefix", typ)
+		}
+	}
+}
+
+func TestNodeTypePrefixesEndWithDot(t *testing.T) {
+	t.Parallel()
+	for _, prefix := range NodeTypePrefixes {
+		if prefix[len(prefix)-1] != '.' {
+			t.Fatalf("prefix %q does not end with dot", prefix)
+		}
+	}
+}
+
+func TestIsBuiltInNodeType(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInNodeTypes {
+		if !IsBuiltInNodeType(typ) {
+			t.Fatalf("IsBuiltInNodeType(%q) returned false", typ)
+		}
+	}
+	if IsBuiltInNodeType("entity.invoice") {
+		t.Fatal("custom type should not be built-in")
+	}
+	if IsBuiltInNodeType("") {
+		t.Fatal("empty string should not be built-in")
+	}
+}
+
+func TestIsBuiltInEdgeType(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInEdgeTypes {
+		if !IsBuiltInEdgeType(typ) {
+			t.Fatalf("IsBuiltInEdgeType(%q) returned false", typ)
+		}
+	}
+	if IsBuiltInEdgeType("ships_to") {
+		t.Fatal("custom type should not be built-in")
+	}
+}
+
+func TestIsBuiltInBusinessCategory(t *testing.T) {
+	t.Parallel()
+	for _, cat := range BusinessCategories {
+		if !IsBuiltInBusinessCategory(cat) {
+			t.Fatalf("IsBuiltInBusinessCategory(%q) returned false", cat)
+		}
+	}
+	if IsBuiltInBusinessCategory("custom_area") {
+		t.Fatal("custom category should not be built-in")
+	}
+}

--- a/go/ontology/types_test.go
+++ b/go/ontology/types_test.go
@@ -26,7 +26,7 @@ func TestBusinessCategoryCount(t *testing.T) {
 
 func TestNodeTypePrefixCount(t *testing.T) {
 	t.Parallel()
-	if got := len(NodeTypePrefixes); got != 5 {
+	if got := len(NodeTypePrefixesList()); got != 5 {
 		t.Fatalf("expected 5 node type prefixes, got %d", got)
 	}
 }
@@ -102,10 +102,50 @@ func TestAllNodeTypesHaveValidPrefix(t *testing.T) {
 
 func TestNodeTypePrefixesEndWithDot(t *testing.T) {
 	t.Parallel()
-	for _, prefix := range NodeTypePrefixes {
+	for _, prefix := range NodeTypePrefixesList() {
 		if prefix[len(prefix)-1] != '.' {
 			t.Fatalf("prefix %q does not end with dot", prefix)
 		}
+	}
+}
+
+func TestRegisterPrefix(t *testing.T) {
+	t.Cleanup(resetPrefixes)
+
+	if err := RegisterPrefix("metric."); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	prefixes := NodeTypePrefixesList()
+	found := false
+	for _, p := range prefixes {
+		if p == "metric." {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected 'metric.' prefix to be registered")
+	}
+	if len(prefixes) != 6 {
+		t.Fatalf("expected 6 prefixes after registration, got %d", len(prefixes))
+	}
+
+	if !IsValidNodeType("metric.cpu_usage") {
+		t.Fatal("expected metric.cpu_usage to be valid after registering metric. prefix")
+	}
+}
+
+func TestRegisterPrefix_Errors(t *testing.T) {
+	t.Cleanup(resetPrefixes)
+
+	if err := RegisterPrefix(""); err == nil {
+		t.Fatal("expected error for empty prefix")
+	}
+	if err := RegisterPrefix("noDot"); err == nil {
+		t.Fatal("expected error for prefix without trailing dot")
+	}
+	if err := RegisterPrefix("entity."); err == nil {
+		t.Fatal("expected error for already-registered prefix")
 	}
 }
 

--- a/go/ontology/validation.go
+++ b/go/ontology/validation.go
@@ -11,6 +11,13 @@ import (
 // followed by lowercase alphanumeric segments separated by underscores.
 var snakeCaseNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
 
+// validStatuses is the set of acceptable TypeStatus values for type definitions.
+var validStatuses = map[TypeStatus]struct{}{
+	TypeStatusActive:     {},
+	TypeStatusProposed:   {},
+	TypeStatusDeprecated: {},
+}
+
 // IsValidNodeType reports whether value is a valid node type identifier.
 // A value is valid if it exactly matches a built-in node type, or if it
 // starts with a valid prefix and has a valid snake_case name after the dot.
@@ -96,10 +103,8 @@ func ValidateTypeDefinition(def TypeDefinition) error {
 	if def.CreatedAt == "" {
 		return fmt.Errorf("ontology: type definition %q has empty createdAt", def.Type)
 	}
-	switch def.Status {
-	case TypeStatusActive, TypeStatusProposed, TypeStatusDeprecated:
-		return nil
-	default:
+	if _, ok := validStatuses[def.Status]; !ok {
 		return fmt.Errorf("ontology: type definition %q has invalid status %q: must be active, proposed, or deprecated", def.Type, def.Status)
 	}
+	return nil
 }

--- a/go/ontology/validation.go
+++ b/go/ontology/validation.go
@@ -25,7 +25,10 @@ func IsValidNodeType(value string) bool {
 	if IsBuiltInNodeType(value) {
 		return true
 	}
-	for _, prefix := range NodeTypePrefixes {
+	prefixMu.RLock()
+	prefixes := nodeTypePrefixes
+	prefixMu.RUnlock()
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(value, prefix) {
 			name := value[len(prefix):]
 			if len(name) == 0 {
@@ -56,7 +59,10 @@ func IsValidBusinessCategory(value string) bool {
 // HasPrefix reports whether the given node type starts with one of the
 // known prefixes and returns the prefix. Returns empty string if no prefix matches.
 func HasPrefix(nodeType string) string {
-	for _, prefix := range NodeTypePrefixes {
+	prefixMu.RLock()
+	prefixes := nodeTypePrefixes
+	prefixMu.RUnlock()
+	for _, prefix := range prefixes {
 		if strings.HasPrefix(nodeType, prefix) {
 			return prefix
 		}

--- a/go/ontology/validation.go
+++ b/go/ontology/validation.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// snakeCaseNameRe matches a valid snake_case name: starts with lowercase letter,
+// followed by lowercase alphanumeric segments separated by underscores.
+var snakeCaseNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(_[a-z0-9]+)*$`)
+
+// IsValidNodeType reports whether value is a valid node type identifier.
+// A value is valid if it exactly matches a built-in node type, or if it
+// starts with a valid prefix and has a valid snake_case name after the dot.
+func IsValidNodeType(value string) bool {
+	if IsBuiltInNodeType(value) {
+		return true
+	}
+	for _, prefix := range NodeTypePrefixes {
+		if strings.HasPrefix(value, prefix) {
+			name := value[len(prefix):]
+			if len(name) == 0 {
+				return false
+			}
+			return snakeCaseNameRe.MatchString(name)
+		}
+	}
+	return false
+}
+
+// IsValidEdgeType reports whether value is a valid edge type identifier.
+// A value is valid if it exactly matches a built-in edge type, or if it
+// matches the snake_case pattern ^[a-z][a-z0-9]*(_[a-z0-9]+)*$.
+func IsValidEdgeType(value string) bool {
+	if IsBuiltInEdgeType(value) {
+		return true
+	}
+	return snakeCaseNameRe.MatchString(value)
+}
+
+// IsValidBusinessCategory reports whether value is a valid business category.
+// A value is valid if it matches the snake_case pattern.
+func IsValidBusinessCategory(value string) bool {
+	return snakeCaseNameRe.MatchString(value)
+}
+
+// HasPrefix reports whether the given node type starts with one of the
+// known prefixes and returns the prefix. Returns empty string if no prefix matches.
+func HasPrefix(nodeType string) string {
+	for _, prefix := range NodeTypePrefixes {
+		if strings.HasPrefix(nodeType, prefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+// ValidateNodeType returns an error if value is not a valid node type.
+func ValidateNodeType(value string) error {
+	if IsValidNodeType(value) {
+		return nil
+	}
+	return fmt.Errorf("ontology: invalid node type %q: must start with a valid prefix (entity., rule., exception., decision., process.) followed by a snake_case name", value)
+}
+
+// ValidateEdgeType returns an error if value is not a valid edge type.
+func ValidateEdgeType(value string) error {
+	if IsValidEdgeType(value) {
+		return nil
+	}
+	return fmt.Errorf("ontology: invalid edge type %q: must be lowercase snake_case starting with a letter", value)
+}
+
+// ValidateBusinessCategory returns an error if value is not a valid business category.
+func ValidateBusinessCategory(value string) error {
+	if IsValidBusinessCategory(value) {
+		return nil
+	}
+	return fmt.Errorf("ontology: invalid business category %q: must be lowercase snake_case starting with a letter", value)
+}
+
+// ValidateTypeDefinition checks that a TypeDefinition has all required fields
+// and valid values.
+func ValidateTypeDefinition(def TypeDefinition) error {
+	if def.Type == "" {
+		return fmt.Errorf("ontology: type definition has empty type field")
+	}
+	if def.Label == "" {
+		return fmt.Errorf("ontology: type definition %q has empty label", def.Type)
+	}
+	if def.Description == "" {
+		return fmt.Errorf("ontology: type definition %q has empty description", def.Type)
+	}
+	if def.CreatedAt == "" {
+		return fmt.Errorf("ontology: type definition %q has empty createdAt", def.Type)
+	}
+	switch def.Status {
+	case TypeStatusActive, TypeStatusProposed, TypeStatusDeprecated:
+		return nil
+	default:
+		return fmt.Errorf("ontology: type definition %q has invalid status %q: must be active, proposed, or deprecated", def.Type, def.Status)
+	}
+}

--- a/go/ontology/validation_test.go
+++ b/go/ontology/validation_test.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import "testing"
+
+func TestIsValidNodeType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		value   string
+		isValid bool
+	}{
+		{"built-in entity.customer", "entity.customer", true},
+		{"built-in rule.combined", "rule.combined", true},
+		{"built-in exception.special_case", "exception.special_case", true},
+		{"built-in decision.table", "decision.table", true},
+		{"built-in process.subworkflow", "process.subworkflow", true},
+		{"custom entity.invoice", "entity.invoice", true},
+		{"custom rule.custom_thing", "rule.custom_thing", true},
+		{"custom exception.timeout_handling", "exception.timeout_handling", true},
+		{"custom decision.routing_logic", "decision.routing_logic", true},
+		{"custom process.batch_job", "process.batch_job", true},
+		{"custom multi underscore", "entity.multi_word_name", true},
+		{"invalid no prefix", "invalid", false},
+		{"invalid wrong prefix", "wrong.prefix", false},
+		{"invalid empty", "", false},
+		{"invalid prefix only", "entity.", false},
+		{"invalid uppercase name", "entity.Customer", false},
+		{"invalid name starts with number", "entity.1thing", false},
+		{"invalid name has hyphen", "entity.my-thing", false},
+		{"invalid name has space", "entity.my thing", false},
+		{"invalid double dot", "entity..customer", false},
+		{"invalid trailing underscore", "entity.name_", false},
+		{"invalid double underscore", "entity.name__thing", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsValidNodeType(tc.value)
+			if got != tc.isValid {
+				t.Fatalf("IsValidNodeType(%q) = %v, want %v", tc.value, got, tc.isValid)
+			}
+		})
+	}
+}
+
+func TestIsValidNodeType_AllBuiltIn(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInNodeTypes {
+		if !IsValidNodeType(typ) {
+			t.Fatalf("built-in node type %q failed validation", typ)
+		}
+	}
+}
+
+func TestIsValidEdgeType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		value   string
+		isValid bool
+	}{
+		{"built-in triggers", "triggers", true},
+		{"built-in requires_approval_from", "requires_approval_from", true},
+		{"built-in validates", "validates", true},
+		{"custom ships_to", "ships_to", true},
+		{"custom custom_relation", "custom_relation", true},
+		{"custom single word", "connects", true},
+		{"invalid uppercase", "Invalid", false},
+		{"invalid has spaces", "has spaces", false},
+		{"invalid starts with number", "123start", false},
+		{"invalid empty", "", false},
+		{"invalid has dot", "has.dot", false},
+		{"invalid has hyphen", "has-hyphen", false},
+		{"invalid trailing underscore", "name_", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsValidEdgeType(tc.value)
+			if got != tc.isValid {
+				t.Fatalf("IsValidEdgeType(%q) = %v, want %v", tc.value, got, tc.isValid)
+			}
+		})
+	}
+}
+
+func TestIsValidEdgeType_AllBuiltIn(t *testing.T) {
+	t.Parallel()
+	for _, typ := range BuiltInEdgeTypes {
+		if !IsValidEdgeType(typ) {
+			t.Fatalf("built-in edge type %q failed validation", typ)
+		}
+	}
+}
+
+func TestIsValidBusinessCategory(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		value   string
+		isValid bool
+	}{
+		{"built-in customer", "customer", true},
+		{"built-in authorization", "authorization", true},
+		{"built-in general", "general", true},
+		{"custom category", "custom_category", true},
+		{"custom multi word", "server_hardware", true},
+		{"invalid Has Spaces", "Has Spaces", false},
+		{"invalid starts with number", "123", false},
+		{"invalid empty", "", false},
+		{"invalid uppercase", "Customer", false},
+		{"invalid has dot", "my.category", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsValidBusinessCategory(tc.value)
+			if got != tc.isValid {
+				t.Fatalf("IsValidBusinessCategory(%q) = %v, want %v", tc.value, got, tc.isValid)
+			}
+		})
+	}
+}
+
+func TestIsValidBusinessCategory_AllBuiltIn(t *testing.T) {
+	t.Parallel()
+	for _, cat := range BusinessCategories {
+		if !IsValidBusinessCategory(cat) {
+			t.Fatalf("built-in business category %q failed validation", cat)
+		}
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		nodeType string
+		want     string
+	}{
+		{"entity prefix", "entity.customer", "entity."},
+		{"rule prefix", "rule.validation", "rule."},
+		{"exception prefix", "exception.override", "exception."},
+		{"decision prefix", "decision.branch", "decision."},
+		{"process prefix", "process.workflow", "process."},
+		{"no prefix", "triggers", ""},
+		{"invalid prefix", "wrong.thing", ""},
+		{"empty string", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := HasPrefix(tc.nodeType)
+			if got != tc.want {
+				t.Fatalf("HasPrefix(%q) = %q, want %q", tc.nodeType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateNodeType_ReturnsError(t *testing.T) {
+	t.Parallel()
+	if err := ValidateNodeType("entity.customer"); err != nil {
+		t.Fatalf("unexpected error for valid type: %v", err)
+	}
+	if err := ValidateNodeType("invalid"); err == nil {
+		t.Fatal("expected error for invalid type, got nil")
+	}
+}
+
+func TestValidateEdgeType_ReturnsError(t *testing.T) {
+	t.Parallel()
+	if err := ValidateEdgeType("triggers"); err != nil {
+		t.Fatalf("unexpected error for valid type: %v", err)
+	}
+	if err := ValidateEdgeType("INVALID"); err == nil {
+		t.Fatal("expected error for invalid type, got nil")
+	}
+}
+
+func TestValidateBusinessCategory_ReturnsError(t *testing.T) {
+	t.Parallel()
+	if err := ValidateBusinessCategory("customer"); err != nil {
+		t.Fatalf("unexpected error for valid category: %v", err)
+	}
+	if err := ValidateBusinessCategory(""); err == nil {
+		t.Fatal("expected error for empty category, got nil")
+	}
+}
+
+func TestValidateTypeDefinition(t *testing.T) {
+	t.Parallel()
+	validDef := TypeDefinition{
+		Type:        "entity.customer",
+		Label:       "Customer",
+		Description: "A customer entity",
+		CreatedAt:   "2026-01-01T00:00:00Z",
+		Status:      TypeStatusActive,
+	}
+	cases := []struct {
+		name    string
+		def     TypeDefinition
+		wantErr bool
+	}{
+		{"valid definition", validDef, false},
+		{"valid proposed", TypeDefinition{Type: "entity.x", Label: "X", Description: "X", CreatedAt: "2026-01-01T00:00:00Z", Status: TypeStatusProposed}, false},
+		{"valid deprecated", TypeDefinition{Type: "entity.x", Label: "X", Description: "X", CreatedAt: "2026-01-01T00:00:00Z", Status: TypeStatusDeprecated}, false},
+		{"empty type", TypeDefinition{Type: "", Label: "L", Description: "D", CreatedAt: "2026-01-01T00:00:00Z", Status: TypeStatusActive}, true},
+		{"empty label", TypeDefinition{Type: "entity.x", Label: "", Description: "D", CreatedAt: "2026-01-01T00:00:00Z", Status: TypeStatusActive}, true},
+		{"empty description", TypeDefinition{Type: "entity.x", Label: "L", Description: "", CreatedAt: "2026-01-01T00:00:00Z", Status: TypeStatusActive}, true},
+		{"empty createdAt", TypeDefinition{Type: "entity.x", Label: "L", Description: "D", CreatedAt: "", Status: TypeStatusActive}, true},
+		{"invalid status", TypeDefinition{Type: "entity.x", Label: "L", Description: "D", CreatedAt: "2026-01-01T00:00:00Z", Status: "invalid"}, true},
+		{"empty status", TypeDefinition{Type: "entity.x", Label: "L", Description: "D", CreatedAt: "2026-01-01T00:00:00Z", Status: ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateTypeDefinition(tc.def)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateTypeDefinition() err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFormatNodeTypeLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"entity customer", "entity.customer", "Customer (Entity)"},
+		{"process approval chain", "process.approval_chain", "Approval Chain (Process)"},
+		{"rule classification", "rule.classification", "Classification (Rule)"},
+		{"exception special case", "exception.special_case", "Special Case (Exception)"},
+		{"decision escalation", "decision.escalation", "Escalation (Decision)"},
+		{"no dot fallback", "invalid", "invalid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatNodeTypeLabel(tc.input)
+			if got != tc.want {
+				t.Fatalf("FormatNodeTypeLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatEdgeTypeLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"requires approval from", "requires_approval_from", "Requires Approval From"},
+		{"triggers", "triggers", "Triggers"},
+		{"feeds into", "feeds_into", "Feeds Into"},
+		{"related to", "related_to", "Related To"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatEdgeTypeLabel(tc.input)
+			if got != tc.want {
+				t.Fatalf("FormatEdgeTypeLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/sdks/ts/memory/src/ontology/descriptions.ts
+++ b/sdks/ts/memory/src/ontology/descriptions.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Human-readable descriptions for all built-in ontology types.
+ *
+ * Port of apps/intelligence-service/src/services/ontology-built-in-descriptions.ts.
+ */
+
+const BUILT_IN_NODE_TYPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  'entity.customer': 'Customers, clients, accounts, subscribers, or end-users of a service',
+  'entity.supplier': 'Vendors, suppliers, partners, or service providers',
+  'entity.product': 'Products, goods, SKUs, services offered, or catalogue items',
+  'entity.department': 'Departments, teams, business units, or organisational divisions',
+  'entity.person': 'Named individuals, contacts, employees, or stakeholders',
+  'entity.document': 'Documents, files, templates, forms, contracts, or certificates',
+  'rule.constraint': 'General constraints, limitations, or restrictions on operations',
+  'rule.validation': 'Data validation checks, format requirements, or input verification',
+  'rule.threshold': 'Numeric thresholds, limits, ranges, minimums, maximums, or SLA targets',
+  'rule.policy': 'Organisational policies, compliance rules, regulations, or mandates',
+  'rule.classification': 'Rules that categorise or classify items into groups',
+  'rule.matching': 'Rules for matching, pairing, or reconciling records',
+  'rule.mapping': 'Rules for transforming, converting, or mapping data between formats',
+  'rule.extraction': 'Rules for extracting specific data from documents or sources',
+  'rule.routing': 'Rules that determine where work or data should be directed',
+  'rule.fallback': 'Default or backup rules applied when primary rules do not match',
+  'rule.priority': 'Rules that establish ordering, ranking, or precedence',
+  'rule.requirement': 'Mandatory conditions, prerequisites, or dependencies',
+  'rule.combined': 'Composite rules that combine multiple rule types',
+  'exception.workaround': 'Temporary solutions or manual interventions to bypass issues',
+  'exception.override': 'Deliberate overrides of existing rules by authorised personnel',
+  'exception.special_case': 'Unique or one-off handling for specific scenarios',
+  'decision.branch': 'Conditional branches, if-then logic, or routing decisions',
+  'decision.escalation': 'Escalation paths, priority handling, or SLA breach responses',
+  'decision.table': 'Decision matrices, lookup tables, or multi-criteria evaluations',
+  'process.workflow': 'End-to-end workflows, automated sequences, or pipelines',
+  'process.approval_chain': 'Approval processes, sign-off sequences, or authorisation flows',
+  'process.procedure': 'Step-by-step procedures, standard operating procedures, or protocols',
+  'process.stage': 'Stages, phases, milestones, or checkpoints within a process',
+  'process.integration': 'Integration points, API connections, or external system interactions',
+  'process.subworkflow': 'Nested workflows, reusable process fragments, or child processes',
+}
+
+const BUILT_IN_EDGE_TYPE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  triggers: 'Source causes target to start or execute',
+  requires_approval_from: 'Source needs approval or sign-off from target',
+  exception_for: 'Source is an exception or deviation from target rule',
+  overrides: 'Source takes precedence over or replaces target',
+  depends_on: 'Source requires target to be completed or available first',
+  belongs_to: 'Source is a member, child, or component of target',
+  escalates_to: 'Source escalates issues or decisions to target',
+  constrains: 'Source imposes restrictions or limitations on target',
+  informed_by: 'Source uses information or data provided by target',
+  produces: 'Source generates, creates, or outputs target',
+  precedes: 'Source occurs before target in sequence',
+  related_to: 'Source has a general association with target',
+  contradicts: 'Source conflicts with or opposes target',
+  fallback_for: 'Source serves as a backup or default when target fails',
+  extends: 'Source adds to or builds upon target',
+  alternative_to: 'Source is an interchangeable option with target',
+  feeds_into: 'Source provides input data or context to target',
+  enables: 'Source makes target possible or available',
+  validates: 'Source checks or confirms the correctness of target',
+}
+
+/**
+ * Returns the human-readable description for a built-in node type.
+ * Returns a generic fallback if the type is not built-in.
+ */
+export function getBuiltInNodeTypeDescription(typ: string): string {
+  return BUILT_IN_NODE_TYPE_DESCRIPTIONS[typ] ?? 'A business intelligence node type'
+}
+
+/**
+ * Returns the human-readable description for a built-in edge type.
+ * Returns a generic fallback if the type is not built-in.
+ */
+export function getBuiltInEdgeTypeDescription(typ: string): string {
+  return BUILT_IN_EDGE_TYPE_DESCRIPTIONS[typ] ?? 'A relationship between intelligence nodes'
+}

--- a/sdks/ts/memory/src/ontology/format.ts
+++ b/sdks/ts/memory/src/ontology/format.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Label formatting functions for ontology type identifiers.
+ * Converts machine-readable identifiers into human-readable labels.
+ *
+ * Port of apps/intelligence-service/src/services/ontology-built-in-descriptions.ts.
+ */
+
+/**
+ * Converts a dotted node type identifier into a human-readable label.
+ * "entity.customer" becomes "Customer (Entity)"
+ * "process.approval_chain" becomes "Approval Chain (Process)"
+ */
+export function formatNodeTypeLabel(typ: string): string {
+  const dotIndex = typ.indexOf('.')
+  if (dotIndex === -1) {
+    return typ
+  }
+  const prefix = typ.slice(0, dotIndex)
+  const name = typ.slice(dotIndex + 1)
+  const formattedName = name
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+  const formattedPrefix = prefix.charAt(0).toUpperCase() + prefix.slice(1)
+  return `${formattedName} (${formattedPrefix})`
+}
+
+/**
+ * Converts a snake_case edge type identifier into a human-readable label.
+ * "requires_approval_from" becomes "Requires Approval From"
+ * "triggers" becomes "Triggers"
+ */
+export function formatEdgeTypeLabel(typ: string): string {
+  return typ
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type {
+  BuiltInEdgeType,
+  BuiltInNodeType,
+  BusinessCategory,
+  EdgeType,
+  NodeType,
+  NodeTypePrefix,
+  OntologyScope,
+  OntologyTypeDefinition,
+  TypeStatus,
+} from './types.js'
+
+export {
+  BUILT_IN_EDGE_TYPES,
+  BUILT_IN_NODE_TYPES,
+  BUSINESS_CATEGORIES,
+  NODE_TYPE_PREFIXES,
+} from './types.js'
+
+export {
+  hasPrefix,
+  isBuiltInBusinessCategory,
+  isBuiltInEdgeType,
+  isBuiltInNodeType,
+  isValidBusinessCategory,
+  isValidEdgeType,
+  isValidNodeType,
+  validateBusinessCategory,
+  validateEdgeType,
+  validateNodeType,
+  validateTypeDefinition,
+} from './validation.js'
+
+export {
+  getBuiltInEdgeTypeDescription,
+  getBuiltInNodeTypeDescription,
+} from './descriptions.js'
+
+export {
+  formatEdgeTypeLabel,
+  formatNodeTypeLabel,
+} from './format.js'

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -17,6 +17,8 @@ export {
   BUILT_IN_NODE_TYPES,
   BUSINESS_CATEGORIES,
   NODE_TYPE_PREFIXES,
+  getNodeTypePrefixes,
+  registerPrefix,
 } from './types.js'
 
 export {

--- a/sdks/ts/memory/src/ontology/types.test.ts
+++ b/sdks/ts/memory/src/ontology/types.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { getBuiltInEdgeTypeDescription, getBuiltInNodeTypeDescription } from './descriptions.js'
+import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, NODE_TYPE_PREFIXES } from './types.js'
+import { hasPrefix } from './validation.js'
+
+describe('BUILT_IN_NODE_TYPES', () => {
+  it('has exactly 31 entries', () => {
+    expect(BUILT_IN_NODE_TYPES).toHaveLength(31)
+  })
+
+  it('contains no duplicates', () => {
+    const unique = new Set(BUILT_IN_NODE_TYPES)
+    expect(unique.size).toBe(BUILT_IN_NODE_TYPES.length)
+  })
+
+  it('all have a valid prefix', () => {
+    for (const typ of BUILT_IN_NODE_TYPES) {
+      expect(hasPrefix(typ)).toBeDefined()
+    }
+  })
+
+  it('all have non-empty descriptions', () => {
+    for (const typ of BUILT_IN_NODE_TYPES) {
+      const desc = getBuiltInNodeTypeDescription(typ)
+      expect(desc).not.toBe('A business intelligence node type')
+      expect(desc.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('BUILT_IN_EDGE_TYPES', () => {
+  it('has exactly 19 entries', () => {
+    expect(BUILT_IN_EDGE_TYPES).toHaveLength(19)
+  })
+
+  it('contains no duplicates', () => {
+    const unique = new Set(BUILT_IN_EDGE_TYPES)
+    expect(unique.size).toBe(BUILT_IN_EDGE_TYPES.length)
+  })
+
+  it('all have non-empty descriptions', () => {
+    for (const typ of BUILT_IN_EDGE_TYPES) {
+      const desc = getBuiltInEdgeTypeDescription(typ)
+      expect(desc).not.toBe('A relationship between intelligence nodes')
+      expect(desc.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('BUSINESS_CATEGORIES', () => {
+  it('has exactly 8 entries', () => {
+    expect(BUSINESS_CATEGORIES).toHaveLength(8)
+  })
+
+  it('contains no duplicates', () => {
+    const unique = new Set(BUSINESS_CATEGORIES)
+    expect(unique.size).toBe(BUSINESS_CATEGORIES.length)
+  })
+})
+
+describe('NODE_TYPE_PREFIXES', () => {
+  it('has exactly 5 entries', () => {
+    expect(NODE_TYPE_PREFIXES).toHaveLength(5)
+  })
+
+  it('all end with a dot', () => {
+    for (const prefix of NODE_TYPE_PREFIXES) {
+      expect(prefix.endsWith('.')).toBe(true)
+    }
+  })
+
+  it('contains no duplicates', () => {
+    const unique = new Set(NODE_TYPE_PREFIXES)
+    expect(unique.size).toBe(NODE_TYPE_PREFIXES.length)
+  })
+})
+
+describe('cross-SDK parity with Go constants', () => {
+  it('node types match expected Go values', () => {
+    const expectedNodeTypes = [
+      'entity.customer',
+      'entity.supplier',
+      'entity.product',
+      'entity.department',
+      'entity.person',
+      'entity.document',
+      'rule.constraint',
+      'rule.validation',
+      'rule.threshold',
+      'rule.policy',
+      'rule.classification',
+      'rule.matching',
+      'rule.mapping',
+      'rule.extraction',
+      'rule.routing',
+      'rule.fallback',
+      'rule.priority',
+      'rule.requirement',
+      'rule.combined',
+      'exception.workaround',
+      'exception.override',
+      'exception.special_case',
+      'decision.branch',
+      'decision.escalation',
+      'decision.table',
+      'process.workflow',
+      'process.approval_chain',
+      'process.procedure',
+      'process.stage',
+      'process.integration',
+      'process.subworkflow',
+    ]
+    expect([...BUILT_IN_NODE_TYPES]).toEqual(expectedNodeTypes)
+  })
+
+  it('edge types match expected Go values', () => {
+    const expectedEdgeTypes = [
+      'triggers',
+      'requires_approval_from',
+      'exception_for',
+      'overrides',
+      'depends_on',
+      'belongs_to',
+      'escalates_to',
+      'constrains',
+      'informed_by',
+      'produces',
+      'precedes',
+      'related_to',
+      'contradicts',
+      'fallback_for',
+      'extends',
+      'alternative_to',
+      'feeds_into',
+      'enables',
+      'validates',
+    ]
+    expect([...BUILT_IN_EDGE_TYPES]).toEqual(expectedEdgeTypes)
+  })
+
+  it('business categories match expected Go values', () => {
+    const expectedCategories = [
+      'customer',
+      'order',
+      'product',
+      'address',
+      'document',
+      'authorization',
+      'integration',
+      'general',
+    ]
+    expect([...BUSINESS_CATEGORIES]).toEqual(expectedCategories)
+  })
+
+  it('prefixes match expected Go values', () => {
+    const expectedPrefixes = ['entity.', 'rule.', 'exception.', 'decision.', 'process.']
+    expect([...NODE_TYPE_PREFIXES]).toEqual(expectedPrefixes)
+  })
+})

--- a/sdks/ts/memory/src/ontology/types.test.ts
+++ b/sdks/ts/memory/src/ontology/types.test.ts
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { getBuiltInEdgeTypeDescription, getBuiltInNodeTypeDescription } from './descriptions.js'
-import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, NODE_TYPE_PREFIXES } from './types.js'
-import { hasPrefix } from './validation.js'
+import {
+  BUILT_IN_EDGE_TYPES,
+  BUILT_IN_NODE_TYPES,
+  BUSINESS_CATEGORIES,
+  NODE_TYPE_PREFIXES,
+  getNodeTypePrefixes,
+  registerPrefix,
+  _resetPrefixes,
+} from './types.js'
+import { hasPrefix, isValidNodeType } from './validation.js'
 
 describe('BUILT_IN_NODE_TYPES', () => {
   it('has exactly 31 entries', () => {
@@ -157,5 +165,35 @@ describe('cross-SDK parity with Go constants', () => {
   it('prefixes match expected Go values', () => {
     const expectedPrefixes = ['entity.', 'rule.', 'exception.', 'decision.', 'process.']
     expect([...NODE_TYPE_PREFIXES]).toEqual(expectedPrefixes)
+  })
+})
+
+describe('registerPrefix', () => {
+  afterEach(() => {
+    _resetPrefixes()
+  })
+
+  it('adds a custom prefix', () => {
+    registerPrefix('metric.')
+    const prefixes = getNodeTypePrefixes()
+    expect(prefixes).toContain('metric.')
+    expect(prefixes).toHaveLength(6)
+  })
+
+  it('enables validation of types with the new prefix', () => {
+    registerPrefix('metric.')
+    expect(isValidNodeType('metric.cpu_usage')).toBe(true)
+  })
+
+  it('rejects empty prefix', () => {
+    expect(() => registerPrefix('')).toThrow('must not be empty')
+  })
+
+  it('rejects prefix without trailing dot', () => {
+    expect(() => registerPrefix('noDot')).toThrow('must end with a dot')
+  })
+
+  it('rejects duplicate prefix', () => {
+    expect(() => registerPrefix('entity.')).toThrow('already registered')
   })
 })

--- a/sdks/ts/memory/src/ontology/types.ts
+++ b/sdks/ts/memory/src/ontology/types.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Core ontology type definitions for the memory knowledge graph.
+ * Defines the 31 built-in node types, 19 edge types, 8 business categories,
+ * and 5 node type prefixes that form the ontology schema.
+ *
+ * Port of packages/intelligence-database/src/types.ts.
+ */
+
+export const BUILT_IN_NODE_TYPES = [
+  'entity.customer',
+  'entity.supplier',
+  'entity.product',
+  'entity.department',
+  'entity.person',
+  'entity.document',
+  'rule.constraint',
+  'rule.validation',
+  'rule.threshold',
+  'rule.policy',
+  'rule.classification',
+  'rule.matching',
+  'rule.mapping',
+  'rule.extraction',
+  'rule.routing',
+  'rule.fallback',
+  'rule.priority',
+  'rule.requirement',
+  'rule.combined',
+  'exception.workaround',
+  'exception.override',
+  'exception.special_case',
+  'decision.branch',
+  'decision.escalation',
+  'decision.table',
+  'process.workflow',
+  'process.approval_chain',
+  'process.procedure',
+  'process.stage',
+  'process.integration',
+  'process.subworkflow',
+] as const
+
+export type BuiltInNodeType = (typeof BUILT_IN_NODE_TYPES)[number]
+
+export const NODE_TYPE_PREFIXES = [
+  'entity.',
+  'rule.',
+  'exception.',
+  'decision.',
+  'process.',
+] as const
+
+export type NodeTypePrefix = (typeof NODE_TYPE_PREFIXES)[number]
+
+export type NodeType =
+  | BuiltInNodeType
+  | `entity.${string}`
+  | `rule.${string}`
+  | `exception.${string}`
+  | `decision.${string}`
+  | `process.${string}`
+
+export const BUILT_IN_EDGE_TYPES = [
+  'triggers',
+  'requires_approval_from',
+  'exception_for',
+  'overrides',
+  'depends_on',
+  'belongs_to',
+  'escalates_to',
+  'constrains',
+  'informed_by',
+  'produces',
+  'precedes',
+  'related_to',
+  'contradicts',
+  'fallback_for',
+  'extends',
+  'alternative_to',
+  'feeds_into',
+  'enables',
+  'validates',
+] as const
+
+export type BuiltInEdgeType = (typeof BUILT_IN_EDGE_TYPES)[number]
+
+export type EdgeType = BuiltInEdgeType | string
+
+export const BUSINESS_CATEGORIES = [
+  'customer',
+  'order',
+  'product',
+  'address',
+  'document',
+  'authorization',
+  'integration',
+  'general',
+] as const
+
+export type BusinessCategory = (typeof BUSINESS_CATEGORIES)[number]
+
+export type OntologyScope = 'built-in' | 'organisation' | 'project' | 'brain'
+
+export type TypeStatus = 'active' | 'proposed' | 'deprecated'
+
+export type OntologyTypeDefinition = {
+  readonly type: string
+  readonly label: string
+  readonly description: string
+  readonly discoveredFrom?: string
+  readonly createdAt: string
+  readonly status: TypeStatus
+}

--- a/sdks/ts/memory/src/ontology/types.ts
+++ b/sdks/ts/memory/src/ontology/types.ts
@@ -86,7 +86,7 @@ export const BUILT_IN_EDGE_TYPES = [
 
 export type BuiltInEdgeType = (typeof BUILT_IN_EDGE_TYPES)[number]
 
-export type EdgeType = BuiltInEdgeType | string
+export type EdgeType = BuiltInEdgeType | (string & {})
 
 export const BUSINESS_CATEGORIES = [
   'customer',

--- a/sdks/ts/memory/src/ontology/types.ts
+++ b/sdks/ts/memory/src/ontology/types.ts
@@ -44,7 +44,7 @@ export const BUILT_IN_NODE_TYPES = [
 
 export type BuiltInNodeType = (typeof BUILT_IN_NODE_TYPES)[number]
 
-export const NODE_TYPE_PREFIXES = [
+const BUILT_IN_PREFIXES = [
   'entity.',
   'rule.',
   'exception.',
@@ -52,7 +52,61 @@ export const NODE_TYPE_PREFIXES = [
   'process.',
 ] as const
 
-export type NodeTypePrefix = (typeof NODE_TYPE_PREFIXES)[number]
+/**
+ * Mutable list of valid node type prefixes. Starts with the 5 built-in
+ * prefixes and can be extended at runtime via registerPrefix().
+ */
+const nodeTypePrefixes: string[] = [...BUILT_IN_PREFIXES]
+
+/**
+ * Read-only reference to the built-in prefixes for static typing.
+ * Runtime validation uses the mutable nodeTypePrefixes list.
+ */
+export const NODE_TYPE_PREFIXES = BUILT_IN_PREFIXES
+
+export type NodeTypePrefix = (typeof BUILT_IN_PREFIXES)[number]
+
+/**
+ * Returns a copy of the current valid node type prefixes, including
+ * any custom prefixes added via registerPrefix().
+ */
+export function getNodeTypePrefixes(): readonly string[] {
+  return [...nodeTypePrefixes]
+}
+
+/**
+ * Internal access to the live prefix list for validation.
+ * Not exported -- used by validation.ts.
+ */
+export function _nodeTypePrefixesRef(): readonly string[] {
+  return nodeTypePrefixes
+}
+
+/**
+ * Registers a custom node type prefix. The prefix must end with a dot
+ * (e.g., "metric."). Throws if the prefix is empty, does not end with
+ * a dot, or is already registered.
+ */
+export function registerPrefix(prefix: string): void {
+  if (prefix === '') {
+    throw new Error('ontology: prefix must not be empty')
+  }
+  if (!prefix.endsWith('.')) {
+    throw new Error(`ontology: prefix "${prefix}" must end with a dot`)
+  }
+  if (nodeTypePrefixes.includes(prefix)) {
+    throw new Error(`ontology: prefix "${prefix}" is already registered`)
+  }
+  nodeTypePrefixes.push(prefix)
+}
+
+/**
+ * Resets prefixes to the 5 built-in defaults (for testing).
+ */
+export function _resetPrefixes(): void {
+  nodeTypePrefixes.length = 0
+  nodeTypePrefixes.push(...BUILT_IN_PREFIXES)
+}
 
 export type NodeType =
   | BuiltInNodeType

--- a/sdks/ts/memory/src/ontology/validation.test.ts
+++ b/sdks/ts/memory/src/ontology/validation.test.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { formatEdgeTypeLabel, formatNodeTypeLabel } from './format.js'
+import type { OntologyTypeDefinition } from './types.js'
+import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES } from './types.js'
+import {
+  hasPrefix,
+  isBuiltInBusinessCategory,
+  isBuiltInEdgeType,
+  isBuiltInNodeType,
+  isValidBusinessCategory,
+  isValidEdgeType,
+  isValidNodeType,
+  validateBusinessCategory,
+  validateEdgeType,
+  validateNodeType,
+  validateTypeDefinition,
+} from './validation.js'
+
+describe('isValidNodeType', () => {
+  it('accepts all 31 built-in node types', () => {
+    for (const typ of BUILT_IN_NODE_TYPES) {
+      expect(isValidNodeType(typ)).toBe(true)
+    }
+  })
+
+  it.each([
+    ['entity.invoice', true],
+    ['rule.custom_thing', true],
+    ['exception.timeout_handling', true],
+    ['decision.routing_logic', true],
+    ['process.batch_job', true],
+    ['entity.multi_word_name', true],
+  ])('accepts valid custom type %s', (value, expected) => {
+    expect(isValidNodeType(value)).toBe(expected)
+  })
+
+  it.each([
+    ['invalid', false],
+    ['wrong.prefix', false],
+    ['', false],
+    ['entity.', false],
+    ['entity.Customer', false],
+    ['entity.1thing', false],
+    ['entity.my-thing', false],
+    ['entity.my thing', false],
+    ['entity..customer', false],
+    ['entity.name_', false],
+    ['entity.name__thing', false],
+  ])('rejects invalid type %s', (value, expected) => {
+    expect(isValidNodeType(value)).toBe(expected)
+  })
+})
+
+describe('isValidEdgeType', () => {
+  it('accepts all 19 built-in edge types', () => {
+    for (const typ of BUILT_IN_EDGE_TYPES) {
+      expect(isValidEdgeType(typ)).toBe(true)
+    }
+  })
+
+  it.each([
+    ['ships_to', true],
+    ['custom_relation', true],
+    ['connects', true],
+  ])('accepts valid custom type %s', (value, expected) => {
+    expect(isValidEdgeType(value)).toBe(expected)
+  })
+
+  it.each([
+    ['Invalid', false],
+    ['has spaces', false],
+    ['123start', false],
+    ['', false],
+    ['has.dot', false],
+    ['has-hyphen', false],
+    ['name_', false],
+  ])('rejects invalid type %s', (value, expected) => {
+    expect(isValidEdgeType(value)).toBe(expected)
+  })
+})
+
+describe('isValidBusinessCategory', () => {
+  it('accepts all 8 built-in categories', () => {
+    for (const cat of BUSINESS_CATEGORIES) {
+      expect(isValidBusinessCategory(cat)).toBe(true)
+    }
+  })
+
+  it.each([
+    ['custom_category', true],
+    ['server_hardware', true],
+  ])('accepts valid custom category %s', (value, expected) => {
+    expect(isValidBusinessCategory(value)).toBe(expected)
+  })
+
+  it.each([
+    ['Has Spaces', false],
+    ['123', false],
+    ['', false],
+    ['Customer', false],
+    ['my.category', false],
+  ])('rejects invalid category %s', (value, expected) => {
+    expect(isValidBusinessCategory(value)).toBe(expected)
+  })
+})
+
+describe('isBuiltInNodeType', () => {
+  it('returns true for all built-in types', () => {
+    for (const typ of BUILT_IN_NODE_TYPES) {
+      expect(isBuiltInNodeType(typ)).toBe(true)
+    }
+  })
+
+  it('returns false for custom types', () => {
+    expect(isBuiltInNodeType('entity.invoice')).toBe(false)
+    expect(isBuiltInNodeType('')).toBe(false)
+  })
+})
+
+describe('isBuiltInEdgeType', () => {
+  it('returns true for all built-in types', () => {
+    for (const typ of BUILT_IN_EDGE_TYPES) {
+      expect(isBuiltInEdgeType(typ)).toBe(true)
+    }
+  })
+
+  it('returns false for custom types', () => {
+    expect(isBuiltInEdgeType('ships_to')).toBe(false)
+  })
+})
+
+describe('isBuiltInBusinessCategory', () => {
+  it('returns true for all built-in categories', () => {
+    for (const cat of BUSINESS_CATEGORIES) {
+      expect(isBuiltInBusinessCategory(cat)).toBe(true)
+    }
+  })
+
+  it('returns false for custom categories', () => {
+    expect(isBuiltInBusinessCategory('custom_area')).toBe(false)
+  })
+})
+
+describe('hasPrefix', () => {
+  it.each([
+    ['entity.customer', 'entity.'],
+    ['rule.validation', 'rule.'],
+    ['exception.override', 'exception.'],
+    ['decision.branch', 'decision.'],
+    ['process.workflow', 'process.'],
+  ])('detects prefix for %s', (nodeType, expected) => {
+    expect(hasPrefix(nodeType)).toBe(expected)
+  })
+
+  it.each([
+    ['triggers', undefined],
+    ['wrong.thing', undefined],
+    ['', undefined],
+  ])('returns undefined for %s', (nodeType, expected) => {
+    expect(hasPrefix(nodeType)).toBe(expected)
+  })
+})
+
+describe('validateNodeType', () => {
+  it('returns undefined for valid types', () => {
+    expect(validateNodeType('entity.customer')).toBeUndefined()
+    expect(validateNodeType('rule.custom_thing')).toBeUndefined()
+  })
+
+  it('returns error message for invalid types', () => {
+    const errMsg = validateNodeType('invalid')
+    expect(errMsg).toBeDefined()
+    expect(errMsg).toContain('invalid node type')
+  })
+})
+
+describe('validateEdgeType', () => {
+  it('returns undefined for valid types', () => {
+    expect(validateEdgeType('triggers')).toBeUndefined()
+    expect(validateEdgeType('ships_to')).toBeUndefined()
+  })
+
+  it('returns error message for invalid types', () => {
+    const errMsg = validateEdgeType('INVALID')
+    expect(errMsg).toBeDefined()
+    expect(errMsg).toContain('invalid edge type')
+  })
+})
+
+describe('validateBusinessCategory', () => {
+  it('returns undefined for valid categories', () => {
+    expect(validateBusinessCategory('customer')).toBeUndefined()
+    expect(validateBusinessCategory('server_hardware')).toBeUndefined()
+  })
+
+  it('returns error message for invalid categories', () => {
+    const errMsg = validateBusinessCategory('')
+    expect(errMsg).toBeDefined()
+    expect(errMsg).toContain('invalid business category')
+  })
+})
+
+describe('validateTypeDefinition', () => {
+  const validDef: OntologyTypeDefinition = {
+    type: 'entity.customer',
+    label: 'Customer',
+    description: 'A customer entity',
+    createdAt: '2026-01-01T00:00:00Z',
+    status: 'active',
+  }
+
+  it('accepts a valid definition', () => {
+    expect(validateTypeDefinition(validDef)).toBeUndefined()
+  })
+
+  it('accepts proposed status', () => {
+    expect(validateTypeDefinition({ ...validDef, status: 'proposed' })).toBeUndefined()
+  })
+
+  it('accepts deprecated status', () => {
+    expect(validateTypeDefinition({ ...validDef, status: 'deprecated' })).toBeUndefined()
+  })
+
+  it('rejects empty type', () => {
+    expect(validateTypeDefinition({ ...validDef, type: '' })).toContain('empty type')
+  })
+
+  it('rejects empty label', () => {
+    expect(validateTypeDefinition({ ...validDef, label: '' })).toContain('empty label')
+  })
+
+  it('rejects empty description', () => {
+    expect(validateTypeDefinition({ ...validDef, description: '' })).toContain('empty description')
+  })
+
+  it('rejects empty createdAt', () => {
+    expect(validateTypeDefinition({ ...validDef, createdAt: '' })).toContain('empty createdAt')
+  })
+
+  it('rejects invalid status', () => {
+    const invalid = { ...validDef, status: 'invalid' as 'active' }
+    expect(validateTypeDefinition(invalid)).toContain('invalid status')
+  })
+})
+
+describe('formatNodeTypeLabel', () => {
+  it.each([
+    ['entity.customer', 'Customer (Entity)'],
+    ['process.approval_chain', 'Approval Chain (Process)'],
+    ['rule.classification', 'Classification (Rule)'],
+    ['exception.special_case', 'Special Case (Exception)'],
+    ['decision.escalation', 'Escalation (Decision)'],
+    ['invalid', 'invalid'],
+  ])('formats %s correctly', (input, expected) => {
+    expect(formatNodeTypeLabel(input)).toBe(expected)
+  })
+})
+
+describe('formatEdgeTypeLabel', () => {
+  it.each([
+    ['requires_approval_from', 'Requires Approval From'],
+    ['triggers', 'Triggers'],
+    ['feeds_into', 'Feeds Into'],
+    ['related_to', 'Related To'],
+  ])('formats %s correctly', (input, expected) => {
+    expect(formatEdgeTypeLabel(input)).toBe(expected)
+  })
+})

--- a/sdks/ts/memory/src/ontology/validation.ts
+++ b/sdks/ts/memory/src/ontology/validation.ts
@@ -8,7 +8,7 @@
  */
 
 import type { OntologyTypeDefinition, TypeStatus } from './types.js'
-import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, NODE_TYPE_PREFIXES } from './types.js'
+import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, _nodeTypePrefixesRef } from './types.js'
 
 const SNAKE_CASE_NAME_RE = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/
 
@@ -48,7 +48,7 @@ export function isValidNodeType(value: string): boolean {
   if (builtInNodeTypeSet.has(value)) {
     return true
   }
-  for (const prefix of NODE_TYPE_PREFIXES) {
+  for (const prefix of _nodeTypePrefixesRef()) {
     if (value.startsWith(prefix)) {
       const name = value.slice(prefix.length)
       if (name.length === 0) {
@@ -83,7 +83,7 @@ export function isValidBusinessCategory(value: string): boolean {
  * Returns the matching prefix for a node type, or undefined if none matches.
  */
 export function hasPrefix(nodeType: string): string | undefined {
-  for (const prefix of NODE_TYPE_PREFIXES) {
+  for (const prefix of _nodeTypePrefixesRef()) {
     if (nodeType.startsWith(prefix)) {
       return prefix
     }

--- a/sdks/ts/memory/src/ontology/validation.ts
+++ b/sdks/ts/memory/src/ontology/validation.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Ontology type validation functions. Validates node types, edge types,
+ * business categories, and type definitions against the naming conventions.
+ *
+ * Port of packages/intelligence-database validation logic.
+ */
+
+import type { OntologyTypeDefinition, TypeStatus } from './types.js'
+import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, NODE_TYPE_PREFIXES } from './types.js'
+
+const SNAKE_CASE_NAME_RE = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/
+
+const builtInNodeTypeSet: ReadonlySet<string> = new Set(BUILT_IN_NODE_TYPES)
+const builtInEdgeTypeSet: ReadonlySet<string> = new Set(BUILT_IN_EDGE_TYPES)
+const businessCategorySet: ReadonlySet<string> = new Set(BUSINESS_CATEGORIES)
+
+const VALID_STATUSES: ReadonlySet<TypeStatus> = new Set(['active', 'proposed', 'deprecated'])
+
+/**
+ * Reports whether value exactly matches a built-in node type.
+ */
+export function isBuiltInNodeType(value: string): boolean {
+  return builtInNodeTypeSet.has(value)
+}
+
+/**
+ * Reports whether value exactly matches a built-in edge type.
+ */
+export function isBuiltInEdgeType(value: string): boolean {
+  return builtInEdgeTypeSet.has(value)
+}
+
+/**
+ * Reports whether value exactly matches a built-in business category.
+ */
+export function isBuiltInBusinessCategory(value: string): boolean {
+  return businessCategorySet.has(value)
+}
+
+/**
+ * Reports whether value is a valid node type identifier.
+ * A value is valid if it exactly matches a built-in node type, or if it
+ * starts with a valid prefix and has a valid snake_case name after the dot.
+ */
+export function isValidNodeType(value: string): boolean {
+  if (builtInNodeTypeSet.has(value)) {
+    return true
+  }
+  for (const prefix of NODE_TYPE_PREFIXES) {
+    if (value.startsWith(prefix)) {
+      const name = value.slice(prefix.length)
+      if (name.length === 0) {
+        return false
+      }
+      return SNAKE_CASE_NAME_RE.test(name)
+    }
+  }
+  return false
+}
+
+/**
+ * Reports whether value is a valid edge type identifier.
+ * A value is valid if it exactly matches a built-in edge type, or if it
+ * matches the snake_case pattern.
+ */
+export function isValidEdgeType(value: string): boolean {
+  if (builtInEdgeTypeSet.has(value)) {
+    return true
+  }
+  return SNAKE_CASE_NAME_RE.test(value)
+}
+
+/**
+ * Reports whether value is a valid business category identifier.
+ */
+export function isValidBusinessCategory(value: string): boolean {
+  return SNAKE_CASE_NAME_RE.test(value)
+}
+
+/**
+ * Returns the matching prefix for a node type, or undefined if none matches.
+ */
+export function hasPrefix(nodeType: string): string | undefined {
+  for (const prefix of NODE_TYPE_PREFIXES) {
+    if (nodeType.startsWith(prefix)) {
+      return prefix
+    }
+  }
+  return undefined
+}
+
+/**
+ * Returns an error message if value is not a valid node type, or undefined if valid.
+ */
+export function validateNodeType(value: string): string | undefined {
+  if (isValidNodeType(value)) {
+    return undefined
+  }
+  return `ontology: invalid node type "${value}": must start with a valid prefix (entity., rule., exception., decision., process.) followed by a snake_case name`
+}
+
+/**
+ * Returns an error message if value is not a valid edge type, or undefined if valid.
+ */
+export function validateEdgeType(value: string): string | undefined {
+  if (isValidEdgeType(value)) {
+    return undefined
+  }
+  return `ontology: invalid edge type "${value}": must be lowercase snake_case starting with a letter`
+}
+
+/**
+ * Returns an error message if value is not a valid business category, or undefined if valid.
+ */
+export function validateBusinessCategory(value: string): string | undefined {
+  if (isValidBusinessCategory(value)) {
+    return undefined
+  }
+  return `ontology: invalid business category "${value}": must be lowercase snake_case starting with a letter`
+}
+
+/**
+ * Validates a type definition has all required fields and valid values.
+ * Returns an error message or undefined if valid.
+ */
+export function validateTypeDefinition(def: OntologyTypeDefinition): string | undefined {
+  if (!def.type) {
+    return 'ontology: type definition has empty type field'
+  }
+  if (!def.label) {
+    return `ontology: type definition "${def.type}" has empty label`
+  }
+  if (!def.description) {
+    return `ontology: type definition "${def.type}" has empty description`
+  }
+  if (!def.createdAt) {
+    return `ontology: type definition "${def.type}" has empty createdAt`
+  }
+  if (!VALID_STATUSES.has(def.status)) {
+    return `ontology: type definition "${def.type}" has invalid status "${def.status}": must be active, proposed, or deprecated`
+  }
+  return undefined
+}

--- a/spec/ONTOLOGY.md
+++ b/spec/ONTOLOGY.md
@@ -1,0 +1,223 @@
+# Ontology Type System
+
+This document defines the canonical ontology type catalogue for the memory package. All node types, edge types, business categories, and validation rules are authoritative. Implementations in Go and TypeScript must produce identical results for identical inputs.
+
+## Node Types
+
+Node types use a dotted notation: `prefix.name` where the prefix classifies the domain category and the name identifies the specific type within that category. Names use `snake_case`.
+
+### Entity Types (6)
+
+Types representing real-world entities in the business domain.
+
+| Type | Description |
+|------|-------------|
+| `entity.customer` | Customers, clients, accounts, subscribers, or end-users of a service |
+| `entity.supplier` | Vendors, suppliers, partners, or service providers |
+| `entity.product` | Products, goods, SKUs, services offered, or catalogue items |
+| `entity.department` | Departments, teams, business units, or organisational divisions |
+| `entity.person` | Named individuals, contacts, employees, or stakeholders |
+| `entity.document` | Documents, files, templates, forms, contracts, or certificates |
+
+### Rule Types (13)
+
+Types representing business rules, constraints, and logic.
+
+| Type | Description |
+|------|-------------|
+| `rule.constraint` | General constraints, limitations, or restrictions on operations |
+| `rule.validation` | Data validation checks, format requirements, or input verification |
+| `rule.threshold` | Numeric thresholds, limits, ranges, minimums, maximums, or SLA targets |
+| `rule.policy` | Organisational policies, compliance rules, regulations, or mandates |
+| `rule.classification` | Rules that categorise or classify items into groups |
+| `rule.matching` | Rules for matching, pairing, or reconciling records |
+| `rule.mapping` | Rules for transforming, converting, or mapping data between formats |
+| `rule.extraction` | Rules for extracting specific data from documents or sources |
+| `rule.routing` | Rules that determine where work or data should be directed |
+| `rule.fallback` | Default or backup rules applied when primary rules do not match |
+| `rule.priority` | Rules that establish ordering, ranking, or precedence |
+| `rule.requirement` | Mandatory conditions, prerequisites, or dependencies |
+| `rule.combined` | Composite rules that combine multiple rule types |
+
+### Exception Types (3)
+
+Types representing deviations from standard rules or processes.
+
+| Type | Description |
+|------|-------------|
+| `exception.workaround` | Temporary solutions or manual interventions to bypass issues |
+| `exception.override` | Deliberate overrides of existing rules by authorised personnel |
+| `exception.special_case` | Unique or one-off handling for specific scenarios |
+
+### Decision Types (3)
+
+Types representing decision points and branching logic.
+
+| Type | Description |
+|------|-------------|
+| `decision.branch` | Conditional branches, if-then logic, or routing decisions |
+| `decision.escalation` | Escalation paths, priority handling, or SLA breach responses |
+| `decision.table` | Decision matrices, lookup tables, or multi-criteria evaluations |
+
+### Process Types (6)
+
+Types representing workflows, procedures, and operational sequences.
+
+| Type | Description |
+|------|-------------|
+| `process.workflow` | End-to-end workflows, automated sequences, or pipelines |
+| `process.approval_chain` | Approval processes, sign-off sequences, or authorisation flows |
+| `process.procedure` | Step-by-step procedures, standard operating procedures, or protocols |
+| `process.stage` | Stages, phases, milestones, or checkpoints within a process |
+| `process.integration` | Integration points, API connections, or external system interactions |
+| `process.subworkflow` | Nested workflows, reusable process fragments, or child processes |
+
+**Total: 31 built-in node types.**
+
+## Edge Types (19)
+
+Edge types represent relationships between nodes. They use `snake_case` identifiers without a prefix.
+
+| Type | Description |
+|------|-------------|
+| `triggers` | Source causes target to start or execute |
+| `requires_approval_from` | Source needs approval or sign-off from target |
+| `exception_for` | Source is an exception or deviation from target rule |
+| `overrides` | Source takes precedence over or replaces target |
+| `depends_on` | Source requires target to be completed or available first |
+| `belongs_to` | Source is a member, child, or component of target |
+| `escalates_to` | Source escalates issues or decisions to target |
+| `constrains` | Source imposes restrictions or limitations on target |
+| `informed_by` | Source uses information or data provided by target |
+| `produces` | Source generates, creates, or outputs target |
+| `precedes` | Source occurs before target in sequence |
+| `related_to` | Source has a general association with target |
+| `contradicts` | Source conflicts with or opposes target |
+| `fallback_for` | Source serves as a backup or default when target fails |
+| `extends` | Source adds to or builds upon target |
+| `alternative_to` | Source is an interchangeable option with target |
+| `feeds_into` | Source provides input data or context to target |
+| `enables` | Source makes target possible or available |
+| `validates` | Source checks or confirms the correctness of target |
+
+## Business Categories (8)
+
+Business categories classify nodes by domain area. They use `snake_case` identifiers.
+
+| Category | Purpose |
+|----------|---------|
+| `customer` | Customer-related entities and processes |
+| `order` | Order management and fulfilment |
+| `product` | Product catalogue and inventory |
+| `address` | Address and location management |
+| `document` | Document management and processing |
+| `authorization` | Authentication, authorisation, and access control |
+| `integration` | External system integrations |
+| `general` | Default category for uncategorised items |
+
+## Node Type Prefixes (5)
+
+Valid prefixes for node type identifiers:
+
+| Prefix | Domain |
+|--------|--------|
+| `entity.` | Real-world entities |
+| `rule.` | Business rules and constraints |
+| `exception.` | Deviations from standard rules |
+| `decision.` | Decision points and branching |
+| `process.` | Workflows and procedures |
+
+## OntologyTypeDefinition Schema
+
+A type definition describes a registered ontology type (node or edge):
+
+```json
+{
+  "type": "string",
+  "label": "string",
+  "description": "string",
+  "discoveredFrom": "string (optional)",
+  "createdAt": "string (ISO 8601)",
+  "status": "active | proposed | deprecated"
+}
+```
+
+Fields:
+
+- `type`: The dotted identifier (e.g., `entity.customer`) or edge identifier (e.g., `triggers`)
+- `label`: Human-readable display name
+- `description`: One-sentence explanation of what the type represents
+- `discoveredFrom`: Source document path where the type was first discovered (optional)
+- `createdAt`: ISO 8601 timestamp of creation
+- `status`: Lifecycle state of the type definition
+
+## Scope Resolution
+
+Types are resolved through a four-level scope hierarchy. Higher scopes override lower scopes when types share the same identifier.
+
+Resolution order (lowest to highest priority):
+
+1. **built-in** -- The 31 node types + 19 edge types defined in this spec
+2. **organisation** -- Custom types defined at the organisation level
+3. **project** -- Custom types scoped to a specific project
+4. **brain** -- Custom types specific to a single brain
+
+When resolving the full ontology:
+
+- Start with all built-in types
+- Layer organisation types on top (overriding built-in types with the same identifier)
+- Layer project types on top (overriding organisation and built-in)
+- Layer brain types on top (overriding all lower scopes)
+- Only types with `status: "active"` are included in resolution
+
+## Validation Rules
+
+### Node Type Validation
+
+A string is a valid node type if it satisfies ANY of these conditions:
+
+1. It exactly matches one of the 31 built-in node types
+2. It starts with a valid prefix (`entity.`, `rule.`, `exception.`, `decision.`, `process.`) AND has at least one character after the dot AND the name portion matches `^[a-z][a-z0-9]*(_[a-z0-9]+)*$`
+
+### Edge Type Validation
+
+A string is a valid edge type if it satisfies ANY of these conditions:
+
+1. It exactly matches one of the 19 built-in edge types
+2. It matches the pattern `^[a-z][a-z0-9]*(_[a-z0-9]+)*$` (lowercase snake_case starting with a letter)
+
+### Business Category Validation
+
+A string is a valid business category if it matches the pattern `^[a-z][a-z0-9]*(_[a-z0-9]+)*$` (lowercase snake_case starting with a letter).
+
+### Type Definition Validation
+
+A TypeDefinition is valid when:
+
+- `type` passes node type or edge type validation (depending on context)
+- `label` is non-empty
+- `description` is non-empty
+- `status` is one of: `active`, `proposed`, `deprecated`
+- `createdAt` is a non-empty string (ISO 8601 format)
+
+## Label Formatting
+
+### Node Type Labels
+
+The format function converts a dotted node type to a human-readable label:
+
+- `entity.customer` becomes `Customer (Entity)`
+- `process.approval_chain` becomes `Approval Chain (Process)`
+- `rule.special_handling` becomes `Special Handling (Rule)`
+
+Algorithm: split on `.`, title-case each word in the name (splitting on `_`), append the prefix in parentheses with title case.
+
+### Edge Type Labels
+
+The format function converts a snake_case edge type to a human-readable label:
+
+- `requires_approval_from` becomes `Requires Approval From`
+- `triggers` becomes `Triggers`
+- `feeds_into` becomes `Feeds Into`
+
+Algorithm: split on `_`, title-case each word, join with spaces.


### PR DESCRIPTION
## Summary

- Complete ontology type system: 31 node types, 19 edge types, 8 business categories, 5 prefixes
- `spec/ONTOLOGY.md` — canonical reference spec
- `go/ontology/` — new package (types, validation, descriptions, format)
- `sdks/ts/memory/src/ontology/` — new module (types, validation, descriptions, format)
- Cross-SDK parity: identical type strings verified in tests
- Validation regex: `^[a-z][a-z0-9]*(_[a-z0-9]+)*$` (rejects Unicode homoglyphs)
- `EdgeType` uses `BuiltInEdgeType | (string & {})` for open union with autocomplete
- Human-readable descriptions for all 50 built-in types

## Test plan

- [ ] 99 Go test cases pass (count verification, uniqueness, descriptions, validation)
- [ ] 91 TS tests pass (same coverage + cross-SDK parity assertions)
- [ ] Exactly 31 node types, 19 edge types, 8 categories, 5 prefixes (verified by test assertions)
- [ ] Invalid type names rejected (uppercase, hyphens, dots, empty, special chars)
- [ ] Format: "entity.customer" → "Customer (Entity)"
- [ ] All types have descriptions (no fallback string returned)

Closes LLE-9789