### PR TITLE
Add chunk-level change detection with content-hash delta updates

### DIFF
--- a/go/knowledge/delta.go
+++ b/go/knowledge/delta.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+package knowledge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+// chunkManifestsPrefix is the logical prefix where chunk manifests are
+// persisted. Each document gets one manifest keyed by its content hash.
+const chunkManifestsPrefix = "raw/.chunk-manifests"
+
+// ChunkManifestEntry records the content hash of a single chunk and its
+// positional identifier within the parent document. Matching during delta
+// detection is by Hash (content-based), not by ChunkID (ordinal-based).
+type ChunkManifestEntry struct {
+	Hash    string `json:"hash"`
+	ChunkID string `json:"chunk_id"`
+}
+
+// ChunkManifest records all chunk hashes for a document. Used by delta
+// detection to skip unchanged chunks on re-ingest. The Generation counter
+// increments on every successful write, enabling external consumers to
+// detect stale manifests.
+type ChunkManifest struct {
+	DocumentHash string               `json:"document_hash"`
+	Generation   int                  `json:"generation"`
+	Chunks       []ChunkManifestEntry `json:"chunks"`
+	UpdatedAt    time.Time            `json:"updated_at"`
+}
+
+// DeltaCategory classifies a chunk's change status during re-ingest.
+// Matching is by BLAKE3/SHA-256 content hash regardless of position.
+type DeltaCategory int
+
+const (
+	// DeltaUnchanged means the chunk's content hash exists in both the
+	// prior manifest and the current chunk set.
+	DeltaUnchanged DeltaCategory = iota
+	// DeltaNew means the chunk's content hash exists in the current set
+	// but not in the prior manifest.
+	DeltaNew
+	// DeltaRemoved means the chunk's content hash exists in the prior
+	// manifest but not in the current set.
+	DeltaRemoved
+)
+
+// ChunkDelta pairs a chunk with its change category and content hash.
+type ChunkDelta struct {
+	Chunk    Chunk
+	Category DeltaCategory
+	Hash     string
+}
+
+// HashChunk computes a SHA-256 content hash of a chunk's text. This is
+// the canonical hashing function for chunk-level change detection. When
+// P1-2 lands BLAKE3 support, this function becomes the single point of
+// swap.
+func HashChunk(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// ComputeChunkDeltas compares new chunks against a stored manifest and
+// returns the delta set. Matching is by content hash regardless of
+// position: hash in old manifest but not in new = DeltaRemoved, hash in
+// new but not in old = DeltaNew, hash in both = DeltaUnchanged.
+//
+// When manifest is nil (first ingest), all chunks are categorized as
+// DeltaNew. Removed chunks carry a zero-value Chunk with only the
+// DocumentID and Ordinal set from the prior manifest entry.
+//
+// Time: O(N + M) where N = len(newChunks), M = len(manifest.Chunks).
+// Space: O(N + M) for the hash lookup maps.
+func ComputeChunkDeltas(newChunks []Chunk, manifest *ChunkManifest) []ChunkDelta {
+	if len(newChunks) == 0 && manifest == nil {
+		return nil
+	}
+
+	newHashes := make(map[string][]int, len(newChunks))
+	for i, chunk := range newChunks {
+		h := HashChunk(chunk.Text)
+		newHashes[h] = append(newHashes[h], i)
+	}
+
+	if manifest == nil {
+		out := make([]ChunkDelta, 0, len(newChunks))
+		for i, chunk := range newChunks {
+			out = append(out, ChunkDelta{
+				Chunk:    chunk,
+				Category: DeltaNew,
+				Hash:     HashChunk(newChunks[i].Text),
+			})
+			_ = chunk // silence vet
+		}
+		return out
+	}
+
+	oldHashes := make(map[string][]int, len(manifest.Chunks))
+	for i, entry := range manifest.Chunks {
+		oldHashes[entry.Hash] = append(oldHashes[entry.Hash], i)
+	}
+
+	// Track which old entries have been matched so we can identify removals.
+	matchedOld := make(map[int]bool, len(manifest.Chunks))
+	out := make([]ChunkDelta, 0, len(newChunks)+len(manifest.Chunks))
+
+	for i, chunk := range newChunks {
+		h := HashChunk(chunk.Text)
+		oldIndices := oldHashes[h]
+		matched := false
+		for _, oldIdx := range oldIndices {
+			if !matchedOld[oldIdx] {
+				matchedOld[oldIdx] = true
+				matched = true
+				break
+			}
+		}
+		category := DeltaNew
+		if matched {
+			category = DeltaUnchanged
+		}
+		out = append(out, ChunkDelta{
+			Chunk:    newChunks[i],
+			Category: category,
+			Hash:     h,
+		})
+	}
+
+	// Identify removed chunks: old entries with no match in new set.
+	for i, entry := range manifest.Chunks {
+		if matchedOld[i] {
+			continue
+		}
+		out = append(out, ChunkDelta{
+			Chunk: Chunk{
+				DocumentID: manifest.DocumentHash,
+				Ordinal:    i,
+			},
+			Category: DeltaRemoved,
+			Hash:     entry.Hash,
+		})
+	}
+
+	return out
+}
+
+// manifestPath returns the brain.Path where a document's chunk manifest
+// is persisted.
+func manifestPath(documentHash string) brain.Path {
+	return brain.Path(chunkManifestsPrefix + "/" + documentHash + ".json")
+}
+
+// ReadChunkManifest loads the chunk manifest for a document from the
+// store. Returns nil and no error when the manifest does not exist (first
+// ingest scenario).
+func ReadChunkManifest(ctx context.Context, store brain.Store, documentHash string) (*ChunkManifest, error) {
+	p := manifestPath(documentHash)
+	data, err := store.Read(ctx, p)
+	if err != nil {
+		if errors.Is(err, brain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("knowledge: reading chunk manifest %s: %w", p, err)
+	}
+	var manifest ChunkManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("knowledge: parsing chunk manifest %s: %w", p, err)
+	}
+	return &manifest, nil
+}
+
+// WriteChunkManifest persists the chunk manifest for a document. Reads
+// the prior manifest to increment the generation counter. When no prior
+// manifest exists, generation starts at 1.
+func WriteChunkManifest(ctx context.Context, store brain.Store, manifest ChunkManifest) error {
+	p := manifestPath(manifest.DocumentHash)
+
+	prior, err := ReadChunkManifest(ctx, store, manifest.DocumentHash)
+	if err != nil {
+		return err
+	}
+	if prior != nil {
+		manifest.Generation = prior.Generation + 1
+	} else {
+		manifest.Generation = 1
+	}
+	manifest.UpdatedAt = time.Now().UTC()
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("knowledge: marshalling chunk manifest: %w", err)
+	}
+	if err := store.Write(ctx, p, data); err != nil {
+		return fmt.Errorf("knowledge: writing chunk manifest %s: %w", p, err)
+	}
+	return nil
+}
+
+// BuildChunkManifest constructs a ChunkManifest from a set of chunks and
+// their parent document hash. This is the entry point for creating a new
+// manifest after chunking.
+func BuildChunkManifest(documentHash string, chunks []Chunk) ChunkManifest {
+	entries := make([]ChunkManifestEntry, 0, len(chunks))
+	for i, chunk := range chunks {
+		entries = append(entries, ChunkManifestEntry{
+			Hash:    HashChunk(chunk.Text),
+			ChunkID: fmt.Sprintf("%s_%d", documentHash, i),
+		})
+	}
+	return ChunkManifest{
+		DocumentHash: documentHash,
+		Chunks:       entries,
+	}
+}

--- a/go/knowledge/delta.go
+++ b/go/knowledge/delta.go
@@ -8,10 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
 )
+
+// validDocumentHashRe validates that a document hash is a lowercase hex
+// string (SHA-256 or BLAKE3 output). Prevents path traversal via
+// crafted hash values.
+var validDocumentHashRe = regexp.MustCompile(`^[a-f0-9]+$`)
 
 // chunkManifestsPrefix is the logical prefix where chunk manifests are
 // persisted. Each document gets one manifest keyed by its content hash.
@@ -22,7 +28,7 @@ const chunkManifestsPrefix = "raw/.chunk-manifests"
 // detection is by Hash (content-based), not by ChunkID (ordinal-based).
 type ChunkManifestEntry struct {
 	Hash    string `json:"hash"`
-	ChunkID string `json:"chunk_id"`
+	ChunkID string `json:"chunkId"`
 }
 
 // ChunkManifest records all chunk hashes for a document. Used by delta
@@ -30,10 +36,10 @@ type ChunkManifestEntry struct {
 // increments on every successful write, enabling external consumers to
 // detect stale manifests.
 type ChunkManifest struct {
-	DocumentHash string               `json:"document_hash"`
+	DocumentHash string               `json:"documentHash"`
 	Generation   int                  `json:"generation"`
 	Chunks       []ChunkManifestEntry `json:"chunks"`
-	UpdatedAt    time.Time            `json:"updated_at"`
+	UpdatedAt    time.Time            `json:"updatedAt"`
 }
 
 // DeltaCategory classifies a chunk's change status during re-ingest.
@@ -152,8 +158,18 @@ func ComputeChunkDeltas(newChunks []Chunk, manifest *ChunkManifest) []ChunkDelta
 	return out
 }
 
+// validateDocumentHash returns an error if the hash is not a valid
+// lowercase hex string. This prevents path traversal attacks via crafted
+// document hash values containing slashes or relative paths.
+func validateDocumentHash(documentHash string) error {
+	if !validDocumentHashRe.MatchString(documentHash) {
+		return fmt.Errorf("knowledge: invalid document hash %q: must match ^[a-f0-9]+$", documentHash)
+	}
+	return nil
+}
+
 // manifestPath returns the brain.Path where a document's chunk manifest
-// is persisted.
+// is persisted. Caller must validate documentHash before calling.
 func manifestPath(documentHash string) brain.Path {
 	return brain.Path(chunkManifestsPrefix + "/" + documentHash + ".json")
 }
@@ -162,6 +178,9 @@ func manifestPath(documentHash string) brain.Path {
 // store. Returns nil and no error when the manifest does not exist (first
 // ingest scenario).
 func ReadChunkManifest(ctx context.Context, store brain.Store, documentHash string) (*ChunkManifest, error) {
+	if err := validateDocumentHash(documentHash); err != nil {
+		return nil, err
+	}
 	p := manifestPath(documentHash)
 	data, err := store.Read(ctx, p)
 	if err != nil {
@@ -181,6 +200,9 @@ func ReadChunkManifest(ctx context.Context, store brain.Store, documentHash stri
 // the prior manifest to increment the generation counter. When no prior
 // manifest exists, generation starts at 1.
 func WriteChunkManifest(ctx context.Context, store brain.Store, manifest ChunkManifest) error {
+	if err := validateDocumentHash(manifest.DocumentHash); err != nil {
+		return err
+	}
 	p := manifestPath(manifest.DocumentHash)
 
 	prior, err := ReadChunkManifest(ctx, store, manifest.DocumentHash)

--- a/go/knowledge/delta_test.go
+++ b/go/knowledge/delta_test.go
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: Apache-2.0
+package knowledge
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/store/mem"
+)
+
+func TestComputeChunkDeltas_first_ingest(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "alpha content"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "beta content"},
+		{DocumentID: "doc1", Ordinal: 2, Text: "gamma content"},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, nil)
+
+	if len(deltas) != 3 {
+		t.Fatalf("expected 3 deltas, got %d", len(deltas))
+	}
+	for i, d := range deltas {
+		if d.Category != DeltaNew {
+			t.Errorf("delta[%d] expected DeltaNew, got %d", i, d.Category)
+		}
+		if d.Hash == "" {
+			t.Errorf("delta[%d] has empty hash", i)
+		}
+	}
+}
+
+func TestComputeChunkDeltas_no_change(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "alpha content"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "beta content"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	var newCount, unchangedCount, removedCount int
+	for _, d := range deltas {
+		switch d.Category {
+		case DeltaNew:
+			newCount++
+		case DeltaUnchanged:
+			unchangedCount++
+		case DeltaRemoved:
+			removedCount++
+		}
+	}
+
+	if newCount != 0 {
+		t.Errorf("expected 0 new, got %d", newCount)
+	}
+	if unchangedCount != 2 {
+		t.Errorf("expected 2 unchanged, got %d", unchangedCount)
+	}
+	if removedCount != 0 {
+		t.Errorf("expected 0 removed, got %d", removedCount)
+	}
+}
+
+func TestComputeChunkDeltas_chunk_added(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "alpha content"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "beta content"},
+		{DocumentID: "doc1", Ordinal: 2, Text: "new paragraph"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	var newCount, unchangedCount int
+	for _, d := range deltas {
+		switch d.Category {
+		case DeltaNew:
+			newCount++
+			if d.Chunk.Text != "new paragraph" {
+				t.Errorf("expected new chunk text 'new paragraph', got %q", d.Chunk.Text)
+			}
+		case DeltaUnchanged:
+			unchangedCount++
+		case DeltaRemoved:
+			t.Errorf("unexpected removed chunk: %+v", d)
+		}
+	}
+
+	if newCount != 1 {
+		t.Errorf("expected 1 new, got %d", newCount)
+	}
+	if unchangedCount != 2 {
+		t.Errorf("expected 2 unchanged, got %d", unchangedCount)
+	}
+}
+
+func TestComputeChunkDeltas_chunk_removed(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "alpha content"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	var unchangedCount, removedCount int
+	for _, d := range deltas {
+		switch d.Category {
+		case DeltaNew:
+			t.Errorf("unexpected new chunk: %+v", d)
+		case DeltaUnchanged:
+			unchangedCount++
+		case DeltaRemoved:
+			removedCount++
+			if d.Hash != HashChunk("beta content") {
+				t.Errorf("expected removed hash for 'beta content', got %q", d.Hash)
+			}
+		}
+	}
+
+	if unchangedCount != 1 {
+		t.Errorf("expected 1 unchanged, got %d", unchangedCount)
+	}
+	if removedCount != 1 {
+		t.Errorf("expected 1 removed, got %d", removedCount)
+	}
+}
+
+func TestComputeChunkDeltas_reordered(t *testing.T) {
+	t.Parallel()
+	// Same content in different positions should all be DeltaUnchanged.
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "beta content"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "alpha content"},
+		{DocumentID: "doc1", Ordinal: 2, Text: "gamma content"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+			{Hash: HashChunk("gamma content"), ChunkID: "doc1hash_2"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	for i, d := range deltas {
+		if d.Category != DeltaUnchanged {
+			t.Errorf("delta[%d] expected DeltaUnchanged (reorder), got %d for text %q", i, d.Category, d.Chunk.Text)
+		}
+	}
+}
+
+func TestComputeChunkDeltas_one_chunk_changed(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "alpha content"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "beta MODIFIED content"},
+		{DocumentID: "doc1", Ordinal: 2, Text: "gamma content"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+			{Hash: HashChunk("gamma content"), ChunkID: "doc1hash_2"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	var newCount, unchangedCount, removedCount int
+	for _, d := range deltas {
+		switch d.Category {
+		case DeltaNew:
+			newCount++
+			if d.Chunk.Text != "beta MODIFIED content" {
+				t.Errorf("expected new chunk 'beta MODIFIED content', got %q", d.Chunk.Text)
+			}
+		case DeltaUnchanged:
+			unchangedCount++
+		case DeltaRemoved:
+			removedCount++
+			if d.Hash != HashChunk("beta content") {
+				t.Errorf("expected removed hash for 'beta content', got %q", d.Hash)
+			}
+		}
+	}
+
+	if newCount != 1 {
+		t.Errorf("expected 1 new, got %d", newCount)
+	}
+	if unchangedCount != 2 {
+		t.Errorf("expected 2 unchanged, got %d", unchangedCount)
+	}
+	if removedCount != 1 {
+		t.Errorf("expected 1 removed, got %d", removedCount)
+	}
+}
+
+func TestComputeChunkDeltas_empty_new_chunks(t *testing.T) {
+	t.Parallel()
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("alpha content"), ChunkID: "doc1hash_0"},
+			{Hash: HashChunk("beta content"), ChunkID: "doc1hash_1"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(nil, manifest)
+
+	var removedCount int
+	for _, d := range deltas {
+		if d.Category != DeltaRemoved {
+			t.Errorf("expected DeltaRemoved, got %d", d.Category)
+		}
+		removedCount++
+	}
+	if removedCount != 2 {
+		t.Errorf("expected 2 removed, got %d", removedCount)
+	}
+}
+
+func TestComputeChunkDeltas_duplicate_content(t *testing.T) {
+	t.Parallel()
+	// Two chunks with identical content in new set, one in old manifest.
+	// One should be unchanged, one should be new.
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "repeated"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "repeated"},
+	}
+
+	manifest := &ChunkManifest{
+		DocumentHash: "doc1hash",
+		Generation:   1,
+		Chunks: []ChunkManifestEntry{
+			{Hash: HashChunk("repeated"), ChunkID: "doc1hash_0"},
+		},
+	}
+
+	deltas := ComputeChunkDeltas(chunks, manifest)
+
+	var newCount, unchangedCount int
+	for _, d := range deltas {
+		switch d.Category {
+		case DeltaNew:
+			newCount++
+		case DeltaUnchanged:
+			unchangedCount++
+		case DeltaRemoved:
+			t.Errorf("unexpected removed delta")
+		}
+	}
+
+	if unchangedCount != 1 {
+		t.Errorf("expected 1 unchanged, got %d", unchangedCount)
+	}
+	if newCount != 1 {
+		t.Errorf("expected 1 new, got %d", newCount)
+	}
+}
+
+func TestReadWriteChunkManifest_round_trip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := mem.New()
+	t.Cleanup(func() { _ = store.Close() })
+
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "first chunk"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "second chunk"},
+		{DocumentID: "doc1", Ordinal: 2, Text: "third chunk"},
+	}
+
+	manifest := BuildChunkManifest("abc123def456", chunks)
+
+	if err := WriteChunkManifest(ctx, store, manifest); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	loaded, err := ReadChunkManifest(ctx, store, "abc123def456")
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil manifest after write")
+	}
+
+	if loaded.DocumentHash != "abc123def456" {
+		t.Errorf("expected document hash 'abc123def456', got %q", loaded.DocumentHash)
+	}
+	if loaded.Generation != 1 {
+		t.Errorf("expected generation 1, got %d", loaded.Generation)
+	}
+	if len(loaded.Chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(loaded.Chunks))
+	}
+
+	for i, entry := range loaded.Chunks {
+		expectedHash := HashChunk(chunks[i].Text)
+		if entry.Hash != expectedHash {
+			t.Errorf("chunk[%d] hash mismatch: got %q, want %q", i, entry.Hash, expectedHash)
+		}
+		expectedID := fmt.Sprintf("abc123def456_%d", i)
+		if entry.ChunkID != expectedID {
+			t.Errorf("chunk[%d] id mismatch: got %q, want %q", i, entry.ChunkID, expectedID)
+		}
+	}
+
+	if loaded.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+}
+
+func TestReadChunkManifest_missing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := mem.New()
+	t.Cleanup(func() { _ = store.Close() })
+
+	loaded, err := ReadChunkManifest(ctx, store, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded != nil {
+		t.Fatalf("expected nil manifest for missing document, got %+v", loaded)
+	}
+}
+
+func TestWriteChunkManifest_increments_generation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := mem.New()
+	t.Cleanup(func() { _ = store.Close() })
+
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "content v1"},
+	}
+
+	manifest := BuildChunkManifest("docXYZ", chunks)
+
+	if err := WriteChunkManifest(ctx, store, manifest); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	loaded, err := ReadChunkManifest(ctx, store, "docXYZ")
+	if err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+	if loaded.Generation != 1 {
+		t.Errorf("expected generation 1 after first write, got %d", loaded.Generation)
+	}
+
+	// Write again with different content.
+	chunks2 := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "content v2"},
+	}
+	manifest2 := BuildChunkManifest("docXYZ", chunks2)
+
+	if err := WriteChunkManifest(ctx, store, manifest2); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	loaded2, err := ReadChunkManifest(ctx, store, "docXYZ")
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	if loaded2.Generation != 2 {
+		t.Errorf("expected generation 2 after second write, got %d", loaded2.Generation)
+	}
+}
+
+func TestHashChunk_deterministic(t *testing.T) {
+	t.Parallel()
+	h1 := HashChunk("hello world")
+	h2 := HashChunk("hello world")
+	if h1 != h2 {
+		t.Errorf("HashChunk not deterministic: %q != %q", h1, h2)
+	}
+	h3 := HashChunk("different content")
+	if h1 == h3 {
+		t.Error("HashChunk collision on different content")
+	}
+}
+
+func TestBuildChunkManifest(t *testing.T) {
+	t.Parallel()
+	chunks := []Chunk{
+		{DocumentID: "doc1", Ordinal: 0, Text: "chunk A"},
+		{DocumentID: "doc1", Ordinal: 1, Text: "chunk B"},
+	}
+
+	manifest := BuildChunkManifest("hash123", chunks)
+
+	if manifest.DocumentHash != "hash123" {
+		t.Errorf("expected document hash 'hash123', got %q", manifest.DocumentHash)
+	}
+	if len(manifest.Chunks) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(manifest.Chunks))
+	}
+	if manifest.Chunks[0].ChunkID != "hash123_0" {
+		t.Errorf("expected chunk id 'hash123_0', got %q", manifest.Chunks[0].ChunkID)
+	}
+	if manifest.Chunks[1].ChunkID != "hash123_1" {
+		t.Errorf("expected chunk id 'hash123_1', got %q", manifest.Chunks[1].ChunkID)
+	}
+	if manifest.Chunks[0].Hash != HashChunk("chunk A") {
+		t.Errorf("chunk[0] hash mismatch")
+	}
+	if manifest.Chunks[1].Hash != HashChunk("chunk B") {
+		t.Errorf("chunk[1] hash mismatch")
+	}
+}

--- a/go/knowledge/delta_test.go
+++ b/go/knowledge/delta_test.go
@@ -354,7 +354,7 @@ func TestReadChunkManifest_missing(t *testing.T) {
 	store := mem.New()
 	t.Cleanup(func() { _ = store.Close() })
 
-	loaded, err := ReadChunkManifest(ctx, store, "nonexistent")
+	loaded, err := ReadChunkManifest(ctx, store, "deadbeef0123456789abcdef")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -373,13 +373,13 @@ func TestWriteChunkManifest_increments_generation(t *testing.T) {
 		{DocumentID: "doc1", Ordinal: 0, Text: "content v1"},
 	}
 
-	manifest := BuildChunkManifest("docXYZ", chunks)
+	manifest := BuildChunkManifest("d0c000000000000000000000000000000000000000000000000000000000abcd", chunks)
 
 	if err := WriteChunkManifest(ctx, store, manifest); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
 
-	loaded, err := ReadChunkManifest(ctx, store, "docXYZ")
+	loaded, err := ReadChunkManifest(ctx, store, "d0c000000000000000000000000000000000000000000000000000000000abcd")
 	if err != nil {
 		t.Fatalf("first read: %v", err)
 	}
@@ -391,13 +391,13 @@ func TestWriteChunkManifest_increments_generation(t *testing.T) {
 	chunks2 := []Chunk{
 		{DocumentID: "doc1", Ordinal: 0, Text: "content v2"},
 	}
-	manifest2 := BuildChunkManifest("docXYZ", chunks2)
+	manifest2 := BuildChunkManifest("d0c000000000000000000000000000000000000000000000000000000000abcd", chunks2)
 
 	if err := WriteChunkManifest(ctx, store, manifest2); err != nil {
 		t.Fatalf("second write: %v", err)
 	}
 
-	loaded2, err := ReadChunkManifest(ctx, store, "docXYZ")
+	loaded2, err := ReadChunkManifest(ctx, store, "d0c000000000000000000000000000000000000000000000000000000000abcd")
 	if err != nil {
 		t.Fatalf("second read: %v", err)
 	}

--- a/sdks/ts/memory/src/ingest/delta.test.ts
+++ b/sdks/ts/memory/src/ingest/delta.test.ts
@@ -298,24 +298,24 @@ describe('readChunkManifest/writeChunkManifest', () => {
 
   it('returns undefined for missing manifest', async () => {
     const store = freshStore()
-    const loaded = await readChunkManifest(store, 'nonexistent')
+    const loaded = await readChunkManifest(store, 'deadbeef0123456789abcdef')
     expect(loaded).toBeUndefined()
   })
 
   it('increments generation on subsequent writes', async () => {
     const store = freshStore()
     const chunks1: Chunk[] = [makeChunk('content v1', 0)]
-    const manifest1 = buildChunkManifest('docXYZ', chunks1)
+    const manifest1 = buildChunkManifest('d0c000000000000000000000000000000000000000000000000000000000abcd', chunks1)
 
     await writeChunkManifest(store, manifest1)
-    const first = await readChunkManifest(store, 'docXYZ')
+    const first = await readChunkManifest(store, 'd0c000000000000000000000000000000000000000000000000000000000abcd')
     expect(first?.generation).toBe(1)
 
     const chunks2: Chunk[] = [makeChunk('content v2', 0)]
-    const manifest2 = buildChunkManifest('docXYZ', chunks2)
+    const manifest2 = buildChunkManifest('d0c000000000000000000000000000000000000000000000000000000000abcd', chunks2)
 
     await writeChunkManifest(store, manifest2)
-    const second = await readChunkManifest(store, 'docXYZ')
+    const second = await readChunkManifest(store, 'd0c000000000000000000000000000000000000000000000000000000000abcd')
     expect(second?.generation).toBe(2)
   })
 })

--- a/sdks/ts/memory/src/ingest/delta.test.ts
+++ b/sdks/ts/memory/src/ingest/delta.test.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for chunk-level change detection (delta computation and
+ * manifest persistence). Mirrors the test coverage in
+ * go/knowledge/delta_test.go.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { createMemStore } from '../store/memstore.js'
+import type { Store } from '../store/index.js'
+import type { Chunk } from './chunker.js'
+import {
+  buildChunkManifest,
+  computeChunkDeltas,
+  hashChunk,
+  readChunkManifest,
+  writeChunkManifest,
+} from './delta.js'
+
+const makeChunk = (content: string, ordinal: number): Chunk => ({
+  content,
+  ordinal,
+  headingPath: [],
+  startLine: 0,
+  endLine: 0,
+  tokens: Math.ceil(content.length / 4),
+})
+
+describe('hashChunk', () => {
+  it('produces deterministic output', () => {
+    const h1 = hashChunk('hello world')
+    const h2 = hashChunk('hello world')
+    expect(h1).toBe(h2)
+  })
+
+  it('produces different hashes for different content', () => {
+    const h1 = hashChunk('hello world')
+    const h2 = hashChunk('different content')
+    expect(h1).not.toBe(h2)
+  })
+
+  it('returns a 64-character hex string', () => {
+    const h = hashChunk('test')
+    expect(h).toMatch(/^[a-f0-9]{64}$/)
+  })
+})
+
+describe('computeChunkDeltas', () => {
+  it('marks all chunks as new when no manifest exists', () => {
+    const chunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+      makeChunk('gamma content', 2),
+    ]
+
+    const deltas = computeChunkDeltas(chunks, undefined)
+
+    expect(deltas).toHaveLength(3)
+    for (const d of deltas) {
+      expect(d.category).toBe('new')
+      expect(d.hash).toMatch(/^[a-f0-9]{64}$/)
+    }
+  })
+
+  it('marks all chunks as unchanged when hashes match', () => {
+    const chunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+    ]
+
+    const manifest = buildChunkManifest('doc1hash', chunks)
+
+    const deltas = computeChunkDeltas(chunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(2)
+    expect(added).toHaveLength(0)
+    expect(removed).toHaveLength(0)
+  })
+
+  it('detects added chunks by hash not in old manifest', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+      makeChunk('new paragraph', 2),
+    ]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(2)
+    expect(added).toHaveLength(1)
+    expect(added[0]?.chunk.content).toBe('new paragraph')
+    expect(removed).toHaveLength(0)
+  })
+
+  it('detects removed chunks by hash in old but not new', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [makeChunk('alpha content', 0)]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(1)
+    expect(removed).toHaveLength(1)
+    expect(removed[0]?.hash).toBe(hashChunk('beta content'))
+  })
+
+  it('marks reordered chunks as unchanged (same hashes, different positions)', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+      makeChunk('gamma content', 2),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [
+      makeChunk('gamma content', 0),
+      makeChunk('alpha content', 1),
+      makeChunk('beta content', 2),
+    ]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(3)
+    expect(added).toHaveLength(0)
+    expect(removed).toHaveLength(0)
+  })
+
+  it('handles complete document rewrite (all new hashes)', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('old alpha', 0),
+      makeChunk('old beta', 1),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [
+      makeChunk('new alpha', 0),
+      makeChunk('new beta', 1),
+      makeChunk('new gamma', 2),
+    ]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(0)
+    expect(added).toHaveLength(3)
+    expect(removed).toHaveLength(2)
+  })
+
+  it('handles one chunk changed while others remain identical', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+      makeChunk('gamma content', 2),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta MODIFIED content', 1),
+      makeChunk('gamma content', 2),
+    ]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(2)
+    expect(added).toHaveLength(1)
+    expect(added[0]?.chunk.content).toBe('beta MODIFIED content')
+    expect(removed).toHaveLength(1)
+    expect(removed[0]?.hash).toBe(hashChunk('beta content'))
+  })
+
+  it('handles duplicate content chunks correctly', () => {
+    const oldChunks: Chunk[] = [makeChunk('repeated', 0)]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const newChunks: Chunk[] = [makeChunk('repeated', 0), makeChunk('repeated', 1)]
+
+    const deltas = computeChunkDeltas(newChunks, manifest)
+
+    const unchanged = deltas.filter((d) => d.category === 'unchanged')
+    const added = deltas.filter((d) => d.category === 'new')
+    const removed = deltas.filter((d) => d.category === 'removed')
+
+    expect(unchanged).toHaveLength(1)
+    expect(added).toHaveLength(1)
+    expect(removed).toHaveLength(0)
+  })
+
+  it('returns empty when both inputs are empty', () => {
+    const deltas = computeChunkDeltas([], undefined)
+    expect(deltas).toHaveLength(0)
+  })
+
+  it('marks all old chunks as removed when new set is empty', () => {
+    const oldChunks: Chunk[] = [
+      makeChunk('alpha content', 0),
+      makeChunk('beta content', 1),
+    ]
+    const manifest = buildChunkManifest('doc1hash', oldChunks)
+
+    const deltas = computeChunkDeltas([], manifest)
+
+    const removed = deltas.filter((d) => d.category === 'removed')
+    expect(removed).toHaveLength(2)
+  })
+})
+
+describe('buildChunkManifest', () => {
+  it('builds entries with correct hash and chunkId', () => {
+    const chunks: Chunk[] = [makeChunk('chunk A', 0), makeChunk('chunk B', 1)]
+
+    const manifest = buildChunkManifest('hash123', chunks)
+
+    expect(manifest.documentHash).toBe('hash123')
+    expect(manifest.chunks).toHaveLength(2)
+    expect(manifest.chunks[0]?.hash).toBe(hashChunk('chunk A'))
+    expect(manifest.chunks[0]?.chunkId).toBe('hash123_0')
+    expect(manifest.chunks[1]?.hash).toBe(hashChunk('chunk B'))
+    expect(manifest.chunks[1]?.chunkId).toBe('hash123_1')
+  })
+})
+
+describe('readChunkManifest/writeChunkManifest', () => {
+  const stores: Store[] = []
+
+  afterEach(async () => {
+    while (stores.length > 0) {
+      const s = stores.pop()
+      if (s !== undefined) await s.close()
+    }
+  })
+
+  const freshStore = (): Store => {
+    const s = createMemStore()
+    stores.push(s)
+    return s
+  }
+
+  it('round-trips through store correctly', async () => {
+    const store = freshStore()
+    const chunks: Chunk[] = [
+      makeChunk('first chunk', 0),
+      makeChunk('second chunk', 1),
+      makeChunk('third chunk', 2),
+    ]
+
+    const manifest = buildChunkManifest('abc123def456', chunks)
+    await writeChunkManifest(store, manifest)
+
+    const loaded = await readChunkManifest(store, 'abc123def456')
+
+    expect(loaded).not.toBeUndefined()
+    expect(loaded?.documentHash).toBe('abc123def456')
+    expect(loaded?.generation).toBe(1)
+    expect(loaded?.chunks).toHaveLength(3)
+    expect(loaded?.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]
+      if (chunk === undefined) continue
+      expect(loaded?.chunks[i]?.hash).toBe(hashChunk(chunk.content))
+      expect(loaded?.chunks[i]?.chunkId).toBe(`abc123def456_${String(i)}`)
+    }
+  })
+
+  it('returns undefined for missing manifest', async () => {
+    const store = freshStore()
+    const loaded = await readChunkManifest(store, 'nonexistent')
+    expect(loaded).toBeUndefined()
+  })
+
+  it('increments generation on subsequent writes', async () => {
+    const store = freshStore()
+    const chunks1: Chunk[] = [makeChunk('content v1', 0)]
+    const manifest1 = buildChunkManifest('docXYZ', chunks1)
+
+    await writeChunkManifest(store, manifest1)
+    const first = await readChunkManifest(store, 'docXYZ')
+    expect(first?.generation).toBe(1)
+
+    const chunks2: Chunk[] = [makeChunk('content v2', 0)]
+    const manifest2 = buildChunkManifest('docXYZ', chunks2)
+
+    await writeChunkManifest(store, manifest2)
+    const second = await readChunkManifest(store, 'docXYZ')
+    expect(second?.generation).toBe(2)
+  })
+})

--- a/sdks/ts/memory/src/ingest/delta.ts
+++ b/sdks/ts/memory/src/ingest/delta.ts
@@ -23,6 +23,18 @@ import { isNotFound, toPath } from '../store/index.js'
 
 const CHUNK_MANIFESTS_PREFIX = 'raw/.chunk-manifests'
 
+/**
+ * Validates that a document hash is a lowercase hex string. Prevents
+ * path traversal attacks via crafted hash values.
+ */
+const VALID_DOCUMENT_HASH_RE = /^[a-f0-9]+$/
+
+const validateDocumentHash = (documentHash: string): void => {
+  if (!VALID_DOCUMENT_HASH_RE.test(documentHash)) {
+    throw new Error(`ingest: invalid document hash "${documentHash}": must match ^[a-f0-9]+$`)
+  }
+}
+
 export type ChunkManifestEntry = {
   readonly hash: string
   readonly chunkId: string
@@ -176,13 +188,29 @@ export const buildChunkManifest = (
   }
 }
 
-const manifestPath = (documentHash: string): string =>
-  `${CHUNK_MANIFESTS_PREFIX}/${documentHash}.json`
+const manifestPath = (documentHash: string): string => {
+  validateDocumentHash(documentHash)
+  return `${CHUNK_MANIFESTS_PREFIX}/${documentHash}.json`
+}
 
 /**
  * Loads the chunk manifest for a document from the store. Returns
  * undefined when the manifest does not exist (first ingest scenario).
  */
+/**
+ * Validates that a parsed JSON value has the required shape of a
+ * ChunkManifest. Returns undefined if invalid (treats as missing
+ * manifest, triggering first-ingest behaviour).
+ */
+const validateChunkManifest = (parsed: unknown): ChunkManifest | undefined => {
+  if (parsed === null || typeof parsed !== 'object') return undefined
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj['documentHash'] !== 'string') return undefined
+  if (typeof obj['generation'] !== 'number') return undefined
+  if (!Array.isArray(obj['chunks'])) return undefined
+  return parsed as ChunkManifest
+}
+
 export const readChunkManifest = async (
   store: Store,
   documentHash: string,
@@ -191,7 +219,7 @@ export const readChunkManifest = async (
   try {
     const data = await store.read(p)
     const parsed: unknown = JSON.parse(data.toString('utf8'))
-    return parsed as ChunkManifest
+    return validateChunkManifest(parsed)
   } catch (err: unknown) {
     if (isNotFound(err)) {
       return undefined

--- a/sdks/ts/memory/src/ingest/delta.ts
+++ b/sdks/ts/memory/src/ingest/delta.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Chunk-level change detection via content-hash delta comparison.
+ * Computes a SHA-256 hash per chunk during chunking and stores chunk
+ * hashes in a manifest alongside the document metadata. On re-ingest,
+ * compares new chunk hashes against the stored manifest to determine
+ * which chunks need re-embedding (new/changed), which can be skipped
+ * (unchanged), and which must be removed from the index (deleted).
+ *
+ * Matching is by CONTENT HASH regardless of position: a chunk that moves
+ * to a different ordinal but retains identical text is classified as
+ * unchanged and does not trigger re-embedding.
+ *
+ * Port of go/knowledge/delta.go.
+ */
+
+import { createHash } from 'node:crypto'
+
+import type { Chunk } from './chunker.js'
+import type { Store } from '../store/index.js'
+import { isNotFound, toPath } from '../store/index.js'
+
+const CHUNK_MANIFESTS_PREFIX = 'raw/.chunk-manifests'
+
+export type ChunkManifestEntry = {
+  readonly hash: string
+  readonly chunkId: string
+}
+
+export type ChunkManifest = {
+  readonly documentHash: string
+  readonly generation: number
+  readonly chunks: readonly ChunkManifestEntry[]
+  readonly updatedAt: string
+}
+
+export type DeltaCategory = 'unchanged' | 'new' | 'removed'
+
+export type ChunkDelta = {
+  readonly chunk: Chunk
+  readonly category: DeltaCategory
+  readonly hash: string
+}
+
+/**
+ * Computes a SHA-256 content hash of a chunk's text. This is the
+ * canonical hashing function for chunk-level change detection. When P1-2
+ * lands BLAKE3 support, this function becomes the single swap point.
+ */
+export const hashChunk = (text: string): string =>
+  createHash('sha256').update(text, 'utf8').digest('hex')
+
+/**
+ * Compares new chunks against a stored manifest and returns the delta
+ * set. Matching is by content hash regardless of position.
+ *
+ * When manifest is undefined (first ingest), all chunks are categorized
+ * as 'new'. Removed chunks carry a synthetic Chunk with ordinal from the
+ * prior manifest entry.
+ *
+ * Time: O(N + M) where N = newChunks.length, M = manifest.chunks.length.
+ * Space: O(N + M) for the hash lookup maps.
+ */
+export const computeChunkDeltas = (
+  newChunks: readonly Chunk[],
+  manifest: ChunkManifest | undefined,
+): readonly ChunkDelta[] => {
+  if (newChunks.length === 0 && manifest === undefined) {
+    return []
+  }
+
+  const newHashMap = new Map<string, number[]>()
+  const newHashes: string[] = []
+  for (let i = 0; i < newChunks.length; i++) {
+    const chunk = newChunks[i]
+    if (chunk === undefined) continue
+    const h = hashChunk(chunk.content)
+    newHashes.push(h)
+    const existing = newHashMap.get(h)
+    if (existing !== undefined) {
+      existing.push(i)
+    } else {
+      newHashMap.set(h, [i])
+    }
+  }
+
+  if (manifest === undefined) {
+    const out: ChunkDelta[] = []
+    for (let i = 0; i < newChunks.length; i++) {
+      const chunk = newChunks[i]
+      if (chunk === undefined) continue
+      const h = newHashes[i]
+      if (h === undefined) continue
+      out.push({ chunk, category: 'new', hash: h })
+    }
+    return out
+  }
+
+  const oldHashMap = new Map<string, number[]>()
+  for (let i = 0; i < manifest.chunks.length; i++) {
+    const entry = manifest.chunks[i]
+    if (entry === undefined) continue
+    const existing = oldHashMap.get(entry.hash)
+    if (existing !== undefined) {
+      existing.push(i)
+    } else {
+      oldHashMap.set(entry.hash, [i])
+    }
+  }
+
+  const matchedOld = new Set<number>()
+  const out: ChunkDelta[] = []
+
+  for (let i = 0; i < newChunks.length; i++) {
+    const chunk = newChunks[i]
+    if (chunk === undefined) continue
+    const h = newHashes[i]
+    if (h === undefined) continue
+    const oldIndices = oldHashMap.get(h)
+    let matched = false
+    if (oldIndices !== undefined) {
+      for (const oldIdx of oldIndices) {
+        if (!matchedOld.has(oldIdx)) {
+          matchedOld.add(oldIdx)
+          matched = true
+          break
+        }
+      }
+    }
+    const category: DeltaCategory = matched ? 'unchanged' : 'new'
+    out.push({ chunk, category, hash: h })
+  }
+
+  // Identify removed chunks: old entries with no match in new set.
+  for (let i = 0; i < manifest.chunks.length; i++) {
+    if (matchedOld.has(i)) continue
+    const entry = manifest.chunks[i]
+    if (entry === undefined) continue
+    const syntheticChunk: Chunk = {
+      content: '',
+      ordinal: i,
+      headingPath: [],
+      startLine: 0,
+      endLine: 0,
+      tokens: 0,
+    }
+    out.push({ chunk: syntheticChunk, category: 'removed', hash: entry.hash })
+  }
+
+  return out
+}
+
+/**
+ * Constructs a ChunkManifest from a set of chunks and their parent
+ * document hash.
+ */
+export const buildChunkManifest = (
+  documentHash: string,
+  chunks: readonly Chunk[],
+): ChunkManifest => {
+  const entries: ChunkManifestEntry[] = []
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]
+    if (chunk === undefined) continue
+    entries.push({
+      hash: hashChunk(chunk.content),
+      chunkId: `${documentHash}_${String(i)}`,
+    })
+  }
+  return {
+    documentHash,
+    generation: 0,
+    chunks: entries,
+    updatedAt: '',
+  }
+}
+
+const manifestPath = (documentHash: string): string =>
+  `${CHUNK_MANIFESTS_PREFIX}/${documentHash}.json`
+
+/**
+ * Loads the chunk manifest for a document from the store. Returns
+ * undefined when the manifest does not exist (first ingest scenario).
+ */
+export const readChunkManifest = async (
+  store: Store,
+  documentHash: string,
+): Promise<ChunkManifest | undefined> => {
+  const p = toPath(manifestPath(documentHash))
+  try {
+    const data = await store.read(p)
+    const parsed: unknown = JSON.parse(data.toString('utf8'))
+    return parsed as ChunkManifest
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      return undefined
+    }
+    throw err
+  }
+}
+
+/**
+ * Persists the chunk manifest for a document. Reads the prior manifest
+ * to increment the generation counter. When no prior manifest exists,
+ * generation starts at 1.
+ */
+export const writeChunkManifest = async (
+  store: Store,
+  manifest: ChunkManifest,
+): Promise<void> => {
+  const p = toPath(manifestPath(manifest.documentHash))
+  const prior = await readChunkManifest(store, manifest.documentHash)
+  const generation = prior !== undefined ? prior.generation + 1 : 1
+  const updatedAt = new Date().toISOString()
+  const toWrite: ChunkManifest = {
+    ...manifest,
+    generation,
+    updatedAt,
+  }
+  const data = Buffer.from(JSON.stringify(toWrite), 'utf8')
+  await store.write(p, data)
+}

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -59,6 +59,18 @@ export {
   type V1PipelineStateEntry,
 } from './state-machine.js'
 
+export {
+  buildChunkManifest,
+  computeChunkDeltas,
+  hashChunk,
+  readChunkManifest,
+  writeChunkManifest,
+  type ChunkDelta,
+  type ChunkManifest,
+  type ChunkManifestEntry,
+  type DeltaCategory,
+} from './delta.js'
+
 export * from './sources/index.js'
 
 export {


### PR DESCRIPTION
## Summary
- Content-hash manifests for chunk-level delta detection (only re-embed changed chunks)
- `ComputeChunkDeltas` with O(N+M) comparison — reordered chunks treated as unchanged
- Manifest persisted at `raw/.chunk-manifests/{documentHash}.json`
- Path traversal protection: documentHash validated as hex-only
- JSON schema validation on manifest parse (no unsafe casts)
- Cross-SDK: camelCase JSON field names standardised

## Test plan
- [ ] First ingest (no prior manifest) → all chunks "added"
- [ ] Re-ingest unchanged → all "unchanged", zero embedding calls needed
- [ ] One chunk changed → only that in "added", old in "removed"
- [ ] Manifest round-trip verified
- [ ] Invalid documentHash rejected
- [ ] 13 Go + 17 TS tests pass

Closes LLE-9781