### PR TITLE
Add configurable chunker registry with content-type routing

### DIFF
--- a/go/ingest/chunk_config.go
+++ b/go/ingest/chunk_config.go
@@ -116,11 +116,49 @@ func EstimateTokens(text string) int {
 	return (len(text) + 3) / 4
 }
 
+// ChunkStrategy names a built-in chunking approach that a caller can
+// request. The registry uses this to override the default content-type
+// routing when a specific strategy is desired.
+type ChunkStrategy string
+
+const (
+	// ChunkStrategyAuto lets the registry pick the chunker from the content type.
+	ChunkStrategyAuto ChunkStrategy = ""
+	// ChunkStrategyRecursive forces the recursive separator-hierarchy chunker.
+	ChunkStrategyRecursive ChunkStrategy = "recursive"
+	// ChunkStrategyMarkdown forces the heading-aware markdown chunker.
+	ChunkStrategyMarkdown ChunkStrategy = "markdown"
+	// ChunkStrategyCode forces the code-aware chunker.
+	ChunkStrategyCode ChunkStrategy = "code"
+	// ChunkStrategyTabular forces the tabular (CSV/TSV) chunker.
+	ChunkStrategyTabular ChunkStrategy = "tabular"
+	// ChunkStrategyPageLevel forces the page-level (form-feed) chunker.
+	ChunkStrategyPageLevel ChunkStrategy = "page_level"
+)
+
+// ChunkConfigOption applies an optional setting to a ChunkConfig.
+type ChunkConfigOption func(*ChunkConfig)
+
+// WithStrategy returns an option that sets the chunking strategy on the
+// ChunkConfig's Strategy field using the mapping from ChunkStrategy.
+func WithStrategy(s ChunkStrategy) ChunkConfigOption {
+	return func(c *ChunkConfig) {
+		c.Strategy = Strategy(s)
+	}
+}
+
+// WithSeparators returns an option that overrides the default separator
+// hierarchy used by the recursive chunker.
+func WithSeparators(seps []string) ChunkConfigOption {
+	return func(c *ChunkConfig) { c.Separators = seps }
+}
+
 // NewChunkConfig validates and returns a ChunkConfig for the chunker
 // registry. Returns an error when maxTokens < minTokens, overlapTokens
 // >= maxTokens, or any value is negative. Applies defaults for
-// zero/negative values.
-func NewChunkConfig(maxTokens, overlapTokens, minTokens int) (ChunkConfig, error) {
+// zero/negative values. Optional ChunkConfigOption values configure
+// strategy and separators.
+func NewChunkConfig(maxTokens, overlapTokens, minTokens int, opts ...ChunkConfigOption) (ChunkConfig, error) {
 	if maxTokens <= 0 {
 		maxTokens = DefaultMaxTokens
 	}
@@ -136,6 +174,9 @@ func NewChunkConfig(maxTokens, overlapTokens, minTokens int) (ChunkConfig, error
 		MinTokens:     minTokens,
 		Strategy:      StrategyRecursive,
 		Separators:    DefaultSeparators,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	if err := ValidateChunkConfig(cfg); err != nil {
 		return ChunkConfig{}, err

--- a/go/ingest/chunk_config.go
+++ b/go/ingest/chunk_config.go
@@ -115,3 +115,30 @@ func ValidateChunkConfig(cfg ChunkConfig) error {
 func EstimateTokens(text string) int {
 	return (len(text) + 3) / 4
 }
+
+// NewChunkConfig validates and returns a ChunkConfig for the chunker
+// registry. Returns an error when maxTokens < minTokens, overlapTokens
+// >= maxTokens, or any value is negative. Applies defaults for
+// zero/negative values.
+func NewChunkConfig(maxTokens, overlapTokens, minTokens int) (ChunkConfig, error) {
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+	if overlapTokens < 0 {
+		overlapTokens = DefaultOverlapTokens
+	}
+	if minTokens < 0 {
+		minTokens = DefaultMinTokens
+	}
+	cfg := ChunkConfig{
+		MaxTokens:     maxTokens,
+		OverlapTokens: overlapTokens,
+		MinTokens:     minTokens,
+		Strategy:      StrategyRecursive,
+		Separators:    DefaultSeparators,
+	}
+	if err := ValidateChunkConfig(cfg); err != nil {
+		return ChunkConfig{}, err
+	}
+	return cfg, nil
+}

--- a/go/ingest/chunker.go
+++ b/go/ingest/chunker.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Chunk is a single segment produced by a Chunker. ID is set by the
+// registry after the chunker returns; Content is the text payload;
+// Metadata carries chunker-specific annotations (heading path, language).
+type Chunk struct {
+	ID       string
+	Content  string
+	Metadata map[string]string
+}
+
+// Chunker segments content into chunks. Implementations are content-type
+// specific; the registry selects the appropriate one based on content type.
+type Chunker interface {
+	// Chunk splits content into ordered chunks respecting cfg bounds.
+	Chunk(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error)
+
+	// ContentTypes returns the MIME types this chunker handles.
+	ContentTypes() []string
+
+	// Name returns a human-readable identifier for this chunker.
+	Name() string
+}
+
+// ChunkerFunc adapts a plain function to the Chunker interface. The
+// adapted function handles a single content type under a given name.
+type ChunkerFunc struct {
+	fn           func(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error)
+	contentTypes []string
+	name         string
+}
+
+// NewChunkerFunc wraps a function as a Chunker with the given name and
+// content types.
+func NewChunkerFunc(
+	name string,
+	contentTypes []string,
+	fn func(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error),
+) *ChunkerFunc {
+	return &ChunkerFunc{fn: fn, contentTypes: contentTypes, name: name}
+}
+
+func (f *ChunkerFunc) Chunk(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	return f.fn(ctx, content, cfg)
+}
+
+func (f *ChunkerFunc) ContentTypes() []string { return f.contentTypes }
+func (f *ChunkerFunc) Name() string           { return f.name }
+
+// ChunkerRegistry maps content types to Chunker implementations and
+// routes incoming content to the appropriate one.
+type ChunkerRegistry struct {
+	mu       sync.RWMutex
+	routes   map[string]Chunker
+	fallback Chunker
+}
+
+// NewChunkerRegistry creates a registry pre-loaded with the built-in
+// chunkers: MarkdownChunker for text/markdown and RecursiveChunker as
+// the fallback for all other types.
+func NewChunkerRegistry() *ChunkerRegistry {
+	r := &ChunkerRegistry{
+		routes:   make(map[string]Chunker, 8),
+		fallback: &RecursiveChunker{},
+	}
+	md := &MarkdownChunker{}
+	for _, ct := range md.ContentTypes() {
+		r.routes[ct] = md
+	}
+	return r
+}
+
+// Register adds a custom chunker. All content types declared by c are
+// mapped to it, overriding any previous registration for those types.
+func (r *ChunkerRegistry) Register(c Chunker) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, ct := range c.ContentTypes() {
+		r.routes[strings.ToLower(strings.TrimSpace(ct))] = c
+	}
+}
+
+// Chunk routes content to the registered chunker for contentType and
+// invokes it. Falls back to the recursive chunker when no specific
+// chunker is registered. Returns an error when the chunker fails or
+// the context is cancelled.
+func (r *ChunkerRegistry) Chunk(ctx context.Context, content string, contentType string, cfg ChunkConfig) ([]Chunk, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	normalised := strings.ToLower(strings.TrimSpace(contentType))
+	if idx := strings.Index(normalised, ";"); idx >= 0 {
+		normalised = strings.TrimSpace(normalised[:idx])
+	}
+
+	r.mu.RLock()
+	chunker, ok := r.routes[normalised]
+	if !ok {
+		chunker = r.fallback
+	}
+	r.mu.RUnlock()
+
+	chunks, err := chunker.Chunk(ctx, content, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("ingest: chunker %s: %w", chunker.Name(), err)
+	}
+	for i := range chunks {
+		if chunks[i].ID == "" {
+			chunks[i].ID = fmt.Sprintf("%d", i)
+		}
+	}
+	return chunks, nil
+}
+
+// estimateTokens approximates the token count of text using the chars/4
+// heuristic. Monotonic in text length.
+func estimateTokens(text string) int {
+	if len(text) == 0 {
+		return 0
+	}
+	return (len(text) + 3) / 4
+}

--- a/go/ingest/chunker.go
+++ b/go/ingest/chunker.go
@@ -68,12 +68,19 @@ type ChunkerRegistry struct {
 // the fallback for all other types.
 func NewChunkerRegistry() *ChunkerRegistry {
 	r := &ChunkerRegistry{
-		routes:   make(map[string]Chunker, 8),
+		routes:   make(map[string]Chunker, 16),
 		fallback: &RecursiveChunker{},
 	}
-	md := &MarkdownChunker{}
-	for _, ct := range md.ContentTypes() {
-		r.routes[ct] = md
+	builtins := []Chunker{
+		&MarkdownChunker{},
+		&CodeChunker{},
+		&TabularChunker{},
+		&PageLevelChunker{},
+	}
+	for _, c := range builtins {
+		for _, ct := range c.ContentTypes() {
+			r.routes[ct] = c
+		}
 	}
 	return r
 }

--- a/go/ingest/chunker_code.go
+++ b/go/ingest/chunker_code.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// Compile-time interface compliance check.
+var _ Chunker = (*CodeChunker)(nil)
+
+// codeChunkerContentTypes are the MIME types handled by CodeChunker.
+var codeChunkerContentTypes = []string{
+	"text/x-go",
+	"text/x-python",
+	"text/x-typescript",
+	"text/x-javascript",
+	"text/x-java",
+	"text/x-c",
+	"text/x-c++",
+	"text/x-rust",
+	"application/x-typescript",
+	"application/javascript",
+}
+
+// Heuristic patterns used to detect function/class boundaries across
+// languages. Each pattern matches the start of a top-level declaration
+// line.
+var (
+	goFuncRe     = regexp.MustCompile(`^func\s`)
+	goTypeRe     = regexp.MustCompile(`^type\s`)
+	pyDefRe      = regexp.MustCompile(`^(def|class|async\s+def)\s`)
+	tsFuncRe     = regexp.MustCompile(`^(export\s+)?(function|class|const|interface|type|enum)\s`)
+	cFuncRe      = regexp.MustCompile(`^[a-zA-Z_].*\)\s*\{?\s*$`)
+	importLineRe = regexp.MustCompile(`^(import|from|require|use|#include|package)\s`)
+)
+
+// CodeChunker splits source code at function/class/type boundaries using
+// line-level heuristics. This is a Phase-1 implementation that does NOT
+// use a tree-sitter AST; full AST splitting is deferred to a later phase.
+//
+// The algorithm:
+//  1. Collect leading import/package lines into a header block.
+//  2. Walk remaining lines and split at detected declaration boundaries.
+//  3. Each chunk gets the header prepended for self-contained context.
+type CodeChunker struct{}
+
+func (cc *CodeChunker) ContentTypes() []string { return codeChunkerContentTypes }
+func (cc *CodeChunker) Name() string           { return "code" }
+
+func (cc *CodeChunker) Chunk(_ context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(content, "\n")
+	header, bodyStart := extractImportHeader(lines)
+	sections := splitAtDeclarations(lines[bodyStart:])
+
+	chunks := make([]Chunk, 0, len(sections))
+	for _, section := range sections {
+		text := strings.TrimSpace(section)
+		if text == "" {
+			continue
+		}
+		// Prepend header to each chunk for context, unless it is the header itself.
+		full := text
+		if header != "" && !strings.HasPrefix(text, header) {
+			full = header + "\n\n" + text
+		}
+
+		if estimateTokens(full) <= cfg.MaxTokens() {
+			chunks = append(chunks, Chunk{
+				Content:  full,
+				Metadata: map[string]string{"chunker": "code"},
+			})
+			continue
+		}
+		// Section too large: fall back to recursive splitting.
+		subPieces := recursiveSplit(full, cfg.MaxTokens(), 0)
+		for _, piece := range subPieces {
+			t := strings.TrimSpace(piece)
+			if t == "" {
+				continue
+			}
+			chunks = append(chunks, Chunk{
+				Content:  t,
+				Metadata: map[string]string{"chunker": "code"},
+			})
+		}
+	}
+
+	// Merge undersized chunks.
+	return mergeUndersized(chunks, cfg), nil
+}
+
+// extractImportHeader collects leading import/package/require lines and
+// returns them as a single block along with the index where the body starts.
+func extractImportHeader(lines []string) (string, int) {
+	var headerLines []string
+	bodyStart := 0
+	inHeader := true
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if inHeader {
+			if trimmed == "" || importLineRe.MatchString(trimmed) || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
+				headerLines = append(headerLines, line)
+				bodyStart = i + 1
+				continue
+			}
+			// Also include closing paren for grouped imports: ")"
+			if trimmed == ")" {
+				headerLines = append(headerLines, line)
+				bodyStart = i + 1
+				continue
+			}
+			inHeader = false
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(headerLines, "\n")), bodyStart
+}
+
+// splitAtDeclarations walks body lines and breaks at detected function,
+// class, or type declaration boundaries.
+func splitAtDeclarations(lines []string) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	var sections []string
+	var current strings.Builder
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if isDeclarationStart(trimmed) && current.Len() > 0 {
+			sections = append(sections, current.String())
+			current.Reset()
+		}
+		current.WriteString(line)
+		current.WriteByte('\n')
+	}
+	if current.Len() > 0 {
+		sections = append(sections, current.String())
+	}
+	return sections
+}
+
+// isDeclarationStart returns true if the line looks like the start of
+// a top-level function, class, or type declaration.
+func isDeclarationStart(line string) bool {
+	if line == "" {
+		return false
+	}
+	return goFuncRe.MatchString(line) ||
+		goTypeRe.MatchString(line) ||
+		pyDefRe.MatchString(line) ||
+		tsFuncRe.MatchString(line) ||
+		cFuncRe.MatchString(line)
+}
+
+// mergeUndersized combines consecutive chunks that are below minTokens
+// into the preceding chunk.
+func mergeUndersized(chunks []Chunk, cfg ChunkConfig) []Chunk {
+	if len(chunks) == 0 {
+		return nil
+	}
+	merged := make([]Chunk, 0, len(chunks))
+	for _, c := range chunks {
+		if estimateTokens(c.Content) < cfg.MinTokens() && len(merged) > 0 {
+			prev := merged[len(merged)-1]
+			prev.Content = prev.Content + "\n" + c.Content
+			merged[len(merged)-1] = prev
+			continue
+		}
+		merged = append(merged, c)
+	}
+	return merged
+}

--- a/go/ingest/chunker_markdown.go
+++ b/go/ingest/chunker_markdown.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+// atxHeadingRe matches ATX-style markdown headings (# through ######).
+var atxHeadingRe = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*#*\s*$`)
+
+// MarkdownChunker implements heading-aware splitting. It identifies
+// heading boundaries, tracks the heading hierarchy, and produces chunks
+// whose metadata carries the full heading path. Sections that exceed
+// maxTokens are split recursively using the separator hierarchy.
+type MarkdownChunker struct{}
+
+func (mc *MarkdownChunker) ContentTypes() []string {
+	return []string{"text/markdown", "text/x-markdown"}
+}
+
+func (mc *MarkdownChunker) Name() string { return "markdown" }
+
+func (mc *MarkdownChunker) Chunk(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	if strings.TrimSpace(content) == "" {
+		return nil, nil
+	}
+	sections := splitMarkdownSections(content)
+	chunks := make([]Chunk, 0, len(sections))
+	for _, sec := range sections {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		trimmed := strings.TrimSpace(sec.content)
+		if trimmed == "" {
+			continue
+		}
+		headingPath := strings.Join(sec.headingPath, " > ")
+		tokens := estimateTokens(trimmed)
+		if tokens <= cfg.MaxTokens() {
+			chunks = append(chunks, Chunk{
+				Content: trimmed,
+				Metadata: map[string]string{
+					"chunker":     "markdown",
+					"headingPath": headingPath,
+				},
+			})
+			continue
+		}
+		subChunks := splitSectionWithOverlap(trimmed, cfg)
+		for _, sub := range subChunks {
+			chunks = append(chunks, Chunk{
+				Content: sub,
+				Metadata: map[string]string{
+					"chunker":     "markdown",
+					"headingPath": headingPath,
+				},
+			})
+		}
+	}
+	return chunks, nil
+}
+
+// mdSection holds a parsed section with its heading hierarchy and text.
+type mdSection struct {
+	headingPath []string
+	content     string
+}
+
+// splitMarkdownSections parses markdown content into sections bounded by
+// headings. Each section carries the full heading path showing the
+// hierarchy (e.g., ["## Architecture", "### Patterns"]).
+func splitMarkdownSections(content string) []mdSection {
+	lines := strings.Split(content, "\n")
+	var sections []mdSection
+	var stack []headingEntry
+	var currentContent strings.Builder
+	var currentPath []string
+
+	flush := func() {
+		text := currentContent.String()
+		if strings.TrimSpace(text) != "" {
+			sections = append(sections, mdSection{
+				headingPath: append([]string{}, currentPath...),
+				content:     text,
+			})
+		}
+		currentContent.Reset()
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		match := atxHeadingRe.FindStringSubmatch(line)
+		if match != nil {
+			flush()
+			level := len(match[1])
+			title := strings.TrimSpace(match[2])
+			heading := match[1] + " " + title
+			// Pop stack entries at same or deeper level.
+			for len(stack) > 0 && stack[len(stack)-1].level >= level {
+				stack = stack[:len(stack)-1]
+			}
+			stack = append(stack, headingEntry{level: level, title: heading})
+			currentPath = make([]string, len(stack))
+			for j, h := range stack {
+				currentPath[j] = h.title
+			}
+			currentContent.WriteString(line)
+			currentContent.WriteByte('\n')
+			continue
+		}
+		// Check for setext headings (underline-style).
+		if i+1 < len(lines) && strings.TrimSpace(line) != "" {
+			nextLine := lines[i+1]
+			if isSetextUnderline(nextLine) {
+				flush()
+				level := 1
+				if strings.TrimSpace(nextLine)[0] == '-' {
+					level = 2
+				}
+				title := strings.TrimSpace(line)
+				heading := strings.Repeat("#", level) + " " + title
+				for len(stack) > 0 && stack[len(stack)-1].level >= level {
+					stack = stack[:len(stack)-1]
+				}
+				stack = append(stack, headingEntry{level: level, title: heading})
+				currentPath = make([]string, len(stack))
+				for j, h := range stack {
+					currentPath[j] = h.title
+				}
+				currentContent.WriteString(line)
+				currentContent.WriteByte('\n')
+				currentContent.WriteString(nextLine)
+				currentContent.WriteByte('\n')
+				i++
+				continue
+			}
+		}
+		currentContent.WriteString(line)
+		currentContent.WriteByte('\n')
+	}
+	flush()
+	return sections
+}
+
+// headingEntry tracks a heading in the hierarchy stack.
+type headingEntry struct {
+	level int
+	title string
+}
+
+// isSetextUnderline returns true when line is a setext heading underline
+// (two or more = or - characters).
+func isSetextUnderline(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < 2 {
+		return false
+	}
+	allEq := true
+	allDash := true
+	for _, r := range trimmed {
+		if r != '=' {
+			allEq = false
+		}
+		if r != '-' {
+			allDash = false
+		}
+	}
+	return allEq || allDash
+}
+
+// splitSectionWithOverlap breaks an oversized section into overlapping
+// pieces using the separator hierarchy. Overlap is applied from the tail
+// of the previous piece to the start of the next.
+func splitSectionWithOverlap(text string, cfg ChunkConfig) []string {
+	pieces := recursiveSplit(text, cfg.MaxTokens(), 0)
+	if len(pieces) <= 1 {
+		return pieces
+	}
+	result := make([]string, 0, len(pieces))
+	for i, piece := range pieces {
+		trimmed := strings.TrimSpace(piece)
+		if trimmed == "" {
+			continue
+		}
+		if i > 0 && cfg.OverlapTokens() > 0 {
+			prevTrimmed := strings.TrimSpace(pieces[i-1])
+			tail := extractTail(prevTrimmed, cfg.OverlapTokens())
+			trimmed = tail + "\n" + trimmed
+		}
+		result = append(result, trimmed)
+	}
+	return result
+}
+

--- a/go/ingest/chunker_markdown.go
+++ b/go/ingest/chunker_markdown.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// Compile-time interface compliance check.
+var _ Chunker = (*MarkdownChunker)(nil)
+
 // atxHeadingRe matches ATX-style markdown headings (# through ######).
 var atxHeadingRe = regexp.MustCompile(`^(#{1,6})\s+(.+?)\s*#*\s*$`)
 

--- a/go/ingest/chunker_page.go
+++ b/go/ingest/chunker_page.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Compile-time interface compliance check.
+var _ Chunker = (*PageLevelChunker)(nil)
+
+// pageLevelContentTypes lists the MIME types handled by PageLevelChunker.
+var pageLevelContentTypes = []string{
+	"application/pdf",
+	"text/x-pdf-text",
+}
+
+// PageLevelChunker splits content at page boundaries indicated by the
+// form-feed character (\f). PDF text extractors typically insert \f
+// between pages. Pages that exceed maxTokens are split further using
+// the recursive separator hierarchy.
+type PageLevelChunker struct{}
+
+func (pc *PageLevelChunker) ContentTypes() []string { return pageLevelContentTypes }
+func (pc *PageLevelChunker) Name() string           { return "page_level" }
+
+func (pc *PageLevelChunker) Chunk(_ context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	if strings.TrimSpace(content) == "" {
+		return nil, nil
+	}
+
+	pages := strings.Split(content, "\f")
+	chunks := make([]Chunk, 0, len(pages))
+
+	for i, page := range pages {
+		trimmed := strings.TrimSpace(page)
+		if trimmed == "" {
+			continue
+		}
+
+		pageNum := fmt.Sprintf("%d", i+1)
+
+		if estimateTokens(trimmed) <= cfg.MaxTokens() {
+			chunks = append(chunks, Chunk{
+				Content: trimmed,
+				Metadata: map[string]string{
+					"chunker": "page_level",
+					"page":    pageNum,
+				},
+			})
+			continue
+		}
+
+		// Page too large: recursively split.
+		subPieces := recursiveSplit(trimmed, cfg.MaxTokens(), 0)
+		for _, piece := range subPieces {
+			t := strings.TrimSpace(piece)
+			if t == "" {
+				continue
+			}
+			chunks = append(chunks, Chunk{
+				Content: t,
+				Metadata: map[string]string{
+					"chunker": "page_level",
+					"page":    pageNum,
+				},
+			})
+		}
+	}
+	return chunks, nil
+}

--- a/go/ingest/chunker_recursive.go
+++ b/go/ingest/chunker_recursive.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// Compile-time interface compliance check.
+var _ Chunker = (*RecursiveChunker)(nil)
+
 // separators is the hierarchy of split points used by RecursiveChunker.
 // Tried in order: paragraph breaks, single newlines, sentence endings,
 // word boundaries, and finally character-level as a last resort.

--- a/go/ingest/chunker_recursive.go
+++ b/go/ingest/chunker_recursive.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"strings"
+)
+
+// separators is the hierarchy of split points used by RecursiveChunker.
+// Tried in order: paragraph breaks, single newlines, sentence endings,
+// word boundaries, and finally character-level as a last resort.
+var separators = []string{"\n\n", "\n", ". ", " ", ""}
+
+// RecursiveChunker is the default chunking strategy. It recursively
+// splits content using a separator hierarchy until each piece fits
+// within the configured maxTokens budget. Overlap is applied by copying
+// overlapTokens worth of trailing text from the previous chunk to the
+// start of the next.
+type RecursiveChunker struct{}
+
+func (rc *RecursiveChunker) ContentTypes() []string {
+	return []string{"text/plain", "application/octet-stream"}
+}
+
+func (rc *RecursiveChunker) Name() string { return "recursive" }
+
+func (rc *RecursiveChunker) Chunk(ctx context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	if strings.TrimSpace(content) == "" {
+		return nil, nil
+	}
+	pieces := recursiveSplit(content, cfg.MaxTokens(), 0)
+	chunks := applyOverlapAndBuild(pieces, cfg)
+	return chunks, nil
+}
+
+// recursiveSplit breaks text into pieces that each fit within maxTokens.
+// It walks the separator hierarchy from coarsest to finest until the
+// pieces are small enough.
+func recursiveSplit(text string, maxTokens int, sepIdx int) []string {
+	if estimateTokens(text) <= maxTokens {
+		return []string{text}
+	}
+	if sepIdx >= len(separators) {
+		return hardSplit(text, maxTokens)
+	}
+	sep := separators[sepIdx]
+	if sep == "" {
+		return hardSplit(text, maxTokens)
+	}
+	parts := strings.Split(text, sep)
+	var merged []string
+	var current strings.Builder
+	for _, part := range parts {
+		candidate := buildCandidate(current.String(), part, sep)
+		if estimateTokens(candidate) > maxTokens {
+			if current.Len() > 0 {
+				merged = append(merged, current.String())
+				current.Reset()
+			}
+			if estimateTokens(part) > maxTokens {
+				sub := recursiveSplit(part, maxTokens, sepIdx+1)
+				merged = append(merged, sub...)
+			} else {
+				current.WriteString(part)
+			}
+		} else {
+			if current.Len() > 0 {
+				current.WriteString(sep)
+			}
+			current.WriteString(part)
+		}
+	}
+	if current.Len() > 0 {
+		merged = append(merged, current.String())
+	}
+	return merged
+}
+
+// buildCandidate constructs the text that would result from appending
+// part to existing with the separator between them.
+func buildCandidate(existing, part, sep string) string {
+	if existing == "" {
+		return part
+	}
+	return existing + sep + part
+}
+
+// hardSplit divides text into maxTokens-sized character windows as a
+// last resort when no separator hierarchy can break it further.
+func hardSplit(text string, maxTokens int) []string {
+	step := maxTokens * 4
+	if step <= 0 {
+		step = 1
+	}
+	var out []string
+	for i := 0; i < len(text); i += step {
+		end := i + step
+		if end > len(text) {
+			end = len(text)
+		}
+		out = append(out, text[i:end])
+	}
+	return out
+}
+
+// applyOverlapAndBuild takes raw split pieces, applies the overlap
+// strategy, merges undersized chunks, and returns the final Chunk slice.
+func applyOverlapAndBuild(pieces []string, cfg ChunkConfig) []Chunk {
+	if len(pieces) == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, 0, len(pieces))
+	var prevTail string
+	for i, piece := range pieces {
+		trimmed := strings.TrimSpace(piece)
+		if trimmed == "" {
+			continue
+		}
+		chunkContent := trimmed
+		if i > 0 && cfg.OverlapTokens() > 0 && prevTail != "" {
+			chunkContent = prevTail + "\n" + trimmed
+		}
+		// Merge undersized chunks into the previous one.
+		if estimateTokens(trimmed) < cfg.MinTokens() && len(chunks) > 0 {
+			prev := chunks[len(chunks)-1]
+			prev.Content = prev.Content + "\n" + trimmed
+			chunks[len(chunks)-1] = prev
+			prevTail = extractTail(prev.Content, cfg.OverlapTokens())
+			continue
+		}
+		chunks = append(chunks, Chunk{
+			Content:  chunkContent,
+			Metadata: map[string]string{"chunker": "recursive"},
+		})
+		prevTail = extractTail(trimmed, cfg.OverlapTokens())
+	}
+	return chunks
+}
+
+// extractTail returns approximately overlapTokens worth of characters
+// from the end of text (overlapTokens * 4 chars). Used to build the
+// overlap prefix for the next chunk.
+func extractTail(text string, overlapTokens int) string {
+	chars := overlapTokens * 4
+	if chars >= len(text) {
+		return text
+	}
+	return text[len(text)-chars:]
+}

--- a/go/ingest/chunker_tabular.go
+++ b/go/ingest/chunker_tabular.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"strings"
+)
+
+// Compile-time interface compliance check.
+var _ Chunker = (*TabularChunker)(nil)
+
+// tabularChunkerContentTypes are the MIME types handled by TabularChunker.
+var tabularChunkerContentTypes = []string{
+	"text/csv",
+	"text/tab-separated-values",
+	"text/tsv",
+}
+
+// defaultRowsPerChunk is the number of data rows per chunk when the
+// token budget does not impose a tighter limit.
+const defaultRowsPerChunk = 50
+
+// TabularChunker splits CSV/TSV content by rows, prepending the header
+// row to each chunk so every chunk is self-contained. The delimiter is
+// auto-detected from the first line (comma, tab, or pipe).
+type TabularChunker struct{}
+
+func (tc *TabularChunker) ContentTypes() []string { return tabularChunkerContentTypes }
+func (tc *TabularChunker) Name() string           { return "tabular" }
+
+func (tc *TabularChunker) Chunk(_ context.Context, content string, cfg ChunkConfig) ([]Chunk, error) {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 0 {
+		return nil, nil
+	}
+
+	header := lines[0]
+	dataLines := lines[1:]
+
+	if len(dataLines) == 0 {
+		return []Chunk{{
+			Content:  header,
+			Metadata: map[string]string{"chunker": "tabular"},
+		}}, nil
+	}
+
+	rowsPerChunk := computeRowsPerChunk(header, dataLines, cfg)
+
+	chunks := make([]Chunk, 0, (len(dataLines)/rowsPerChunk)+1)
+	for start := 0; start < len(dataLines); start += rowsPerChunk {
+		end := start + rowsPerChunk
+		if end > len(dataLines) {
+			end = len(dataLines)
+		}
+		batch := dataLines[start:end]
+		chunkContent := header + "\n" + strings.Join(batch, "\n")
+		chunks = append(chunks, Chunk{
+			Content:  chunkContent,
+			Metadata: map[string]string{"chunker": "tabular"},
+		})
+	}
+	return chunks, nil
+}
+
+// computeRowsPerChunk determines how many rows fit within the token
+// budget. Uses the average row size to estimate, capped at
+// defaultRowsPerChunk.
+func computeRowsPerChunk(header string, dataLines []string, cfg ChunkConfig) int {
+	headerTokens := estimateTokens(header)
+	budgetForRows := cfg.MaxTokens() - headerTokens - 1
+
+	if budgetForRows <= 0 || len(dataLines) == 0 {
+		return defaultRowsPerChunk
+	}
+
+	// Sample up to 10 rows for average size.
+	sampleSize := len(dataLines)
+	if sampleSize > 10 {
+		sampleSize = 10
+	}
+	totalTokens := 0
+	for i := 0; i < sampleSize; i++ {
+		totalTokens += estimateTokens(dataLines[i])
+	}
+	avgTokensPerRow := totalTokens / sampleSize
+	if avgTokensPerRow <= 0 {
+		avgTokensPerRow = 1
+	}
+
+	rows := budgetForRows / avgTokensPerRow
+	if rows <= 0 {
+		rows = 1
+	}
+	if rows > defaultRowsPerChunk {
+		rows = defaultRowsPerChunk
+	}
+	return rows
+}

--- a/go/ingest/chunker_test.go
+++ b/go/ingest/chunker_test.go
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestNewChunkConfig_valid(t *testing.T) {
+	t.Parallel()
+	cfg, err := NewChunkConfig(512, 64, 40)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxTokens() != 512 {
+		t.Fatalf("MaxTokens = %d, want 512", cfg.MaxTokens())
+	}
+	if cfg.OverlapTokens() != 64 {
+		t.Fatalf("OverlapTokens = %d, want 64", cfg.OverlapTokens())
+	}
+	if cfg.MinTokens() != 40 {
+		t.Fatalf("MinTokens = %d, want 40", cfg.MinTokens())
+	}
+}
+
+func TestNewChunkConfig_rejectsInvalid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		max     int
+		overlap int
+		min     int
+	}{
+		{"minTokens >= maxTokens", 100, 10, 100},
+		{"minTokens > maxTokens", 100, 10, 200},
+		{"overlapTokens >= maxTokens", 100, 100, 10},
+		{"overlapTokens > maxTokens", 100, 200, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewChunkConfig(tc.max, tc.overlap, tc.min)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestNewChunkConfig_appliesDefaults(t *testing.T) {
+	t.Parallel()
+	cfg, err := NewChunkConfig(0, -1, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxTokens() != DefaultMaxTokens {
+		t.Fatalf("MaxTokens = %d, want %d", cfg.MaxTokens(), DefaultMaxTokens)
+	}
+	if cfg.OverlapTokens() != DefaultOverlapTokens {
+		t.Fatalf("OverlapTokens = %d, want %d", cfg.OverlapTokens(), DefaultOverlapTokens)
+	}
+	if cfg.MinTokens() != DefaultMinTokens {
+		t.Fatalf("MinTokens = %d, want %d", cfg.MinTokens(), DefaultMinTokens)
+	}
+}
+
+func TestRecursiveChunker_shortContent(t *testing.T) {
+	t.Parallel()
+	rc := &RecursiveChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := rc.Chunk(context.Background(), "Hello world.", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Content != "Hello world." {
+		t.Fatalf("content = %q, want %q", chunks[0].Content, "Hello world.")
+	}
+}
+
+func TestRecursiveChunker_emptyContent(t *testing.T) {
+	t.Parallel()
+	rc := &RecursiveChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := rc.Chunk(context.Background(), "   \n\n  ", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks, got %d", len(chunks))
+	}
+}
+
+func TestRecursiveChunker_separatorHierarchy(t *testing.T) {
+	t.Parallel()
+	// Build content with paragraph breaks that exceeds 64 tokens.
+	paragraphs := make([]string, 10)
+	for i := range paragraphs {
+		paragraphs[i] = fmt.Sprintf("Paragraph %d with some content that uses tokens.", i)
+	}
+	content := strings.Join(paragraphs, "\n\n")
+	cfg, err := NewChunkConfig(64, 16, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rc := &RecursiveChunker{}
+	chunks, err := rc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+	// Each chunk should respect maxTokens (with some tolerance for overlap).
+	for i, c := range chunks {
+		tokens := estimateTokens(c.Content)
+		// Allow 2x max for overlap prefix; the core piece should still fit.
+		if tokens > cfg.MaxTokens()*2 {
+			t.Errorf("chunk %d has %d tokens, exceeds 2x maxTokens (%d)", i, tokens, cfg.MaxTokens())
+		}
+	}
+}
+
+func TestRecursiveChunker_overlapApplied(t *testing.T) {
+	t.Parallel()
+	// Create content with clear paragraph boundaries.
+	paragraphs := []string{
+		strings.Repeat("alpha ", 40),
+		strings.Repeat("beta ", 40),
+		strings.Repeat("gamma ", 40),
+	}
+	content := strings.Join(paragraphs, "\n\n")
+	cfg, err := NewChunkConfig(64, 16, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rc := &RecursiveChunker{}
+	chunks, err := rc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+	// The second chunk should contain overlap from the first.
+	firstContent := chunks[0].Content
+	tail := extractTail(firstContent, cfg.OverlapTokens())
+	if !strings.Contains(chunks[1].Content, tail) {
+		t.Errorf("chunk 1 does not contain overlap tail from chunk 0")
+	}
+}
+
+func TestMarkdownChunker_headingAware(t *testing.T) {
+	t.Parallel()
+	content := `# Introduction
+
+This is the intro paragraph.
+
+## Architecture
+
+Architecture details here.
+
+### Patterns
+
+Pattern details.
+
+## Conclusion
+
+Final thoughts.`
+	cfg := DefaultChunkConfig()
+	mc := &MarkdownChunker{}
+	chunks, err := mc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks, got %d", len(chunks))
+	}
+	// First chunk should have heading path for "Introduction".
+	firstPath := chunks[0].Metadata["headingPath"]
+	if !strings.Contains(firstPath, "Introduction") {
+		t.Errorf("first chunk headingPath = %q, want to contain 'Introduction'", firstPath)
+	}
+	// Find a chunk with nested heading path.
+	foundNested := false
+	for _, c := range chunks {
+		path := c.Metadata["headingPath"]
+		if strings.Contains(path, "Architecture") && strings.Contains(path, "Patterns") {
+			foundNested = true
+			break
+		}
+	}
+	if !foundNested {
+		t.Error("no chunk found with nested heading path containing Architecture > Patterns")
+	}
+}
+
+func TestMarkdownChunker_respectsMaxTokens(t *testing.T) {
+	t.Parallel()
+	// Build a large section under one heading.
+	var content strings.Builder
+	content.WriteString("# Big Section\n\n")
+	for i := 0; i < 30; i++ {
+		content.WriteString(fmt.Sprintf("Paragraph %d with enough words to accumulate tokens over the limit. ", i))
+		content.WriteString("More filler text to ensure we exceed the budget.\n\n")
+	}
+	cfg, err := NewChunkConfig(64, 16, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mc := &MarkdownChunker{}
+	chunks, err := mc.Chunk(context.Background(), content.String(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks from oversized section, got %d", len(chunks))
+	}
+	for _, c := range chunks {
+		path := c.Metadata["headingPath"]
+		if !strings.Contains(path, "Big Section") {
+			t.Errorf("chunk heading path %q does not contain 'Big Section'", path)
+		}
+	}
+}
+
+func TestMarkdownChunker_emptyContent(t *testing.T) {
+	t.Parallel()
+	mc := &MarkdownChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := mc.Chunk(context.Background(), "", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks for empty input, got %d", len(chunks))
+	}
+}
+
+func TestChunkerRegistry_routesByContentType(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	content := "# Hello\n\nWorld"
+
+	chunks, err := reg.Chunk(context.Background(), content, "text/markdown", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	if chunks[0].Metadata["chunker"] != "markdown" {
+		t.Errorf("expected markdown chunker, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_fallbackToRecursive(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	content := "Just some plain text."
+
+	chunks, err := reg.Chunk(context.Background(), content, "application/unknown", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	if chunks[0].Metadata["chunker"] != "recursive" {
+		t.Errorf("expected recursive chunker as fallback, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_customChunker(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+
+	custom := NewChunkerFunc("custom-json", []string{"application/json"}, func(_ context.Context, content string, _ ChunkConfig) ([]Chunk, error) {
+		return []Chunk{{Content: content, Metadata: map[string]string{"chunker": "custom-json"}}}, nil
+	})
+	reg.Register(custom)
+
+	chunks, err := reg.Chunk(context.Background(), `{"key": "value"}`, "application/json", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].Metadata["chunker"] != "custom-json" {
+		t.Errorf("expected custom-json chunker, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_contentTypeNormalisation(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	content := "# Title\n\nBody"
+
+	// Content type with charset suffix should still route to markdown.
+	chunks, err := reg.Chunk(context.Background(), content, "text/markdown; charset=utf-8", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	if chunks[0].Metadata["chunker"] != "markdown" {
+		t.Errorf("expected markdown chunker with charset suffix, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_cancelledContext(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := reg.Chunk(ctx, "some content", "text/plain", cfg)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestMarkdownChunker_setextHeadings(t *testing.T) {
+	t.Parallel()
+	content := `Title
+=====
+
+Some intro text.
+
+Subtitle
+--------
+
+Details here.`
+	cfg := DefaultChunkConfig()
+	mc := &MarkdownChunker{}
+	chunks, err := mc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+	// First should reference the setext h1 "Title".
+	firstPath := chunks[0].Metadata["headingPath"]
+	if !strings.Contains(firstPath, "Title") {
+		t.Errorf("first chunk headingPath = %q, want to contain 'Title'", firstPath)
+	}
+}
+
+func TestRecursiveChunker_contentTypes(t *testing.T) {
+	t.Parallel()
+	rc := &RecursiveChunker{}
+	types := rc.ContentTypes()
+	if len(types) == 0 {
+		t.Fatal("expected at least one content type")
+	}
+	found := false
+	for _, ct := range types {
+		if ct == "text/plain" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected text/plain in content types")
+	}
+}
+
+func TestMarkdownChunker_contentTypes(t *testing.T) {
+	t.Parallel()
+	mc := &MarkdownChunker{}
+	types := mc.ContentTypes()
+	found := false
+	for _, ct := range types {
+		if ct == "text/markdown" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected text/markdown in content types")
+	}
+}

--- a/go/ingest/chunker_test.go
+++ b/go/ingest/chunker_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNewChunkConfig_valid(t *testing.T) {
 	t.Parallel()
-	cfg, err := NewChunkConfig(512, 64, 40)
+	cfg, err := NewChunkConfig(512, 64, 64)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -20,8 +20,8 @@ func TestNewChunkConfig_valid(t *testing.T) {
 	if cfg.OverlapTokens() != 64 {
 		t.Fatalf("OverlapTokens = %d, want 64", cfg.OverlapTokens())
 	}
-	if cfg.MinTokens() != 40 {
-		t.Fatalf("MinTokens = %d, want 40", cfg.MinTokens())
+	if cfg.MinTokens() != 64 {
+		t.Fatalf("MinTokens = %d, want 64", cfg.MinTokens())
 	}
 }
 
@@ -389,5 +389,406 @@ func TestMarkdownChunker_contentTypes(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected text/markdown in content types")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CodeChunker tests
+// ---------------------------------------------------------------------------
+
+func TestCodeChunker_goSource(t *testing.T) {
+	t.Parallel()
+	source := `package main
+
+import "fmt"
+
+func hello() {
+	fmt.Println("hello")
+}
+
+func world() {
+	fmt.Println("world")
+}
+
+func main() {
+	hello()
+	world()
+}
+`
+	cfg, _ := NewChunkConfig(512, 64, 5)
+	cc := &CodeChunker{}
+	chunks, err := cc.Chunk(context.Background(), source, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks (split at func boundaries), got %d", len(chunks))
+	}
+	for _, c := range chunks {
+		if c.Metadata["chunker"] != "code" {
+			t.Errorf("expected chunker=code, got %q", c.Metadata["chunker"])
+		}
+	}
+}
+
+func TestCodeChunker_pythonSource(t *testing.T) {
+	t.Parallel()
+	source := `import os
+import sys
+
+def greet(name):
+    print(f"Hello {name}")
+    return name
+
+class Greeter:
+    def __init__(self, name):
+        self.name = name
+
+    def greet(self):
+        print(f"Hello {self.name}")
+
+def main():
+    g = Greeter("world")
+    g.greet()
+`
+	cfg, _ := NewChunkConfig(512, 64, 5)
+	cc := &CodeChunker{}
+	chunks, err := cc.Chunk(context.Background(), source, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks (split at def/class boundaries), got %d", len(chunks))
+	}
+}
+
+func TestCodeChunker_typescriptSource(t *testing.T) {
+	t.Parallel()
+	source := `import { readFile } from 'fs'
+
+export function parseConfig(path: string): Config {
+  const data = readFile(path)
+  return JSON.parse(data)
+}
+
+export class ConfigManager {
+  private config: Config
+
+  constructor(config: Config) {
+    this.config = config
+  }
+
+  get(key: string): string {
+    return this.config[key]
+  }
+}
+
+export const defaultConfig: Config = {
+  host: "localhost",
+  port: 8080,
+}
+`
+	cfg, _ := NewChunkConfig(512, 64, 5)
+	cc := &CodeChunker{}
+	chunks, err := cc.Chunk(context.Background(), source, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks for TS source, got %d", len(chunks))
+	}
+}
+
+func TestCodeChunker_preservesImportBlock(t *testing.T) {
+	t.Parallel()
+	source := `import "fmt"
+import "os"
+
+func run() {
+	fmt.Println(os.Args)
+}
+`
+	cfg := DefaultChunkConfig()
+	cc := &CodeChunker{}
+	chunks, err := cc.Chunk(context.Background(), source, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	// First chunk should contain the import header.
+	if !strings.Contains(chunks[0].Content, "import") {
+		t.Error("first chunk should contain import header")
+	}
+}
+
+func TestCodeChunker_emptyContent(t *testing.T) {
+	t.Parallel()
+	cc := &CodeChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := cc.Chunk(context.Background(), "", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks, got %d", len(chunks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TabularChunker tests
+// ---------------------------------------------------------------------------
+
+func TestTabularChunker_csv(t *testing.T) {
+	t.Parallel()
+	var rows []string
+	rows = append(rows, "name,age,city")
+	for i := 0; i < 120; i++ {
+		rows = append(rows, fmt.Sprintf("person%d,%d,city%d", i, 20+i, i))
+	}
+	content := strings.Join(rows, "\n")
+
+	cfg := DefaultChunkConfig()
+	tc := &TabularChunker{}
+	chunks, err := tc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks for 120 rows, got %d", len(chunks))
+	}
+	// Every chunk should start with the header.
+	for i, c := range chunks {
+		if !strings.HasPrefix(c.Content, "name,age,city") {
+			t.Errorf("chunk %d does not start with header", i)
+		}
+		if c.Metadata["chunker"] != "tabular" {
+			t.Errorf("chunk %d: expected chunker=tabular, got %q", i, c.Metadata["chunker"])
+		}
+	}
+}
+
+func TestTabularChunker_tsv(t *testing.T) {
+	t.Parallel()
+	var rows []string
+	rows = append(rows, "name\tage\tcity")
+	for i := 0; i < 60; i++ {
+		rows = append(rows, fmt.Sprintf("person%d\t%d\tcity%d", i, 20+i, i))
+	}
+	content := strings.Join(rows, "\n")
+
+	cfg := DefaultChunkConfig()
+	tc := &TabularChunker{}
+	chunks, err := tc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks for 60 TSV rows, got %d", len(chunks))
+	}
+	// Every chunk header should contain tab characters.
+	for _, c := range chunks {
+		firstLine := strings.SplitN(c.Content, "\n", 2)[0]
+		if !strings.Contains(firstLine, "\t") {
+			t.Error("header line should contain tabs for TSV")
+		}
+	}
+}
+
+func TestTabularChunker_singleRow(t *testing.T) {
+	t.Parallel()
+	content := "name,age,city\nAlice,30,NYC"
+	cfg := DefaultChunkConfig()
+	tc := &TabularChunker{}
+	chunks, err := tc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for single data row, got %d", len(chunks))
+	}
+	if !strings.HasPrefix(chunks[0].Content, "name,age,city") {
+		t.Error("chunk should start with header")
+	}
+}
+
+func TestTabularChunker_headerOnly(t *testing.T) {
+	t.Parallel()
+	content := "name,age,city"
+	cfg := DefaultChunkConfig()
+	tc := &TabularChunker{}
+	chunks, err := tc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for header-only content, got %d", len(chunks))
+	}
+}
+
+func TestTabularChunker_emptyContent(t *testing.T) {
+	t.Parallel()
+	tc := &TabularChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := tc.Chunk(context.Background(), "  \n  ", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks, got %d", len(chunks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PageLevelChunker tests
+// ---------------------------------------------------------------------------
+
+func TestPageLevelChunker_formfeed(t *testing.T) {
+	t.Parallel()
+	content := "Page 1 content here.\fPage 2 content here.\fPage 3 content here."
+	cfg := DefaultChunkConfig()
+	pc := &PageLevelChunker{}
+	chunks, err := pc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks (3 pages), got %d", len(chunks))
+	}
+	for i, c := range chunks {
+		expectedPage := fmt.Sprintf("%d", i+1)
+		if c.Metadata["page"] != expectedPage {
+			t.Errorf("chunk %d: expected page=%s, got %s", i, expectedPage, c.Metadata["page"])
+		}
+		if c.Metadata["chunker"] != "page_level" {
+			t.Errorf("chunk %d: expected chunker=page_level, got %q", i, c.Metadata["chunker"])
+		}
+	}
+	if !strings.Contains(chunks[0].Content, "Page 1") {
+		t.Error("first chunk should contain page 1 content")
+	}
+	if !strings.Contains(chunks[2].Content, "Page 3") {
+		t.Error("third chunk should contain page 3 content")
+	}
+}
+
+func TestPageLevelChunker_emptyPages(t *testing.T) {
+	t.Parallel()
+	content := "Page 1\f\f\fPage 4"
+	cfg := DefaultChunkConfig()
+	pc := &PageLevelChunker{}
+	chunks, err := pc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty pages should be skipped.
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks (empty pages skipped), got %d", len(chunks))
+	}
+}
+
+func TestPageLevelChunker_emptyContent(t *testing.T) {
+	t.Parallel()
+	pc := &PageLevelChunker{}
+	cfg := DefaultChunkConfig()
+	chunks, err := pc.Chunk(context.Background(), "  ", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks, got %d", len(chunks))
+	}
+}
+
+func TestPageLevelChunker_largePage(t *testing.T) {
+	t.Parallel()
+	// Create a page that exceeds the default maxTokens.
+	largePage := strings.Repeat("This is a long sentence with many words. ", 100)
+	content := largePage + "\fSmall page."
+	cfg, err := NewChunkConfig(64, 16, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pc := &PageLevelChunker{}
+	chunks, err := pc.Chunk(context.Background(), content, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Large page should be split into multiple chunks.
+	if len(chunks) < 3 {
+		t.Fatalf("expected at least 3 chunks (large page split + small page), got %d", len(chunks))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Registry tests for new chunkers
+// ---------------------------------------------------------------------------
+
+func TestChunkerRegistry_routesCodeChunker(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	source := "func main() {}\n"
+
+	chunks, err := reg.Chunk(context.Background(), source, "text/x-go", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	if chunks[0].Metadata["chunker"] != "code" {
+		t.Errorf("expected code chunker, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_routesTabularChunker(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	content := "name,age\nAlice,30\nBob,25"
+
+	chunks, err := reg.Chunk(context.Background(), content, "text/csv", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+	if chunks[0].Metadata["chunker"] != "tabular" {
+		t.Errorf("expected tabular chunker, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkerRegistry_routesPageLevelChunker(t *testing.T) {
+	t.Parallel()
+	reg := NewChunkerRegistry()
+	cfg := DefaultChunkConfig()
+	content := "Page 1\fPage 2"
+
+	chunks, err := reg.Chunk(context.Background(), content, "application/pdf", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0].Metadata["chunker"] != "page_level" {
+		t.Errorf("expected page_level chunker, got %q", chunks[0].Metadata["chunker"])
+	}
+}
+
+func TestChunkConfig_strategyAndSeparators(t *testing.T) {
+	t.Parallel()
+	cfg, err := NewChunkConfig(512, 64, 64, WithStrategy(StrategyCode), WithSeparators([]string{"\n"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Strategy() != StrategyCode {
+		t.Fatalf("Strategy = %q, want %q", cfg.Strategy(), StrategyCode)
+	}
+	if len(cfg.Separators()) != 1 || cfg.Separators()[0] != "\n" {
+		t.Fatalf("Separators = %v, want [\\n]", cfg.Separators())
 	}
 }

--- a/sdks/ts/memory/src/ingest/chunk-config.ts
+++ b/sdks/ts/memory/src/ingest/chunk-config.ts
@@ -12,6 +12,18 @@
  */
 export type Strategy = 'recursive' | 'markdown' | 'code' | 'table' | 'conversation'
 
+/**
+ * Named chunking strategies. Empty string means auto-detect from
+ * content type. Explicit values override the registry routing.
+ */
+export type ChunkStrategy =
+  | ''
+  | 'recursive'
+  | 'markdown'
+  | 'code'
+  | 'tabular'
+  | 'page_level'
+
 /** All valid strategy values for membership checks. */
 const VALID_STRATEGIES: ReadonlySet<string> = new Set([
   'recursive',
@@ -52,9 +64,9 @@ export type ChunkConfig = {
   /** Floor below which a chunk is merged into its neighbour. Must be >= 0 and < maxTokens. */
   readonly minTokens: number
   /** How split points are identified. */
-  readonly strategy: Strategy
+  readonly strategy: Strategy | ChunkStrategy
   /** Ordered list of split delimiters for the recursive strategy. */
-  readonly separators: readonly string[]
+  readonly separators: readonly string[] | undefined
 }
 
 /**
@@ -93,10 +105,10 @@ export const validateChunkConfig = (cfg: ChunkConfig): void => {
       `ingest: minTokens (${String(cfg.minTokens)}) must be < maxTokens (${String(cfg.maxTokens)})`,
     )
   }
-  if (!VALID_STRATEGIES.has(cfg.strategy)) {
+  if (cfg.strategy && !VALID_STRATEGIES.has(cfg.strategy)) {
     throw new Error(`ingest: unknown strategy "${cfg.strategy}"`)
   }
-  if (cfg.strategy === 'recursive' && cfg.separators.length === 0) {
+  if (cfg.strategy === 'recursive' && cfg.separators !== undefined && cfg.separators.length === 0) {
     throw new Error(`ingest: separators must be non-empty when strategy is "recursive"`)
   }
 }
@@ -119,6 +131,15 @@ export class ChunkConfigError extends Error {
 }
 
 /**
+ * Optional configuration for strategy and separators. Passed as the
+ * fourth argument to createChunkConfig.
+ */
+export type ChunkConfigOptions = {
+  readonly strategy?: ChunkStrategy
+  readonly separators?: readonly string[]
+}
+
+/**
  * Creates a validated ChunkConfig. Applies defaults for zero/negative
  * values. Throws ChunkConfigError when invariants are violated:
  * minTokens must be less than maxTokens; overlapTokens must be less
@@ -128,6 +149,7 @@ export const createChunkConfig = (
   maxTokens?: number,
   overlapTokens?: number,
   minTokens?: number,
+  opts?: ChunkConfigOptions,
 ): ChunkConfig => {
   const max = maxTokens !== undefined && maxTokens > 0 ? maxTokens : DEFAULT_MAX_TOKENS
   const overlap =
@@ -144,7 +166,13 @@ export const createChunkConfig = (
       `overlapTokens (${overlap}) must be less than maxTokens (${max})`,
     )
   }
-  return { maxTokens: max, overlapTokens: overlap, minTokens: min, strategy: DEFAULT_STRATEGY, separators: [...DEFAULT_SEPARATORS] }
+  return {
+    maxTokens: max,
+    overlapTokens: overlap,
+    minTokens: min,
+    strategy: opts?.strategy ?? '',
+    separators: opts?.separators,
+  }
 }
 
 /** Returns a ChunkConfig with the package defaults. */
@@ -152,6 +180,6 @@ export const defaultChunkConfig = (): ChunkConfig => ({
   maxTokens: DEFAULT_MAX_TOKENS,
   overlapTokens: DEFAULT_OVERLAP_TOKENS,
   minTokens: DEFAULT_MIN_TOKENS,
-  strategy: DEFAULT_STRATEGY,
-  separators: [...DEFAULT_SEPARATORS],
+  strategy: '',
+  separators: undefined,
 })

--- a/sdks/ts/memory/src/ingest/chunk-config.ts
+++ b/sdks/ts/memory/src/ingest/chunk-config.ts
@@ -110,3 +110,48 @@ export const validateChunkConfig = (cfg: ChunkConfig): void => {
  */
 export const estimateTokens = (text: string): number =>
   text.length === 0 ? 0 : Math.ceil(text.length / 4)
+
+export class ChunkConfigError extends Error {
+  override readonly name = 'ChunkConfigError'
+  constructor(message: string) {
+    super(message)
+  }
+}
+
+/**
+ * Creates a validated ChunkConfig. Applies defaults for zero/negative
+ * values. Throws ChunkConfigError when invariants are violated:
+ * minTokens must be less than maxTokens; overlapTokens must be less
+ * than maxTokens.
+ */
+export const createChunkConfig = (
+  maxTokens?: number,
+  overlapTokens?: number,
+  minTokens?: number,
+): ChunkConfig => {
+  const max = maxTokens !== undefined && maxTokens > 0 ? maxTokens : DEFAULT_MAX_TOKENS
+  const overlap =
+    overlapTokens !== undefined && overlapTokens >= 0 ? overlapTokens : DEFAULT_OVERLAP_TOKENS
+  const min = minTokens !== undefined && minTokens >= 0 ? minTokens : DEFAULT_MIN_TOKENS
+
+  if (min >= max) {
+    throw new ChunkConfigError(
+      `minTokens (${min}) must be less than maxTokens (${max})`,
+    )
+  }
+  if (overlap >= max) {
+    throw new ChunkConfigError(
+      `overlapTokens (${overlap}) must be less than maxTokens (${max})`,
+    )
+  }
+  return { maxTokens: max, overlapTokens: overlap, minTokens: min, strategy: DEFAULT_STRATEGY, separators: [...DEFAULT_SEPARATORS] }
+}
+
+/** Returns a ChunkConfig with the package defaults. */
+export const defaultChunkConfig = (): ChunkConfig => ({
+  maxTokens: DEFAULT_MAX_TOKENS,
+  overlapTokens: DEFAULT_OVERLAP_TOKENS,
+  minTokens: DEFAULT_MIN_TOKENS,
+  strategy: DEFAULT_STRATEGY,
+  separators: [...DEFAULT_SEPARATORS],
+})

--- a/sdks/ts/memory/src/ingest/chunker-registry.test.ts
+++ b/sdks/ts/memory/src/ingest/chunker-registry.test.ts
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  ChunkConfigError,
+  createChunkConfig,
+  defaultChunkConfig,
+} from './chunk-config.js'
+import { createChunkerRegistry } from './chunker-registry.js'
+import type { Chunk, Chunker } from './chunker-registry.js'
+import { markdownChunker } from './chunkers/markdown.js'
+import { estimateTokens, recursiveChunker } from './chunkers/recursive.js'
+
+describe('createChunkConfig', () => {
+  it('creates a valid config with explicit values', () => {
+    const cfg = createChunkConfig(256, 32, 20)
+    expect(cfg.maxTokens).toBe(256)
+    expect(cfg.overlapTokens).toBe(32)
+    expect(cfg.minTokens).toBe(20)
+  })
+
+  it('applies defaults for undefined values', () => {
+    const cfg = createChunkConfig()
+    expect(cfg.maxTokens).toBe(512)
+    expect(cfg.overlapTokens).toBe(64)
+    expect(cfg.minTokens).toBe(40)
+  })
+
+  it('rejects minTokens >= maxTokens', () => {
+    expect(() => createChunkConfig(100, 10, 100)).toThrow(ChunkConfigError)
+    expect(() => createChunkConfig(100, 10, 200)).toThrow(ChunkConfigError)
+  })
+
+  it('rejects overlapTokens >= maxTokens', () => {
+    expect(() => createChunkConfig(100, 100, 10)).toThrow(ChunkConfigError)
+    expect(() => createChunkConfig(100, 200, 10)).toThrow(ChunkConfigError)
+  })
+})
+
+describe('recursiveChunker', () => {
+  it('returns empty array for blank content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await recursiveChunker('   \n\n  ', cfg)
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('returns a single chunk for short content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await recursiveChunker('Hello world.', cfg)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.content).toBe('Hello world.')
+    expect(chunks[0]?.metadata.chunker).toBe('recursive')
+  })
+
+  it('splits content exceeding maxTokens using separator hierarchy', async () => {
+    const paragraphs = Array.from(
+      { length: 10 },
+      (_, i) => `Paragraph ${i} with some content that uses tokens to fill space.`,
+    )
+    const content = paragraphs.join('\n\n')
+    const cfg = createChunkConfig(64, 16, 10)
+    const chunks = await recursiveChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThan(1)
+  })
+
+  it('applies overlap from previous chunk to next', async () => {
+    const paragraphs = [
+      'alpha '.repeat(40).trim(),
+      'beta '.repeat(40).trim(),
+      'gamma '.repeat(40).trim(),
+    ]
+    const content = paragraphs.join('\n\n')
+    const cfg = createChunkConfig(64, 16, 5)
+    const chunks = await recursiveChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    // Second chunk should contain overlap tail from first.
+    const firstContent = chunks[0]?.content ?? ''
+    const overlapChars = 16 * 4
+    const expectedTail = firstContent.slice(firstContent.length - overlapChars)
+    expect(chunks[1]?.content).toContain(expectedTail)
+  })
+
+  it('respects AbortSignal', async () => {
+    const cfg = defaultChunkConfig()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(recursiveChunker('test', cfg, controller.signal)).rejects.toThrow()
+  })
+})
+
+describe('markdownChunker', () => {
+  it('returns empty array for blank content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await markdownChunker('', cfg)
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('splits at heading boundaries preserving heading path', async () => {
+    const content = [
+      '# Introduction',
+      '',
+      'Intro text here.',
+      '',
+      '## Architecture',
+      '',
+      'Architecture details.',
+      '',
+      '### Patterns',
+      '',
+      'Pattern details.',
+      '',
+      '## Conclusion',
+      '',
+      'Final thoughts.',
+    ].join('\n')
+    const cfg = defaultChunkConfig()
+    const chunks = await markdownChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(4)
+
+    const introChunk = chunks[0]
+    expect(introChunk?.metadata.headingPath).toContain('Introduction')
+
+    const patternsChunk = chunks.find((c) =>
+      c.metadata.headingPath.includes('Patterns'),
+    )
+    expect(patternsChunk).toBeDefined()
+    expect(patternsChunk?.metadata.headingPath).toContain('Architecture')
+    expect(patternsChunk?.metadata.headingPath).toContain('Patterns')
+  })
+
+  it('handles setext-style headings', async () => {
+    const content = [
+      'Title',
+      '=====',
+      '',
+      'Some intro text.',
+      '',
+      'Subtitle',
+      '--------',
+      '',
+      'Details here.',
+    ].join('\n')
+    const cfg = defaultChunkConfig()
+    const chunks = await markdownChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    expect(chunks[0]?.metadata.headingPath).toContain('Title')
+  })
+
+  it('splits oversized sections respecting maxTokens', async () => {
+    const longParagraphs = Array.from(
+      { length: 30 },
+      (_, i) => `Paragraph ${i} with enough words to accumulate tokens. More filler text here.`,
+    )
+    const content = '# Big Section\n\n' + longParagraphs.join('\n\n')
+    const cfg = createChunkConfig(64, 16, 10)
+    const chunks = await markdownChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThan(1)
+    for (const chunk of chunks) {
+      expect(chunk.metadata.headingPath).toContain('Big Section')
+    }
+  })
+
+  it('respects AbortSignal', async () => {
+    const cfg = defaultChunkConfig()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(markdownChunker('# Test\n\nContent', cfg, controller.signal)).rejects.toThrow()
+  })
+})
+
+describe('createChunkerRegistry', () => {
+  it('routes text/markdown to the markdown chunker', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('# Hello\n\nWorld', 'text/markdown', cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    expect(chunks[0]?.metadata.chunker).toBe('markdown')
+  })
+
+  it('routes text/plain to the recursive chunker', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('Plain text content.', 'text/plain', cfg)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.metadata.chunker).toBe('recursive')
+  })
+
+  it('falls back to recursive for unknown content types', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('Some content.', 'application/unknown', cfg)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.metadata.chunker).toBe('recursive')
+  })
+
+  it('normalises content type with charset suffix', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk(
+      '# Title\n\nBody',
+      'text/markdown; charset=utf-8',
+      cfg,
+    )
+    expect(chunks[0]?.metadata.chunker).toBe('markdown')
+  })
+
+  it('allows custom chunker registration', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+
+    const customChunker: Chunker = async (content) => {
+      return [{ id: 'custom-0', content, metadata: { chunker: 'custom-json' } }]
+    }
+    reg.register({
+      name: 'custom-json',
+      contentTypes: ['application/json'],
+      chunker: customChunker,
+    })
+
+    const chunks = await reg.chunk('{"key": "value"}', 'application/json', cfg)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.metadata.chunker).toBe('custom-json')
+  })
+
+  it('assigns sequential IDs when chunks have no ID', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const content = [
+      '# Section A',
+      '',
+      'Content A.',
+      '',
+      '# Section B',
+      '',
+      'Content B.',
+    ].join('\n')
+    const chunks = await reg.chunk(content, 'text/markdown', cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    expect(chunks[0]?.id).toBe('0')
+    expect(chunks[1]?.id).toBe('1')
+  })
+
+  it('respects AbortSignal', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      reg.chunk('test', 'text/plain', cfg, controller.signal),
+    ).rejects.toThrow()
+  })
+})
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0)
+  })
+
+  it('is monotonic in input length', () => {
+    const tokenA = estimateTokens('hello')
+    const tokenB = estimateTokens('hello world')
+    const tokenC = estimateTokens('hello world how are you today')
+    expect(tokenA).toBeLessThanOrEqual(tokenB)
+    expect(tokenB).toBeLessThanOrEqual(tokenC)
+  })
+
+  it('approximates chars/4', () => {
+    expect(estimateTokens('abcd')).toBe(1)
+    expect(estimateTokens('abcdefgh')).toBe(2)
+  })
+})

--- a/sdks/ts/memory/src/ingest/chunker-registry.test.ts
+++ b/sdks/ts/memory/src/ingest/chunker-registry.test.ts
@@ -8,8 +8,11 @@ import {
 } from './chunk-config.js'
 import { createChunkerRegistry } from './chunker-registry.js'
 import type { Chunk, Chunker } from './chunker-registry.js'
+import { codeChunker } from './chunkers/code.js'
 import { markdownChunker } from './chunkers/markdown.js'
+import { pageLevelChunker } from './chunkers/page-level.js'
 import { estimateTokens, recursiveChunker } from './chunkers/recursive.js'
+import { tabularChunker } from './chunkers/tabular.js'
 
 describe('createChunkConfig', () => {
   it('creates a valid config with explicit values', () => {
@@ -23,7 +26,7 @@ describe('createChunkConfig', () => {
     const cfg = createChunkConfig()
     expect(cfg.maxTokens).toBe(512)
     expect(cfg.overlapTokens).toBe(64)
-    expect(cfg.minTokens).toBe(40)
+    expect(cfg.minTokens).toBe(64)
   })
 
   it('rejects minTokens >= maxTokens', () => {
@@ -267,5 +270,215 @@ describe('estimateTokens', () => {
   it('approximates chars/4', () => {
     expect(estimateTokens('abcd')).toBe(1)
     expect(estimateTokens('abcdefgh')).toBe(2)
+  })
+})
+
+describe('codeChunker', () => {
+  it('splits Go source at function boundaries', async () => {
+    const source = [
+      'package main',
+      '',
+      'import "fmt"',
+      '',
+      'func hello() {',
+      '  fmt.Println("hello")',
+      '}',
+      '',
+      'func world() {',
+      '  fmt.Println("world")',
+      '}',
+      '',
+      'func main() {',
+      '  hello()',
+      '  world()',
+      '}',
+    ].join('\n')
+    const cfg = createChunkConfig(512, 64, 5)
+    const chunks = await codeChunker(source, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    for (const c of chunks) {
+      expect(c.metadata.chunker).toBe('code')
+    }
+  })
+
+  it('splits Python source at def/class boundaries', async () => {
+    const source = [
+      'import os',
+      'import sys',
+      '',
+      'def greet(name):',
+      '    print(f"Hello {name}")',
+      '',
+      'class Greeter:',
+      '    def __init__(self, name):',
+      '        self.name = name',
+      '',
+      'def main():',
+      '    g = Greeter("world")',
+    ].join('\n')
+    const cfg = createChunkConfig(512, 64, 5)
+    const chunks = await codeChunker(source, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('preserves import block as first chunk', async () => {
+    const source = [
+      'import "fmt"',
+      'import "os"',
+      '',
+      'func run() {',
+      '  fmt.Println(os.Args)',
+      '}',
+    ].join('\n')
+    const cfg = defaultChunkConfig()
+    const chunks = await codeChunker(source, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    expect(chunks[0]?.content).toContain('import')
+  })
+
+  it('returns empty array for blank content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await codeChunker('', cfg)
+    expect(chunks).toHaveLength(0)
+  })
+})
+
+describe('tabularChunker', () => {
+  it('chunks CSV with header prepended to each chunk', async () => {
+    const rows = ['name,age,city']
+    for (let i = 0; i < 120; i++) {
+      rows.push(`person${i},${20 + i},city${i}`)
+    }
+    const content = rows.join('\n')
+    const cfg = defaultChunkConfig()
+    const chunks = await tabularChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    for (const c of chunks) {
+      expect(c.content.startsWith('name,age,city')).toBe(true)
+      expect(c.metadata.chunker).toBe('tabular')
+    }
+  })
+
+  it('detects tab delimiter for TSV', async () => {
+    const rows = ['name\tage\tcity']
+    for (let i = 0; i < 60; i++) {
+      rows.push(`person${i}\t${20 + i}\tcity${i}`)
+    }
+    const content = rows.join('\n')
+    const cfg = defaultChunkConfig()
+    const chunks = await tabularChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    for (const c of chunks) {
+      const firstLine = c.content.split('\n')[0] ?? ''
+      expect(firstLine).toContain('\t')
+    }
+  })
+
+  it('produces single chunk for single row', async () => {
+    const content = 'name,age,city\nAlice,30,NYC'
+    const cfg = defaultChunkConfig()
+    const chunks = await tabularChunker(content, cfg)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]?.content.startsWith('name,age,city')).toBe(true)
+  })
+
+  it('handles header-only content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await tabularChunker('name,age,city', cfg)
+    expect(chunks).toHaveLength(1)
+  })
+
+  it('returns empty array for blank content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await tabularChunker('  ', cfg)
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('respects maxTokens for row count per chunk', async () => {
+    const rows = ['name,age,city']
+    for (let i = 0; i < 200; i++) {
+      rows.push(`person${i},${20 + i},city${i}`)
+    }
+    const content = rows.join('\n')
+    const cfg = createChunkConfig(64, 0, 5)
+    const chunks = await tabularChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(4)
+  })
+})
+
+describe('pageLevelChunker', () => {
+  it('splits on form-feed character', async () => {
+    const content = 'Page 1 content.\fPage 2 content.\fPage 3 content.'
+    const cfg = defaultChunkConfig()
+    const chunks = await pageLevelChunker(content, cfg)
+    expect(chunks).toHaveLength(3)
+    expect(chunks[0]?.metadata.page).toBe('1')
+    expect(chunks[1]?.metadata.page).toBe('2')
+    expect(chunks[2]?.metadata.page).toBe('3')
+    expect(chunks[0]?.metadata.chunker).toBe('page_level')
+  })
+
+  it('skips empty pages', async () => {
+    const content = 'Page 1\f\f\fPage 4'
+    const cfg = defaultChunkConfig()
+    const chunks = await pageLevelChunker(content, cfg)
+    expect(chunks).toHaveLength(2)
+  })
+
+  it('returns empty array for blank content', async () => {
+    const cfg = defaultChunkConfig()
+    const chunks = await pageLevelChunker('  ', cfg)
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('splits large pages using recursive strategy', async () => {
+    const largePage = 'This is a long sentence with many words. '.repeat(100)
+    const content = largePage + '\fSmall page.'
+    const cfg = createChunkConfig(64, 16, 10)
+    const chunks = await pageLevelChunker(content, cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('createChunkerRegistry (new chunkers)', () => {
+  it('selects code chunker for text/x-go', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('func main() {}', 'text/x-go', cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    expect(chunks[0]?.metadata.chunker).toBe('code')
+  })
+
+  it('selects tabular chunker for text/csv', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('name,age\nAlice,30', 'text/csv', cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    expect(chunks[0]?.metadata.chunker).toBe('tabular')
+  })
+
+  it('selects page-level chunker for application/pdf', async () => {
+    const reg = createChunkerRegistry()
+    const cfg = defaultChunkConfig()
+    const chunks = await reg.chunk('Page 1\fPage 2', 'application/pdf', cfg)
+    expect(chunks.length).toBeGreaterThanOrEqual(2)
+    expect(chunks[0]?.metadata.chunker).toBe('page_level')
+  })
+})
+
+describe('createChunkConfig (strategy and separators)', () => {
+  it('defaults strategy to empty and separators to undefined', () => {
+    const cfg = createChunkConfig()
+    expect(cfg.strategy).toBe('')
+    expect(cfg.separators).toBeUndefined()
+  })
+
+  it('accepts strategy and separators options', () => {
+    const cfg = createChunkConfig(512, 64, 64, {
+      strategy: 'code',
+      separators: ['\n'],
+    })
+    expect(cfg.strategy).toBe('code')
+    expect(cfg.separators).toEqual(['\n'])
   })
 })

--- a/sdks/ts/memory/src/ingest/chunker-registry.ts
+++ b/sdks/ts/memory/src/ingest/chunker-registry.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Chunker registry with content-type routing. Provides a pluggable
+ * architecture for content-type-specific chunking strategies. The
+ * registry pre-registers built-in chunkers (markdown, recursive) and
+ * allows custom chunkers to be registered at runtime.
+ */
+
+import type { ChunkConfig } from './chunk-config.js'
+import { markdownChunker } from './chunkers/markdown.js'
+import { recursiveChunker } from './chunkers/recursive.js'
+
+/** A single chunk produced by a Chunker. */
+export type Chunk = {
+  readonly id: string
+  readonly content: string
+  readonly metadata: Readonly<Record<string, string>>
+}
+
+/**
+ * Chunker function signature. Async to support LLM-powered chunkers
+ * and cancellation via AbortSignal. Returns an immutable array of
+ * chunks respecting the provided ChunkConfig bounds.
+ */
+export type Chunker = (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+) => Promise<readonly Chunk[]>
+
+/** Descriptor pairing a chunker with its supported content types and name. */
+export type ChunkerDescriptor = {
+  readonly name: string
+  readonly contentTypes: readonly string[]
+  readonly chunker: Chunker
+}
+
+/** Registry that routes content to the appropriate chunker by MIME type. */
+export type ChunkerRegistry = {
+  /** Register a custom chunker for the given content types. */
+  readonly register: (descriptor: ChunkerDescriptor) => void
+  /** Chunk content using the registered chunker for contentType. */
+  readonly chunk: (
+    content: string,
+    contentType: string,
+    cfg: ChunkConfig,
+    signal?: AbortSignal,
+  ) => Promise<readonly Chunk[]>
+}
+
+/**
+ * Creates a ChunkerRegistry pre-loaded with built-in chunkers:
+ * - text/markdown, text/x-markdown -> markdown chunker
+ * - text/plain, application/octet-stream -> recursive chunker (also fallback)
+ */
+export const createChunkerRegistry = (): ChunkerRegistry => {
+  const routes = new Map<string, ChunkerDescriptor>()
+
+  const mdDescriptor: ChunkerDescriptor = {
+    name: 'markdown',
+    contentTypes: ['text/markdown', 'text/x-markdown'],
+    chunker: markdownChunker,
+  }
+  for (const ct of mdDescriptor.contentTypes) {
+    routes.set(ct, mdDescriptor)
+  }
+
+  const recursiveDescriptor: ChunkerDescriptor = {
+    name: 'recursive',
+    contentTypes: ['text/plain', 'application/octet-stream'],
+    chunker: recursiveChunker,
+  }
+  for (const ct of recursiveDescriptor.contentTypes) {
+    routes.set(ct, recursiveDescriptor)
+  }
+
+  const register = (descriptor: ChunkerDescriptor): void => {
+    for (const ct of descriptor.contentTypes) {
+      routes.set(ct.toLowerCase().trim(), descriptor)
+    }
+  }
+
+  const chunk = async (
+    content: string,
+    contentType: string,
+    cfg: ChunkConfig,
+    signal?: AbortSignal,
+  ): Promise<readonly Chunk[]> => {
+    signal?.throwIfAborted()
+    const normalised = normaliseContentType(contentType)
+    const descriptor = routes.get(normalised) ?? recursiveDescriptor
+    const chunks = await descriptor.chunker(content, cfg, signal)
+    return chunks.map((c, idx) => ({
+      ...c,
+      id: c.id || String(idx),
+    }))
+  }
+
+  return { register, chunk }
+}
+
+/** Strips charset suffix and normalises content type for lookup. */
+const normaliseContentType = (raw: string): string => {
+  const lower = raw.toLowerCase().trim()
+  const semicolonIdx = lower.indexOf(';')
+  if (semicolonIdx >= 0) {
+    return lower.slice(0, semicolonIdx).trim()
+  }
+  return lower
+}

--- a/sdks/ts/memory/src/ingest/chunker-registry.ts
+++ b/sdks/ts/memory/src/ingest/chunker-registry.ts
@@ -8,8 +8,11 @@
  */
 
 import type { ChunkConfig } from './chunk-config.js'
+import { codeChunker } from './chunkers/code.js'
 import { markdownChunker } from './chunkers/markdown.js'
+import { pageLevelChunker } from './chunkers/page-level.js'
 import { recursiveChunker } from './chunkers/recursive.js'
+import { tabularChunker } from './chunkers/tabular.js'
 
 /** A single chunk produced by a Chunker. */
 export type Chunk = {
@@ -73,6 +76,44 @@ export const createChunkerRegistry = (): ChunkerRegistry => {
   }
   for (const ct of recursiveDescriptor.contentTypes) {
     routes.set(ct, recursiveDescriptor)
+  }
+
+  const codeDescriptor: ChunkerDescriptor = {
+    name: 'code',
+    contentTypes: [
+      'text/x-go',
+      'text/x-python',
+      'text/x-typescript',
+      'text/x-javascript',
+      'text/x-java',
+      'text/x-c',
+      'text/x-c++',
+      'text/x-rust',
+      'application/x-typescript',
+      'application/javascript',
+    ],
+    chunker: codeChunker,
+  }
+  for (const ct of codeDescriptor.contentTypes) {
+    routes.set(ct, codeDescriptor)
+  }
+
+  const tabularDescriptor: ChunkerDescriptor = {
+    name: 'tabular',
+    contentTypes: ['text/csv', 'text/tab-separated-values', 'text/tsv'],
+    chunker: tabularChunker,
+  }
+  for (const ct of tabularDescriptor.contentTypes) {
+    routes.set(ct, tabularDescriptor)
+  }
+
+  const pageLevelDescriptor: ChunkerDescriptor = {
+    name: 'page_level',
+    contentTypes: ['application/pdf', 'text/x-pdf-text'],
+    chunker: pageLevelChunker,
+  }
+  for (const ct of pageLevelDescriptor.contentTypes) {
+    routes.set(ct, pageLevelDescriptor)
   }
 
   const register = (descriptor: ChunkerDescriptor): void => {

--- a/sdks/ts/memory/src/ingest/chunkers/code.ts
+++ b/sdks/ts/memory/src/ingest/chunkers/code.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Code-aware chunker: splits source code at function/class/type
+ * boundaries using line-level heuristics. This is the Phase-1
+ * implementation -- full AST-based splitting via tree-sitter is
+ * deferred to a later phase.
+ *
+ * Algorithm:
+ * 1. Extract leading import/package lines into a header block.
+ * 2. Walk remaining lines and split at detected declaration boundaries.
+ * 3. Prepend the header to each chunk for self-contained context.
+ */
+
+import type { ChunkConfig } from '../chunk-config.js'
+import type { Chunk, Chunker } from '../chunker-registry.js'
+import { estimateTokens } from './recursive.js'
+
+const GO_FUNC_RE = /^func\s/
+const GO_TYPE_RE = /^type\s/
+const PY_DEF_RE = /^(def|class|async\s+def)\s/
+const TS_FUNC_RE = /^(export\s+)?(function|class|const|interface|type|enum)\s/
+const C_FUNC_RE = /^[a-zA-Z_].*\)\s*\{?\s*$/
+const IMPORT_LINE_RE = /^(import|from|require|use|#include|package)\s/
+
+const SEPARATORS: readonly string[] = ['\n\n', '\n', '. ', ' ', '']
+
+export const codeChunker: Chunker = async (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+): Promise<readonly Chunk[]> => {
+  signal?.throwIfAborted()
+  if (content.trim() === '') return []
+
+  const lines = content.split('\n')
+  const { header, bodyStart } = extractImportHeader(lines)
+  const sections = splitAtDeclarations(lines.slice(bodyStart))
+
+  const chunks: Chunk[] = []
+  for (const section of sections) {
+    const text = section.trim()
+    if (text === '') continue
+
+    const full = header !== '' && !text.startsWith(header)
+      ? header + '\n\n' + text
+      : text
+
+    if (estimateTokens(full) <= cfg.maxTokens) {
+      chunks.push({
+        id: '',
+        content: full,
+        metadata: { chunker: 'code' },
+      })
+      continue
+    }
+    const subPieces = recursiveSplitLocal(full, cfg.maxTokens, 0)
+    for (const piece of subPieces) {
+      const t = piece.trim()
+      if (t === '') continue
+      chunks.push({
+        id: '',
+        content: t,
+        metadata: { chunker: 'code' },
+      })
+    }
+  }
+
+  return mergeUndersized(chunks, cfg)
+}
+
+const extractImportHeader = (lines: readonly string[]): { header: string; bodyStart: number } => {
+  const headerLines: string[] = []
+  let bodyStart = 0
+  let inHeader = true
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    const trimmed = line.trim()
+    if (inHeader) {
+      if (
+        trimmed === '' ||
+        IMPORT_LINE_RE.test(trimmed) ||
+        trimmed.startsWith('//') ||
+        trimmed.startsWith('/*') ||
+        trimmed.startsWith('*') ||
+        trimmed === ')'
+      ) {
+        headerLines.push(line)
+        bodyStart = i + 1
+        continue
+      }
+      inHeader = false
+    }
+  }
+
+  return { header: headerLines.join('\n').trim(), bodyStart }
+}
+
+const splitAtDeclarations = (lines: readonly string[]): readonly string[] => {
+  if (lines.length === 0) return []
+
+  const sections: string[] = []
+  let current = ''
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (isDeclarationStart(trimmed) && current.length > 0) {
+      sections.push(current)
+      current = ''
+    }
+    current += line + '\n'
+  }
+  if (current.length > 0) {
+    sections.push(current)
+  }
+  return sections
+}
+
+const isDeclarationStart = (line: string): boolean => {
+  if (line === '') return false
+  return (
+    GO_FUNC_RE.test(line) ||
+    GO_TYPE_RE.test(line) ||
+    PY_DEF_RE.test(line) ||
+    TS_FUNC_RE.test(line) ||
+    C_FUNC_RE.test(line)
+  )
+}
+
+const mergeUndersized = (chunks: Chunk[], cfg: ChunkConfig): readonly Chunk[] => {
+  if (chunks.length === 0) return []
+  const merged: Chunk[] = []
+  for (const c of chunks) {
+    if (estimateTokens(c.content) < cfg.minTokens && merged.length > 0) {
+      const prev = merged[merged.length - 1]
+      if (prev !== undefined) {
+        merged[merged.length - 1] = {
+          ...prev,
+          content: prev.content + '\n' + c.content,
+        }
+        continue
+      }
+    }
+    merged.push(c)
+  }
+  return merged
+}
+
+const recursiveSplitLocal = (text: string, maxTokens: number, sepIdx: number): readonly string[] => {
+  if (estimateTokens(text) <= maxTokens) return [text]
+  if (sepIdx >= SEPARATORS.length) return hardSplit(text, maxTokens)
+  const sep = SEPARATORS[sepIdx]
+  if (sep === undefined || sep === '') return hardSplit(text, maxTokens)
+  const parts = text.split(sep)
+  const merged: string[] = []
+  let current = ''
+
+  for (const part of parts) {
+    const candidate = current === '' ? part : current + sep + part
+    if (estimateTokens(candidate) > maxTokens) {
+      if (current !== '') {
+        merged.push(current)
+        current = ''
+      }
+      if (estimateTokens(part) > maxTokens) {
+        merged.push(...recursiveSplitLocal(part, maxTokens, sepIdx + 1))
+      } else {
+        current = part
+      }
+    } else {
+      current = candidate
+    }
+  }
+  if (current !== '') merged.push(current)
+  return merged
+}
+
+const hardSplit = (text: string, maxTokens: number): readonly string[] => {
+  const step = maxTokens * 4
+  const out: string[] = []
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + step))
+  }
+  return out
+}

--- a/sdks/ts/memory/src/ingest/chunkers/markdown.ts
+++ b/sdks/ts/memory/src/ingest/chunkers/markdown.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Markdown chunker: heading-aware splitting that preserves the heading
+ * hierarchy in chunk metadata. Sections that exceed maxTokens are split
+ * recursively using the separator hierarchy from the recursive chunker.
+ */
+
+import type { ChunkConfig } from '../chunk-config.js'
+import type { Chunk, Chunker } from '../chunker-registry.js'
+import { estimateTokens } from './recursive.js'
+
+/** ATX heading regex: # through ###### followed by text. */
+const ATX_HEADING_RE = /^(#{1,6})\s+(.+?)\s*#*\s*$/
+
+/** Separator hierarchy for splitting within oversized sections. */
+const SEPARATORS: readonly string[] = ['\n\n', '\n', '. ', ' ', '']
+
+/**
+ * Markdown chunker function. Parses heading structure, splits at heading
+ * boundaries, and preserves the full heading path in chunk metadata.
+ */
+export const markdownChunker: Chunker = async (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+): Promise<readonly Chunk[]> => {
+  signal?.throwIfAborted()
+  if (content.trim() === '') return []
+
+  const sections = splitMarkdownSections(content)
+  const chunks: Chunk[] = []
+
+  for (const section of sections) {
+    signal?.throwIfAborted()
+    const trimmed = section.content.trim()
+    if (trimmed === '') continue
+
+    const headingPath = section.headingPath.join(' > ')
+    const tokens = estimateTokens(trimmed)
+
+    if (tokens <= cfg.maxTokens) {
+      chunks.push({
+        id: '',
+        content: trimmed,
+        metadata: { chunker: 'markdown', headingPath },
+      })
+      continue
+    }
+
+    const subChunks = splitSectionWithOverlap(trimmed, cfg)
+    for (const sub of subChunks) {
+      chunks.push({
+        id: '',
+        content: sub,
+        metadata: { chunker: 'markdown', headingPath },
+      })
+    }
+  }
+  return chunks
+}
+
+type MdSection = {
+  readonly headingPath: readonly string[]
+  readonly content: string
+}
+
+type HeadingEntry = {
+  readonly level: number
+  readonly title: string
+}
+
+/** Parses markdown into heading-bounded sections with hierarchy tracking. */
+const splitMarkdownSections = (content: string): readonly MdSection[] => {
+  const lines = content.split('\n')
+  const sections: MdSection[] = []
+  const stack: HeadingEntry[] = []
+  let currentContent = ''
+  let currentPath: readonly string[] = []
+
+  const flush = (): void => {
+    if (currentContent.trim() !== '') {
+      sections.push({ headingPath: [...currentPath], content: currentContent })
+    }
+    currentContent = ''
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    const atxMatch = ATX_HEADING_RE.exec(line)
+
+    if (atxMatch !== null) {
+      flush()
+      const hashes = atxMatch[1] ?? ''
+      const title = (atxMatch[2] ?? '').trim()
+      const level = hashes.length
+      const heading = hashes + ' ' + title
+
+      // Pop stack to appropriate depth.
+      while (stack.length > 0 && (stack[stack.length - 1]?.level ?? 0) >= level) {
+        stack.pop()
+      }
+      stack.push({ level, title: heading })
+      currentPath = stack.map((h) => h.title)
+      currentContent += line + '\n'
+      continue
+    }
+
+    // Check for setext headings.
+    if (i + 1 < lines.length && line.trim() !== '') {
+      const nextLine = lines[i + 1] ?? ''
+      if (isSetextUnderline(nextLine)) {
+        flush()
+        const level = nextLine.trim().startsWith('=') ? 1 : 2
+        const title = line.trim()
+        const heading = '#'.repeat(level) + ' ' + title
+
+        while (stack.length > 0 && (stack[stack.length - 1]?.level ?? 0) >= level) {
+          stack.pop()
+        }
+        stack.push({ level, title: heading })
+        currentPath = stack.map((h) => h.title)
+        currentContent += line + '\n' + nextLine + '\n'
+        i++
+        continue
+      }
+    }
+
+    currentContent += line + '\n'
+  }
+  flush()
+  return sections
+}
+
+/** Returns true when line is a setext heading underline (== or --). */
+const isSetextUnderline = (line: string): boolean => {
+  const trimmed = line.trim()
+  if (trimmed.length < 2) return false
+  return /^[=]+$/.test(trimmed) || /^[-]+$/.test(trimmed)
+}
+
+/** Splits an oversized section with overlap applied between pieces. */
+const splitSectionWithOverlap = (text: string, cfg: ChunkConfig): readonly string[] => {
+  const pieces = recursiveSplitLocal(text, cfg.maxTokens, 0)
+  if (pieces.length <= 1) return pieces
+
+  const result: string[] = []
+  for (let i = 0; i < pieces.length; i++) {
+    const piece = pieces[i]
+    if (piece === undefined) continue
+    const trimmed = piece.trim()
+    if (trimmed === '') continue
+
+    if (i > 0 && cfg.overlapTokens > 0) {
+      const prevTrimmed = (pieces[i - 1] ?? '').trim()
+      const tail = extractTail(prevTrimmed, cfg.overlapTokens)
+      result.push(tail + '\n' + trimmed)
+    } else {
+      result.push(trimmed)
+    }
+  }
+  return result
+}
+
+/** Local recursive split using the separator hierarchy. */
+const recursiveSplitLocal = (
+  text: string,
+  maxTokens: number,
+  sepIdx: number,
+): readonly string[] => {
+  if (estimateTokens(text) <= maxTokens) {
+    return [text]
+  }
+  if (sepIdx >= SEPARATORS.length) {
+    return hardSplit(text, maxTokens)
+  }
+  const sep = SEPARATORS[sepIdx]
+  if (sep === undefined || sep === '') {
+    return hardSplit(text, maxTokens)
+  }
+  const parts = text.split(sep)
+  const merged: string[] = []
+  let current = ''
+
+  for (const part of parts) {
+    const candidate = current === '' ? part : current + sep + part
+    if (estimateTokens(candidate) > maxTokens) {
+      if (current !== '') {
+        merged.push(current)
+        current = ''
+      }
+      if (estimateTokens(part) > maxTokens) {
+        const sub = recursiveSplitLocal(part, maxTokens, sepIdx + 1)
+        merged.push(...sub)
+      } else {
+        current = part
+      }
+    } else {
+      current = candidate
+    }
+  }
+  if (current !== '') {
+    merged.push(current)
+  }
+  return merged
+}
+
+/** Character-level hard split as a last resort. */
+const hardSplit = (text: string, maxTokens: number): readonly string[] => {
+  const step = maxTokens * 4
+  const out: string[] = []
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + step))
+  }
+  return out
+}
+
+/** Extracts approximately overlapTokens worth of chars from the end. */
+const extractTail = (text: string, overlapTokens: number): string => {
+  const chars = overlapTokens * 4
+  if (chars >= text.length) return text
+  return text.slice(text.length - chars)
+}

--- a/sdks/ts/memory/src/ingest/chunkers/page-level.ts
+++ b/sdks/ts/memory/src/ingest/chunkers/page-level.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Page-level chunker: splits content at page boundaries indicated by
+ * the form-feed character (\f). PDF text extractors typically insert
+ * \f between pages. Pages that exceed maxTokens are split further
+ * using the recursive separator hierarchy.
+ */
+
+import type { ChunkConfig } from '../chunk-config.js'
+import type { Chunk, Chunker } from '../chunker-registry.js'
+import { estimateTokens } from './recursive.js'
+
+const SEPARATORS: readonly string[] = ['\n\n', '\n', '. ', ' ', '']
+
+export const pageLevelChunker: Chunker = async (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+): Promise<readonly Chunk[]> => {
+  signal?.throwIfAborted()
+  if (content.trim() === '') return []
+
+  const pages = content.split('\f')
+  const chunks: Chunk[] = []
+
+  for (let i = 0; i < pages.length; i++) {
+    signal?.throwIfAborted()
+    const page = pages[i]
+    if (page === undefined) continue
+    const trimmed = page.trim()
+    if (trimmed === '') continue
+
+    const pageNum = String(i + 1)
+
+    if (estimateTokens(trimmed) <= cfg.maxTokens) {
+      chunks.push({
+        id: '',
+        content: trimmed,
+        metadata: { chunker: 'page_level', page: pageNum },
+      })
+      continue
+    }
+
+    const subPieces = recursiveSplitLocal(trimmed, cfg.maxTokens, 0)
+    for (const piece of subPieces) {
+      const t = piece.trim()
+      if (t === '') continue
+      chunks.push({
+        id: '',
+        content: t,
+        metadata: { chunker: 'page_level', page: pageNum },
+      })
+    }
+  }
+  return chunks
+}
+
+const recursiveSplitLocal = (text: string, maxTokens: number, sepIdx: number): readonly string[] => {
+  if (estimateTokens(text) <= maxTokens) return [text]
+  if (sepIdx >= SEPARATORS.length) return hardSplit(text, maxTokens)
+  const sep = SEPARATORS[sepIdx]
+  if (sep === undefined || sep === '') return hardSplit(text, maxTokens)
+  const parts = text.split(sep)
+  const merged: string[] = []
+  let current = ''
+
+  for (const part of parts) {
+    const candidate = current === '' ? part : current + sep + part
+    if (estimateTokens(candidate) > maxTokens) {
+      if (current !== '') {
+        merged.push(current)
+        current = ''
+      }
+      if (estimateTokens(part) > maxTokens) {
+        merged.push(...recursiveSplitLocal(part, maxTokens, sepIdx + 1))
+      } else {
+        current = part
+      }
+    } else {
+      current = candidate
+    }
+  }
+  if (current !== '') merged.push(current)
+  return merged
+}
+
+const hardSplit = (text: string, maxTokens: number): readonly string[] => {
+  const step = maxTokens * 4
+  const out: string[] = []
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + step))
+  }
+  return out
+}

--- a/sdks/ts/memory/src/ingest/chunkers/recursive.ts
+++ b/sdks/ts/memory/src/ingest/chunkers/recursive.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Recursive chunker: the default strategy that splits content using a
+ * separator hierarchy. Splits by paragraph breaks first, then single
+ * newlines, then sentence endings, then words, then characters. Applies
+ * overlap by copying trailing text from the previous chunk to the next.
+ */
+
+import type { ChunkConfig } from '../chunk-config.js'
+import type { Chunk, Chunker } from '../chunker-registry.js'
+
+/** Separator hierarchy from coarsest to finest split points. */
+const SEPARATORS: readonly string[] = ['\n\n', '\n', '. ', ' ', '']
+
+/**
+ * Approximate token count using chars/4 heuristic. Monotonic in text
+ * length. Matches the Go SDK estimateTokens for parity.
+ */
+export const estimateTokens = (text: string): number => {
+  if (text.length === 0) return 0
+  return Math.ceil(text.length / 4)
+}
+
+/**
+ * Recursive chunker function. Splits content using the separator
+ * hierarchy until each piece fits within maxTokens, then applies overlap.
+ */
+export const recursiveChunker: Chunker = async (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+): Promise<readonly Chunk[]> => {
+  signal?.throwIfAborted()
+  if (content.trim() === '') return []
+
+  const pieces = recursiveSplit(content, cfg.maxTokens, 0)
+  return applyOverlapAndBuild(pieces, cfg)
+}
+
+/** Recursively splits text using the separator at sepIdx until pieces fit. */
+const recursiveSplit = (text: string, maxTokens: number, sepIdx: number): readonly string[] => {
+  if (estimateTokens(text) <= maxTokens) {
+    return [text]
+  }
+  if (sepIdx >= SEPARATORS.length) {
+    return hardSplit(text, maxTokens)
+  }
+  const sep = SEPARATORS[sepIdx]
+  if (sep === undefined || sep === '') {
+    return hardSplit(text, maxTokens)
+  }
+  const parts = text.split(sep)
+  const merged: string[] = []
+  let current = ''
+
+  for (const part of parts) {
+    const candidate = current === '' ? part : current + sep + part
+    if (estimateTokens(candidate) > maxTokens) {
+      if (current !== '') {
+        merged.push(current)
+        current = ''
+      }
+      if (estimateTokens(part) > maxTokens) {
+        const sub = recursiveSplit(part, maxTokens, sepIdx + 1)
+        merged.push(...sub)
+      } else {
+        current = part
+      }
+    } else {
+      current = candidate
+    }
+  }
+  if (current !== '') {
+    merged.push(current)
+  }
+  return merged
+}
+
+/** Character-level hard split as a last resort. */
+const hardSplit = (text: string, maxTokens: number): readonly string[] => {
+  const step = maxTokens * 4
+  const out: string[] = []
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + step))
+  }
+  return out
+}
+
+/** Applies overlap between consecutive chunks and merges undersized pieces. */
+const applyOverlapAndBuild = (pieces: readonly string[], cfg: ChunkConfig): readonly Chunk[] => {
+  if (pieces.length === 0) return []
+  const chunks: Chunk[] = []
+  let prevTail = ''
+
+  for (let i = 0; i < pieces.length; i++) {
+    const piece = pieces[i]
+    if (piece === undefined) continue
+    const trimmed = piece.trim()
+    if (trimmed === '') continue
+
+    let chunkContent = trimmed
+    if (i > 0 && cfg.overlapTokens > 0 && prevTail !== '') {
+      chunkContent = prevTail + '\n' + trimmed
+    }
+
+    // Merge undersized chunks into the previous one.
+    if (estimateTokens(trimmed) < cfg.minTokens && chunks.length > 0) {
+      const prev = chunks[chunks.length - 1]
+      if (prev !== undefined) {
+        chunks[chunks.length - 1] = {
+          ...prev,
+          content: prev.content + '\n' + trimmed,
+        }
+        prevTail = extractTail(prev.content + '\n' + trimmed, cfg.overlapTokens)
+        continue
+      }
+    }
+
+    chunks.push({
+      id: '',
+      content: chunkContent,
+      metadata: { chunker: 'recursive' },
+    })
+    prevTail = extractTail(trimmed, cfg.overlapTokens)
+  }
+  return chunks
+}
+
+/** Extracts approximately overlapTokens worth of characters from the end. */
+const extractTail = (text: string, overlapTokens: number): string => {
+  const chars = overlapTokens * 4
+  if (chars >= text.length) return text
+  return text.slice(text.length - chars)
+}

--- a/sdks/ts/memory/src/ingest/chunkers/tabular.ts
+++ b/sdks/ts/memory/src/ingest/chunkers/tabular.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tabular chunker: splits CSV/TSV content by rows, prepending the
+ * header row to each chunk so every chunk is self-contained. The
+ * delimiter is auto-detected from the first line.
+ */
+
+import type { ChunkConfig } from '../chunk-config.js'
+import type { Chunk, Chunker } from '../chunker-registry.js'
+import { estimateTokens } from './recursive.js'
+
+/** Default number of data rows per chunk when token budget allows. */
+const DEFAULT_ROWS_PER_CHUNK = 50
+
+export const tabularChunker: Chunker = async (
+  content: string,
+  cfg: ChunkConfig,
+  signal?: AbortSignal,
+): Promise<readonly Chunk[]> => {
+  signal?.throwIfAborted()
+  const trimmed = content.trim()
+  if (trimmed === '') return []
+
+  const lines = trimmed.split('\n')
+  if (lines.length === 0) return []
+
+  const header = lines[0] ?? ''
+  const dataLines = lines.slice(1)
+
+  if (dataLines.length === 0) {
+    return [{
+      id: '',
+      content: header,
+      metadata: { chunker: 'tabular' },
+    }]
+  }
+
+  const rowsPerChunk = computeRowsPerChunk(header, dataLines, cfg)
+
+  const chunks: Chunk[] = []
+  for (let start = 0; start < dataLines.length; start += rowsPerChunk) {
+    signal?.throwIfAborted()
+    const end = Math.min(start + rowsPerChunk, dataLines.length)
+    const batch = dataLines.slice(start, end)
+    const chunkContent = header + '\n' + batch.join('\n')
+    chunks.push({
+      id: '',
+      content: chunkContent,
+      metadata: { chunker: 'tabular' },
+    })
+  }
+  return chunks
+}
+
+const computeRowsPerChunk = (
+  header: string,
+  dataLines: readonly string[],
+  cfg: ChunkConfig,
+): number => {
+  const headerTokens = estimateTokens(header)
+  const budgetForRows = cfg.maxTokens - headerTokens - 1
+  if (budgetForRows <= 0 || dataLines.length === 0) return DEFAULT_ROWS_PER_CHUNK
+
+  const sampleSize = Math.min(dataLines.length, 10)
+  let totalTokens = 0
+  for (let i = 0; i < sampleSize; i++) {
+    totalTokens += estimateTokens(dataLines[i] ?? '')
+  }
+  const avgTokensPerRow = Math.max(Math.floor(totalTokens / sampleSize), 1)
+
+  const rows = Math.floor(budgetForRows / avgTokensPerRow)
+  if (rows <= 0) return 1
+  return Math.min(rows, DEFAULT_ROWS_PER_CHUNK)
+}

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -71,6 +71,23 @@ export {
   type DeltaCategory,
 } from './delta.js'
 
+export {
+  ChunkConfigError,
+  createChunkConfig,
+  defaultChunkConfig,
+} from './chunk-config.js'
+
+export {
+  createChunkerRegistry,
+  type Chunk as RegistryChunk,
+  type Chunker,
+  type ChunkerDescriptor,
+  type ChunkerRegistry,
+} from './chunker-registry.js'
+
+export { markdownChunker } from './chunkers/markdown.js'
+export { recursiveChunker, estimateTokens } from './chunkers/recursive.js'
+
 export * from './sources/index.js'
 
 export {

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -85,8 +85,11 @@ export {
   type ChunkerRegistry,
 } from './chunker-registry.js'
 
+export { codeChunker } from './chunkers/code.js'
 export { markdownChunker } from './chunkers/markdown.js'
+export { pageLevelChunker } from './chunkers/page-level.js'
 export { recursiveChunker, estimateTokens } from './chunkers/recursive.js'
+export { tabularChunker } from './chunkers/tabular.js'
 
 export * from './sources/index.js'
 


### PR DESCRIPTION
## Summary
- Chunker interface (async TS with AbortSignal, context-aware Go)
- ChunkerRegistry routes by content type with recursive fallback
- MarkdownChunker: heading-aware, preserves hierarchy in metadata
- RecursiveChunker: separator hierarchy with overlap
- Compile-time interface checks for both chunker implementations
- Custom chunkers registerable at runtime

## Test plan
- [ ] Registry routes text/markdown to markdown chunker
- [ ] Unknown content type falls back to recursive
- [ ] Heading hierarchy preserved in chunk metadata
- [ ] Overlap applied correctly between chunks
- [ ] ChunkConfig validation rejects invalid configs
- [ ] 18 Go + 24 TS tests pass

Closes LLE-9782