### PR TITLE
Add ontology type registry with 4-layer scope resolution

### DIFF
--- a/go/ontology/registry.go
+++ b/go/ontology/registry.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ProposeDedupThreshold is the Jaro-Winkler similarity threshold above
+// which ProposeType skips registration (considers the type a duplicate).
+const ProposeDedupThreshold = 0.85
+
+// Registry provides high-level ontology operations on top of an
+// OntologyStore. It adds ProposeType with fuzzy dedup guard,
+// RegisterType, DeprecateType, and ApplyTemplate.
+type Registry struct {
+	store OntologyStore
+}
+
+// NewRegistry creates a Registry backed by the given OntologyStore.
+func NewRegistry(store OntologyStore) *Registry {
+	return &Registry{store: store}
+}
+
+// RegisterType adds or updates a type at the specified scope.
+func (r *Registry) RegisterType(ctx context.Context, scope Scope, def TypeDefinition) error {
+	return r.store.UpsertType(ctx, scope, def)
+}
+
+// DeprecateType marks a type as deprecated at the specified scope.
+func (r *Registry) DeprecateType(ctx context.Context, scope Scope, typeName string) error {
+	existing, err := r.store.GetType(ctx, scope, typeName)
+	if err != nil {
+		return fmt.Errorf("ontology: deprecate type %q at %s: %w", typeName, scope, err)
+	}
+	deprecated := *existing
+	deprecated.Status = TypeStatusDeprecated
+	return r.store.UpsertType(ctx, scope, deprecated)
+}
+
+// ProposeType creates a proposed type, skipping if a fuzzy-similar type
+// already exists (Jaro-Winkler >= 0.85). Returns nil without error when
+// the type is skipped as a duplicate.
+func (r *Registry) ProposeType(ctx context.Context, scope Scope, category string, typeName string, reason string) error {
+	resolved, err := r.store.GetResolvedOntology(ctx, "", "", "")
+	if err != nil {
+		return fmt.Errorf("ontology: propose type resolve: %w", err)
+	}
+
+	var existingLabels []string
+	switch category {
+	case "nodeType":
+		for _, rt := range resolved.NodeTypes {
+			existingLabels = append(existingLabels, rt.Label)
+		}
+	case "edgeType":
+		for _, rt := range resolved.EdgeTypes {
+			existingLabels = append(existingLabels, rt.Label)
+		}
+	default:
+		return fmt.Errorf("ontology: category must be nodeType or edgeType, got %q", category)
+	}
+
+	proposedLabel := FormatNodeTypeLabel(typeName)
+	if category == "edgeType" {
+		proposedLabel = FormatEdgeTypeLabel(typeName)
+	}
+
+	for _, existing := range existingLabels {
+		sim := jaroWinkler(strings.ToLower(proposedLabel), strings.ToLower(existing))
+		if sim >= ProposeDedupThreshold {
+			return nil
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	def := TypeDefinition{
+		Type:           typeName,
+		Label:          proposedLabel,
+		Description:    reason,
+		DiscoveredFrom: "proposal",
+		CreatedAt:      now,
+		Status:         TypeStatusProposed,
+	}
+	return r.store.UpsertType(ctx, scope, def)
+}
+
+// Resolve returns the fully merged ontology from the store.
+func (r *Registry) Resolve(ctx context.Context, brainID, projectID, orgID string) (*ResolvedOntology, error) {
+	return r.store.GetResolvedOntology(ctx, brainID, projectID, orgID)
+}
+
+// jaroWinkler computes Jaro-Winkler similarity between two lowercase
+// strings. This is a standalone implementation to avoid depending on
+// the dedup package (P6-5).
+func jaroWinkler(s1, s2 string) float64 {
+	if s1 == s2 {
+		return 1.0
+	}
+	if len(s1) == 0 || len(s2) == 0 {
+		return 0.0
+	}
+
+	maxDist := len(s1)
+	if len(s2) > maxDist {
+		maxDist = len(s2)
+	}
+	matchWindow := maxDist/2 - 1
+	if matchWindow < 0 {
+		matchWindow = 0
+	}
+
+	s1Matches := make([]bool, len(s1))
+	s2Matches := make([]bool, len(s2))
+
+	matches := 0
+	transpositions := 0
+
+	for i := 0; i < len(s1); i++ {
+		start := i - matchWindow
+		if start < 0 {
+			start = 0
+		}
+		end := i + matchWindow + 1
+		if end > len(s2) {
+			end = len(s2)
+		}
+		for j := start; j < end; j++ {
+			if s2Matches[j] || s1[i] != s2[j] {
+				continue
+			}
+			s1Matches[i] = true
+			s2Matches[j] = true
+			matches++
+			break
+		}
+	}
+
+	if matches == 0 {
+		return 0.0
+	}
+
+	k := 0
+	for i := 0; i < len(s1); i++ {
+		if !s1Matches[i] {
+			continue
+		}
+		for !s2Matches[k] {
+			k++
+		}
+		if s1[i] != s2[k] {
+			transpositions++
+		}
+		k++
+	}
+
+	jaro := (float64(matches)/float64(len(s1)) +
+		float64(matches)/float64(len(s2)) +
+		float64(matches-transpositions/2)/float64(matches)) / 3.0
+
+	commonPrefix := 0
+	limit := 4
+	if len(s1) < limit {
+		limit = len(s1)
+	}
+	if len(s2) < limit {
+		limit = len(s2)
+	}
+	for i := 0; i < limit; i++ {
+		if s1[i] != s2[i] {
+			break
+		}
+		commonPrefix++
+	}
+
+	return jaro + float64(commonPrefix)*0.1*(1.0-jaro)
+}

--- a/go/ontology/registry_test.go
+++ b/go/ontology/registry_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/ontology"
+	"github.com/jeffs-brain/memory/go/store/mem"
+)
+
+func newTestRegistry(t *testing.T) *ontology.Registry {
+	t.Helper()
+	ms := mem.New()
+	t.Cleanup(func() { _ = ms.Close() })
+	cfg := ontology.FileOntologyStoreConfig{
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+	}
+	store, err := ontology.NewFileOntologyStore(ms, cfg)
+	if err != nil {
+		t.Fatalf("NewFileOntologyStore: %v", err)
+	}
+	return ontology.NewRegistry(store)
+}
+
+func TestRegistryRegisterType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.invoice",
+		Label:       "Invoice",
+		Description: "Financial invoice",
+		CreatedAt:   "2026-01-01T00:00:00Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := reg.RegisterType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("RegisterType: %v", err)
+	}
+
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	found := false
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.invoice" && rt.Label == "Invoice" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected entity.invoice in resolved ontology after RegisterType")
+	}
+}
+
+func TestRegistryDeprecateType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.invoice",
+		Label:       "Invoice",
+		Description: "Financial invoice",
+		CreatedAt:   "2026-01-01T00:00:00Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := reg.RegisterType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("RegisterType: %v", err)
+	}
+	if err := reg.DeprecateType(ctx, ontology.ScopeBrain, "entity.invoice"); err != nil {
+		t.Fatalf("DeprecateType: %v", err)
+	}
+
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.invoice" {
+			t.Fatal("deprecated type should not appear in resolved ontology")
+		}
+	}
+}
+
+func TestRegistryProposeType_CreatesNew(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	if err := reg.ProposeType(ctx, ontology.ScopeBrain, "nodeType", "entity.invoice", "Discovered in procurement docs"); err != nil {
+		t.Fatalf("ProposeType: %v", err)
+	}
+
+	types, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Proposed types should NOT appear in resolved (only active types resolve)
+	for _, rt := range types.NodeTypes {
+		if rt.Type == "entity.invoice" && rt.Scope == "brain" {
+			// The type exists but should be proposed status, which is filtered
+			t.Fatal("proposed type should not appear as active in resolved ontology")
+		}
+	}
+}
+
+func TestRegistryProposeType_SkipsSimilar(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	// "entity.customer" is built-in with label "Customer (Entity)".
+	// Proposing "entity.customers" should be skipped because
+	// "Customers (Entity)" is very similar to "Customer (Entity)".
+	if err := reg.ProposeType(ctx, ontology.ScopeBrain, "nodeType", "entity.customers", "Should be skipped"); err != nil {
+		t.Fatalf("ProposeType: %v", err)
+	}
+
+	// Verify the type was NOT created (it was skipped as duplicate)
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.customers" {
+			t.Fatal("similar type should have been skipped")
+		}
+	}
+}
+
+func TestRegistryProposeType_InvalidCategory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	err := reg.ProposeType(ctx, ontology.ScopeBrain, "invalid", "entity.test", "reason")
+	if err == nil {
+		t.Fatal("expected error for invalid category")
+	}
+}
+
+func TestRegistryResolve_BuiltInOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := newTestRegistry(t)
+
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(resolved.NodeTypes) != 31 {
+		t.Fatalf("expected 31 node types, got %d", len(resolved.NodeTypes))
+	}
+	if len(resolved.EdgeTypes) != 19 {
+		t.Fatalf("expected 19 edge types, got %d", len(resolved.EdgeTypes))
+	}
+	if len(resolved.BusinessCategories) != 8 {
+		t.Fatalf("expected 8 business categories, got %d", len(resolved.BusinessCategories))
+	}
+}

--- a/go/ontology/store.go
+++ b/go/ontology/store.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import "context"
+
+// OntologyStore provides persistence for ontology type definitions.
+// Dual-backend: FileOntologyStore (local-first, file-based) and
+// PostgresOntologyStore (hosted). This interface covers type CRUD
+// operations and 4-layer scope resolution.
+type OntologyStore interface {
+	// GetType returns a single type definition at the given scope.
+	// Returns an error wrapping brain.ErrNotFound if the type does not exist.
+	GetType(ctx context.Context, scope Scope, typeID string) (*TypeDefinition, error)
+
+	// ListTypes returns all types at the given scope, optionally filtered.
+	ListTypes(ctx context.Context, scope Scope, opts ListTypesOpts) ([]TypeDefinition, error)
+
+	// UpsertType creates or updates a type definition at the given scope.
+	UpsertType(ctx context.Context, scope Scope, def TypeDefinition) error
+
+	// DeleteType removes a type from the given scope.
+	DeleteType(ctx context.Context, scope Scope, typeID string) error
+
+	// GetResolvedOntology returns the fully merged ontology across all 4 layers.
+	// Resolution order: built-in -> organisation -> project -> brain.
+	// Higher scopes shadow lower scopes for types sharing the same identifier.
+	// Only active types are included in the result.
+	GetResolvedOntology(ctx context.Context, brainID, projectID, orgID string) (*ResolvedOntology, error)
+
+	// Close releases any resources held by the store.
+	Close() error
+}
+
+// ListTypesOpts filters results from ListTypes.
+type ListTypesOpts struct {
+	Prefix string // filter node types by prefix (e.g., "entity.", "rule.")
+	Status string // filter by status: "active", "proposed", "deprecated"
+}
+
+// ResolvedType is a TypeDefinition enriched with its resolution scope.
+type ResolvedType struct {
+	TypeDefinition
+	Scope Scope `json:"scope"`
+}
+
+// ResolvedOntology is the merged result of 4-layer scope resolution.
+// Resolution order: built-in -> organisation -> project -> brain.
+// Higher scopes shadow lower scopes for types sharing the same identifier.
+type ResolvedOntology struct {
+	NodeTypes          []ResolvedType `json:"nodeTypes"`
+	EdgeTypes          []ResolvedType `json:"edgeTypes"`
+	BusinessCategories []string       `json:"businessCategories"`
+}
+
+// StoredOntology is the on-disk JSON shape for custom types at a single scope.
+type StoredOntology struct {
+	CustomNodeTypes          []TypeDefinition `json:"customNodeTypes"`
+	CustomEdgeTypes          []TypeDefinition `json:"customEdgeTypes"`
+	CustomBusinessCategories []string         `json:"customBusinessCategories"`
+}

--- a/go/ontology/store_file.go
+++ b/go/ontology/store_file.go
@@ -6,11 +6,29 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/jeffs-brain/memory/go/brain"
 )
+
+// validIDPattern matches IDs that start with an alphanumeric character followed
+// by zero or more alphanumeric, underscore, or hyphen characters.
+var validIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// validateID checks that an ID is safe for path interpolation. IDs must start
+// with an alphanumeric character and contain only alphanumeric, underscore, or
+// hyphen characters. This prevents path traversal attacks via ".." or "/" in IDs.
+func validateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("ontology: ID must not be empty")
+	}
+	if !validIDPattern.MatchString(id) {
+		return fmt.Errorf("ontology: invalid ID %q: must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$", id)
+	}
+	return nil
+}
 
 // FileOntologyStoreConfig holds the IDs used by FileOntologyStore to
 // determine which scope files to read and write for CRUD operations.
@@ -37,12 +55,28 @@ type FileOntologyStore struct {
 var _ OntologyStore = (*FileOntologyStore)(nil)
 
 // NewFileOntologyStore creates a FileOntologyStore backed by the given store.
-func NewFileOntologyStore(store brain.Store, cfg FileOntologyStoreConfig) *FileOntologyStore {
+// Returns an error if any configured ID fails validation (path traversal prevention).
+func NewFileOntologyStore(store brain.Store, cfg FileOntologyStoreConfig) (*FileOntologyStore, error) {
+	if cfg.BrainID != "" {
+		if err := validateID(cfg.BrainID); err != nil {
+			return nil, fmt.Errorf("ontology: invalid BrainID: %w", err)
+		}
+	}
+	if cfg.ProjectID != "" {
+		if err := validateID(cfg.ProjectID); err != nil {
+			return nil, fmt.Errorf("ontology: invalid ProjectID: %w", err)
+		}
+	}
+	if cfg.OrgID != "" {
+		if err := validateID(cfg.OrgID); err != nil {
+			return nil, fmt.Errorf("ontology: invalid OrgID: %w", err)
+		}
+	}
 	return &FileOntologyStore{
 		store:  store,
 		config: cfg,
 		cache:  make(map[string]*ResolvedOntology),
-	}
+	}, nil
 }
 
 // GetType returns a single type definition at the given scope.
@@ -134,6 +168,18 @@ func (f *FileOntologyStore) DeleteType(ctx context.Context, scope Scope, typeID 
 
 // GetResolvedOntology returns the fully merged ontology across all 4 layers.
 func (f *FileOntologyStore) GetResolvedOntology(ctx context.Context, brainID, projectID, orgID string) (*ResolvedOntology, error) {
+	for _, pair := range []struct{ name, id string }{
+		{"brainID", brainID},
+		{"projectID", projectID},
+		{"orgID", orgID},
+	} {
+		if pair.id != "" {
+			if err := validateID(pair.id); err != nil {
+				return nil, fmt.Errorf("ontology: GetResolvedOntology invalid %s: %w", pair.name, err)
+			}
+		}
+	}
+
 	cacheKey := buildCacheKey(brainID, projectID, orgID)
 	f.mu.RLock()
 	cached, ok := f.cache[cacheKey]

--- a/go/ontology/store_file.go
+++ b/go/ontology/store_file.go
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+// FileOntologyStoreConfig holds the IDs used by FileOntologyStore to
+// determine which scope files to read and write for CRUD operations.
+type FileOntologyStoreConfig struct {
+	BrainID   string
+	ProjectID string
+	OrgID     string
+}
+
+// FileOntologyStore implements OntologyStore using a brain.Store backend.
+// Types are stored as JSON files at well-known paths:
+//   - Organisation: ontology/org/{orgID}/types.json
+//   - Project: ontology/project/{projectID}/types.json
+//   - Brain: ontology/brain/{brainID}/types.json
+//
+// Built-in types are hardcoded and always available without any file I/O.
+type FileOntologyStore struct {
+	store  brain.Store
+	config FileOntologyStoreConfig
+	mu     sync.RWMutex
+	cache  map[string]*ResolvedOntology
+}
+
+var _ OntologyStore = (*FileOntologyStore)(nil)
+
+// NewFileOntologyStore creates a FileOntologyStore backed by the given store.
+func NewFileOntologyStore(store brain.Store, cfg FileOntologyStoreConfig) *FileOntologyStore {
+	return &FileOntologyStore{
+		store:  store,
+		config: cfg,
+		cache:  make(map[string]*ResolvedOntology),
+	}
+}
+
+// GetType returns a single type definition at the given scope.
+func (f *FileOntologyStore) GetType(ctx context.Context, scope Scope, typeID string) (*TypeDefinition, error) {
+	if scope == ScopeBuiltIn {
+		return getBuiltInType(typeID)
+	}
+	stored, err := f.readScopeByID(ctx, scope, f.idForScope(scope))
+	if err != nil {
+		return nil, fmt.Errorf("ontology: get type %q at %s: %w", typeID, scope, err)
+	}
+	for i := range stored.CustomNodeTypes {
+		if stored.CustomNodeTypes[i].Type == typeID {
+			return &stored.CustomNodeTypes[i], nil
+		}
+	}
+	for i := range stored.CustomEdgeTypes {
+		if stored.CustomEdgeTypes[i].Type == typeID {
+			return &stored.CustomEdgeTypes[i], nil
+		}
+	}
+	return nil, fmt.Errorf("ontology: type %q not found at scope %s: %w", typeID, scope, brain.ErrNotFound)
+}
+
+// ListTypes returns all types at the given scope, optionally filtered.
+func (f *FileOntologyStore) ListTypes(ctx context.Context, scope Scope, opts ListTypesOpts) ([]TypeDefinition, error) {
+	if scope == ScopeBuiltIn {
+		return listBuiltInTypes(opts), nil
+	}
+	stored, err := f.readScopeByID(ctx, scope, f.idForScope(scope))
+	if err != nil {
+		return nil, fmt.Errorf("ontology: list types at %s: %w", scope, err)
+	}
+	combined := make([]TypeDefinition, 0, len(stored.CustomNodeTypes)+len(stored.CustomEdgeTypes))
+	combined = append(combined, stored.CustomNodeTypes...)
+	combined = append(combined, stored.CustomEdgeTypes...)
+	return filterTypes(combined, opts), nil
+}
+
+// UpsertType creates or updates a type definition at the given scope.
+func (f *FileOntologyStore) UpsertType(ctx context.Context, scope Scope, def TypeDefinition) error {
+	if scope == ScopeBuiltIn {
+		return fmt.Errorf("ontology: cannot upsert to built-in scope")
+	}
+	if err := ValidateTypeDefinition(def); err != nil {
+		return err
+	}
+	id := f.idForScope(scope)
+	stored, err := f.readScopeByID(ctx, scope, id)
+	if err != nil {
+		return fmt.Errorf("ontology: upsert type at %s: %w", scope, err)
+	}
+	if HasPrefix(def.Type) != "" {
+		stored.CustomNodeTypes = upsertInSlice(stored.CustomNodeTypes, def)
+	} else {
+		stored.CustomEdgeTypes = upsertInSlice(stored.CustomEdgeTypes, def)
+	}
+	if err := f.writeScopeByID(ctx, scope, id, stored); err != nil {
+		return fmt.Errorf("ontology: upsert type at %s: %w", scope, err)
+	}
+	f.invalidateCache()
+	return nil
+}
+
+// DeleteType removes a type from the given scope.
+func (f *FileOntologyStore) DeleteType(ctx context.Context, scope Scope, typeID string) error {
+	if scope == ScopeBuiltIn {
+		return fmt.Errorf("ontology: cannot delete from built-in scope")
+	}
+	id := f.idForScope(scope)
+	stored, err := f.readScopeByID(ctx, scope, id)
+	if err != nil {
+		return fmt.Errorf("ontology: delete type at %s: %w", scope, err)
+	}
+	var found bool
+	stored.CustomNodeTypes, found = removeFromSlice(stored.CustomNodeTypes, typeID)
+	if !found {
+		stored.CustomEdgeTypes, found = removeFromSlice(stored.CustomEdgeTypes, typeID)
+	}
+	if !found {
+		return fmt.Errorf("ontology: type %q not found at scope %s: %w", typeID, scope, brain.ErrNotFound)
+	}
+	if err := f.writeScopeByID(ctx, scope, id, stored); err != nil {
+		return fmt.Errorf("ontology: delete type at %s: %w", scope, err)
+	}
+	f.invalidateCache()
+	return nil
+}
+
+// GetResolvedOntology returns the fully merged ontology across all 4 layers.
+func (f *FileOntologyStore) GetResolvedOntology(ctx context.Context, brainID, projectID, orgID string) (*ResolvedOntology, error) {
+	cacheKey := buildCacheKey(brainID, projectID, orgID)
+	f.mu.RLock()
+	cached, ok := f.cache[cacheKey]
+	f.mu.RUnlock()
+	if ok {
+		return cached, nil
+	}
+
+	nodeMap := make(map[string]ResolvedType, len(BuiltInNodeTypes))
+	edgeMap := make(map[string]ResolvedType, len(BuiltInEdgeTypes))
+	categorySet := make(map[string]struct{}, len(BusinessCategories))
+
+	for _, c := range BusinessCategories {
+		categorySet[c] = struct{}{}
+	}
+	for _, nt := range BuiltInNodeTypes {
+		nodeMap[nt] = ResolvedType{
+			TypeDefinition: TypeDefinition{
+				Type:        nt,
+				Label:       FormatNodeTypeLabel(nt),
+				Description: GetBuiltInNodeTypeDescription(nt),
+				CreatedAt:   "1970-01-01T00:00:00.000Z",
+				Status:      TypeStatusActive,
+			},
+			Scope: ScopeBuiltIn,
+		}
+	}
+	for _, et := range BuiltInEdgeTypes {
+		edgeMap[et] = ResolvedType{
+			TypeDefinition: TypeDefinition{
+				Type:        et,
+				Label:       FormatEdgeTypeLabel(et),
+				Description: GetBuiltInEdgeTypeDescription(et),
+				CreatedAt:   "1970-01-01T00:00:00.000Z",
+				Status:      TypeStatusActive,
+			},
+			Scope: ScopeBuiltIn,
+		}
+	}
+
+	layers := []struct {
+		scope Scope
+		id    string
+	}{
+		{ScopeOrganisation, orgID},
+		{ScopeProject, projectID},
+		{ScopeBrain, brainID},
+	}
+	for _, layer := range layers {
+		if layer.id == "" {
+			continue
+		}
+		stored, err := f.readScopeByID(ctx, layer.scope, layer.id)
+		if err != nil {
+			continue
+		}
+		for _, nt := range stored.CustomNodeTypes {
+			nodeMap[nt.Type] = ResolvedType{TypeDefinition: nt, Scope: layer.scope}
+		}
+		for _, et := range stored.CustomEdgeTypes {
+			edgeMap[et.Type] = ResolvedType{TypeDefinition: et, Scope: layer.scope}
+		}
+		for _, cat := range stored.CustomBusinessCategories {
+			categorySet[cat] = struct{}{}
+		}
+	}
+
+	resolved := &ResolvedOntology{
+		NodeTypes:          filterActiveResolved(nodeMap),
+		EdgeTypes:          filterActiveResolved(edgeMap),
+		BusinessCategories: sortedKeys(categorySet),
+	}
+
+	f.mu.Lock()
+	f.cache[cacheKey] = resolved
+	f.mu.Unlock()
+
+	return resolved, nil
+}
+
+// Close releases resources held by the store.
+func (f *FileOntologyStore) Close() error {
+	f.mu.Lock()
+	f.cache = nil
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *FileOntologyStore) idForScope(scope Scope) string {
+	switch scope {
+	case ScopeOrganisation:
+		return f.config.OrgID
+	case ScopeProject:
+		return f.config.ProjectID
+	case ScopeBrain:
+		return f.config.BrainID
+	default:
+		return ""
+	}
+}
+
+func (f *FileOntologyStore) readScopeByID(ctx context.Context, scope Scope, id string) (*StoredOntology, error) {
+	p := scopePath(scope, id)
+	data, err := f.store.Read(ctx, p)
+	if err != nil {
+		if errors.Is(err, brain.ErrNotFound) {
+			return &StoredOntology{}, nil
+		}
+		return nil, err
+	}
+	var stored StoredOntology
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, fmt.Errorf("ontology: unmarshal %s: %w", p, err)
+	}
+	return &stored, nil
+}
+
+func (f *FileOntologyStore) writeScopeByID(ctx context.Context, scope Scope, id string, stored *StoredOntology) error {
+	p := scopePath(scope, id)
+	data, err := json.Marshal(stored)
+	if err != nil {
+		return fmt.Errorf("ontology: marshal %s: %w", p, err)
+	}
+	return f.store.Write(ctx, p, data)
+}
+
+func (f *FileOntologyStore) invalidateCache() {
+	f.mu.Lock()
+	f.cache = make(map[string]*ResolvedOntology)
+	f.mu.Unlock()
+}
+
+func getBuiltInType(typeID string) (*TypeDefinition, error) {
+	if IsBuiltInNodeType(typeID) {
+		return &TypeDefinition{
+			Type:        typeID,
+			Label:       FormatNodeTypeLabel(typeID),
+			Description: GetBuiltInNodeTypeDescription(typeID),
+			CreatedAt:   "1970-01-01T00:00:00.000Z",
+			Status:      TypeStatusActive,
+		}, nil
+	}
+	if IsBuiltInEdgeType(typeID) {
+		return &TypeDefinition{
+			Type:        typeID,
+			Label:       FormatEdgeTypeLabel(typeID),
+			Description: GetBuiltInEdgeTypeDescription(typeID),
+			CreatedAt:   "1970-01-01T00:00:00.000Z",
+			Status:      TypeStatusActive,
+		}, nil
+	}
+	return nil, fmt.Errorf("ontology: type %q not found at scope built-in: %w", typeID, brain.ErrNotFound)
+}
+
+func listBuiltInTypes(opts ListTypesOpts) []TypeDefinition {
+	defs := make([]TypeDefinition, 0, len(BuiltInNodeTypes)+len(BuiltInEdgeTypes))
+	for _, nt := range BuiltInNodeTypes {
+		defs = append(defs, TypeDefinition{
+			Type:        nt,
+			Label:       FormatNodeTypeLabel(nt),
+			Description: GetBuiltInNodeTypeDescription(nt),
+			CreatedAt:   "1970-01-01T00:00:00.000Z",
+			Status:      TypeStatusActive,
+		})
+	}
+	for _, et := range BuiltInEdgeTypes {
+		defs = append(defs, TypeDefinition{
+			Type:        et,
+			Label:       FormatEdgeTypeLabel(et),
+			Description: GetBuiltInEdgeTypeDescription(et),
+			CreatedAt:   "1970-01-01T00:00:00.000Z",
+			Status:      TypeStatusActive,
+		})
+	}
+	return filterTypes(defs, opts)
+}
+
+func buildCacheKey(brainID, projectID, orgID string) string {
+	return "org:" + orgID + ":proj:" + projectID + ":brain:" + brainID
+}
+
+func scopePath(scope Scope, id string) brain.Path {
+	switch scope {
+	case ScopeOrganisation:
+		return brain.Path("ontology/org/" + id + "/types.json")
+	case ScopeProject:
+		return brain.Path("ontology/project/" + id + "/types.json")
+	case ScopeBrain:
+		return brain.Path("ontology/brain/" + id + "/types.json")
+	default:
+		return brain.Path("ontology/types.json")
+	}
+}
+
+func upsertInSlice(slice []TypeDefinition, def TypeDefinition) []TypeDefinition {
+	for i := range slice {
+		if slice[i].Type == def.Type {
+			slice[i] = def
+			return slice
+		}
+	}
+	return append(slice, def)
+}
+
+func removeFromSlice(slice []TypeDefinition, typeID string) ([]TypeDefinition, bool) {
+	for i := range slice {
+		if slice[i].Type == typeID {
+			return append(slice[:i], slice[i+1:]...), true
+		}
+	}
+	return slice, false
+}
+
+func filterTypes(defs []TypeDefinition, opts ListTypesOpts) []TypeDefinition {
+	if opts.Prefix == "" && opts.Status == "" {
+		return defs
+	}
+	filtered := make([]TypeDefinition, 0, len(defs))
+	for _, d := range defs {
+		if opts.Prefix != "" && !strings.HasPrefix(d.Type, opts.Prefix) {
+			continue
+		}
+		if opts.Status != "" && string(d.Status) != opts.Status {
+			continue
+		}
+		filtered = append(filtered, d)
+	}
+	return filtered
+}
+
+func filterActiveResolved(m map[string]ResolvedType) []ResolvedType {
+	result := make([]ResolvedType, 0, len(m))
+	for _, rt := range m {
+		if rt.Status == TypeStatusActive {
+			result = append(result, rt)
+		}
+	}
+	return result
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	return keys
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/go/ontology/store_test.go
+++ b/go/ontology/store_test.go
@@ -20,7 +20,11 @@ func newTestStore(t *testing.T) (*ontology.FileOntologyStore, *mem.Store) {
 		ProjectID: "proj-1",
 		OrgID:     "org-1",
 	}
-	return ontology.NewFileOntologyStore(ms, cfg), ms
+	store, err := ontology.NewFileOntologyStore(ms, cfg)
+	if err != nil {
+		t.Fatalf("NewFileOntologyStore: %v", err)
+	}
+	return store, ms
 }
 
 func TestGetType_BuiltInNodeType(t *testing.T) {
@@ -477,7 +481,10 @@ func TestGetResolvedOntology_CustomCategories(t *testing.T) {
 		ProjectID: "proj-1",
 		OrgID:     "org-1",
 	}
-	s := ontology.NewFileOntologyStore(ms, cfg)
+	s, err := ontology.NewFileOntologyStore(ms, cfg)
+	if err != nil {
+		t.Fatalf("NewFileOntologyStore: %v", err)
+	}
 	ctx := context.Background()
 
 	stored := ontology.StoredOntology{

--- a/go/ontology/store_test.go
+++ b/go/ontology/store_test.go
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/brain"
+	"github.com/jeffs-brain/memory/go/ontology"
+	"github.com/jeffs-brain/memory/go/store/mem"
+)
+
+func newTestStore(t *testing.T) (*ontology.FileOntologyStore, *mem.Store) {
+	t.Helper()
+	ms := mem.New()
+	t.Cleanup(func() { _ = ms.Close() })
+	cfg := ontology.FileOntologyStoreConfig{
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+	}
+	return ontology.NewFileOntologyStore(ms, cfg), ms
+}
+
+func TestGetType_BuiltInNodeType(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def, err := s.GetType(ctx, ontology.ScopeBuiltIn, "entity.customer")
+	if err != nil {
+		t.Fatalf("GetType(built-in, entity.customer) = %v", err)
+	}
+	if def.Type != "entity.customer" {
+		t.Fatalf("expected type entity.customer, got %q", def.Type)
+	}
+	if def.Status != ontology.TypeStatusActive {
+		t.Fatalf("expected status active, got %q", def.Status)
+	}
+	if def.Label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if def.Description == "" {
+		t.Fatal("expected non-empty description")
+	}
+}
+
+func TestGetType_BuiltInEdgeType(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def, err := s.GetType(ctx, ontology.ScopeBuiltIn, "triggers")
+	if err != nil {
+		t.Fatalf("GetType(built-in, triggers) = %v", err)
+	}
+	if def.Type != "triggers" {
+		t.Fatalf("expected type triggers, got %q", def.Type)
+	}
+}
+
+func TestGetType_BuiltInNotFound(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := s.GetType(ctx, ontology.ScopeBuiltIn, "nonexistent.type")
+	if err == nil {
+		t.Fatal("expected error for nonexistent built-in type")
+	}
+}
+
+func TestUpsertType_BrainScope(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.invoice",
+		Label:       "Invoice",
+		Description: "Financial invoice documents",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("UpsertType = %v", err)
+	}
+
+	got, err := s.GetType(ctx, ontology.ScopeBrain, "entity.invoice")
+	if err != nil {
+		t.Fatalf("GetType after upsert = %v", err)
+	}
+	if got.Type != "entity.invoice" {
+		t.Fatalf("expected entity.invoice, got %q", got.Type)
+	}
+	if got.Label != "Invoice" {
+		t.Fatalf("expected label Invoice, got %q", got.Label)
+	}
+}
+
+func TestUpsertType_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.invoice",
+		Label:       "Invoice V1",
+		Description: "First version",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("first UpsertType = %v", err)
+	}
+
+	def.Label = "Invoice V2"
+	def.Description = "Second version"
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("second UpsertType = %v", err)
+	}
+
+	got, err := s.GetType(ctx, ontology.ScopeBrain, "entity.invoice")
+	if err != nil {
+		t.Fatalf("GetType after overwrite = %v", err)
+	}
+	if got.Label != "Invoice V2" {
+		t.Fatalf("expected Invoice V2, got %q", got.Label)
+	}
+}
+
+func TestUpsertType_RejectsBuiltInScope(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.test",
+		Label:       "Test",
+		Description: "A test type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	err := s.UpsertType(ctx, ontology.ScopeBuiltIn, def)
+	if err == nil {
+		t.Fatal("expected error when upserting to built-in scope")
+	}
+}
+
+func TestUpsertType_RejectsInvalidDefinition(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:   "entity.test",
+		Label:  "",
+		Status: ontology.TypeStatusActive,
+	}
+	err := s.UpsertType(ctx, ontology.ScopeBrain, def)
+	if err == nil {
+		t.Fatal("expected error for invalid definition")
+	}
+}
+
+func TestDeleteType_RemovesFromScope(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.invoice",
+		Label:       "Invoice",
+		Description: "Financial invoices",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("UpsertType = %v", err)
+	}
+
+	if err := s.DeleteType(ctx, ontology.ScopeBrain, "entity.invoice"); err != nil {
+		t.Fatalf("DeleteType = %v", err)
+	}
+
+	_, err := s.GetType(ctx, ontology.ScopeBrain, "entity.invoice")
+	if err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestDeleteType_NotFoundReturnsError(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	err := s.DeleteType(ctx, ontology.ScopeBrain, "entity.nonexistent")
+	if err == nil {
+		t.Fatal("expected error when deleting nonexistent type")
+	}
+}
+
+func TestDeleteType_RejectsBuiltInScope(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	err := s.DeleteType(ctx, ontology.ScopeBuiltIn, "entity.customer")
+	if err == nil {
+		t.Fatal("expected error when deleting from built-in scope")
+	}
+}
+
+func TestListTypes_BuiltIn(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	types, err := s.ListTypes(ctx, ontology.ScopeBuiltIn, ontology.ListTypesOpts{})
+	if err != nil {
+		t.Fatalf("ListTypes(built-in) = %v", err)
+	}
+	if len(types) != 50 {
+		t.Fatalf("expected 50 built-in types (31 nodes + 19 edges), got %d", len(types))
+	}
+}
+
+func TestListTypes_FilterByPrefix(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	types, err := s.ListTypes(ctx, ontology.ScopeBuiltIn, ontology.ListTypesOpts{Prefix: "entity."})
+	if err != nil {
+		t.Fatalf("ListTypes(prefix=entity.) = %v", err)
+	}
+	if len(types) != 6 {
+		t.Fatalf("expected 6 entity types, got %d", len(types))
+	}
+	for _, td := range types {
+		if !hasEntityPrefix(td.Type) {
+			t.Fatalf("unexpected type %q in entity prefix filter", td.Type)
+		}
+	}
+}
+
+func TestListTypes_FilterByStatus(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	active := ontology.TypeDefinition{
+		Type:        "entity.active_one",
+		Label:       "Active One",
+		Description: "An active type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	proposed := ontology.TypeDefinition{
+		Type:        "entity.proposed_one",
+		Label:       "Proposed One",
+		Description: "A proposed type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusProposed,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, active); err != nil {
+		t.Fatalf("UpsertType active = %v", err)
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, proposed); err != nil {
+		t.Fatalf("UpsertType proposed = %v", err)
+	}
+
+	types, err := s.ListTypes(ctx, ontology.ScopeBrain, ontology.ListTypesOpts{Status: "proposed"})
+	if err != nil {
+		t.Fatalf("ListTypes(status=proposed) = %v", err)
+	}
+	if len(types) != 1 {
+		t.Fatalf("expected 1 proposed type, got %d", len(types))
+	}
+	if types[0].Type != "entity.proposed_one" {
+		t.Fatalf("expected entity.proposed_one, got %q", types[0].Type)
+	}
+}
+
+func TestGetResolvedOntology_BuiltInOnly(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+	if len(resolved.NodeTypes) != 31 {
+		t.Fatalf("expected 31 node types, got %d", len(resolved.NodeTypes))
+	}
+	if len(resolved.EdgeTypes) != 19 {
+		t.Fatalf("expected 19 edge types, got %d", len(resolved.EdgeTypes))
+	}
+	if len(resolved.BusinessCategories) != 8 {
+		t.Fatalf("expected 8 categories, got %d", len(resolved.BusinessCategories))
+	}
+}
+
+func TestGetResolvedOntology_BrainOverridesBuiltIn(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	override := ontology.TypeDefinition{
+		Type:        "entity.customer",
+		Label:       "Custom Customer",
+		Description: "Brain-level override of built-in customer type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, override); err != nil {
+		t.Fatalf("UpsertType = %v", err)
+	}
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.customer" {
+			if rt.Label != "Custom Customer" {
+				t.Fatalf("expected brain override label, got %q", rt.Label)
+			}
+			if rt.Scope != ontology.ScopeBrain {
+				t.Fatalf("expected scope brain, got %q", rt.Scope)
+			}
+			return
+		}
+	}
+	t.Fatal("entity.customer not found in resolved ontology")
+}
+
+func TestGetResolvedOntology_ScopeHierarchy(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	orgDef := ontology.TypeDefinition{
+		Type:        "entity.tenant",
+		Label:       "Org Tenant",
+		Description: "Organisation-level tenant",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeOrganisation, orgDef); err != nil {
+		t.Fatalf("UpsertType org = %v", err)
+	}
+
+	projectDef := ontology.TypeDefinition{
+		Type:        "entity.tenant",
+		Label:       "Project Tenant",
+		Description: "Project-level tenant override",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeProject, projectDef); err != nil {
+		t.Fatalf("UpsertType project = %v", err)
+	}
+
+	brainDef := ontology.TypeDefinition{
+		Type:        "entity.tenant",
+		Label:       "Brain Tenant",
+		Description: "Brain-level tenant override",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, brainDef); err != nil {
+		t.Fatalf("UpsertType brain = %v", err)
+	}
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.tenant" {
+			if rt.Label != "Brain Tenant" {
+				t.Fatalf("expected brain to shadow project and org, got label %q", rt.Label)
+			}
+			if rt.Scope != ontology.ScopeBrain {
+				t.Fatalf("expected scope brain, got %q", rt.Scope)
+			}
+			return
+		}
+	}
+	t.Fatal("entity.tenant not found in resolved ontology")
+}
+
+func TestGetResolvedOntology_ProjectOverridesOrg(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	orgDef := ontology.TypeDefinition{
+		Type:        "entity.account",
+		Label:       "Org Account",
+		Description: "Organisation-level account",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeOrganisation, orgDef); err != nil {
+		t.Fatalf("UpsertType org = %v", err)
+	}
+
+	projectDef := ontology.TypeDefinition{
+		Type:        "entity.account",
+		Label:       "Project Account",
+		Description: "Project-level account override",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeProject, projectDef); err != nil {
+		t.Fatalf("UpsertType project = %v", err)
+	}
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.account" {
+			if rt.Label != "Project Account" {
+				t.Fatalf("expected project to shadow org, got label %q", rt.Label)
+			}
+			if rt.Scope != ontology.ScopeProject {
+				t.Fatalf("expected scope project, got %q", rt.Scope)
+			}
+			return
+		}
+	}
+	t.Fatal("entity.account not found in resolved ontology")
+}
+
+func TestGetResolvedOntology_DeprecatedExcluded(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	deprecated := ontology.TypeDefinition{
+		Type:        "entity.legacy",
+		Label:       "Legacy Entity",
+		Description: "A deprecated type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusDeprecated,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, deprecated); err != nil {
+		t.Fatalf("UpsertType = %v", err)
+	}
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.legacy" {
+			t.Fatal("deprecated type should not appear in resolved ontology")
+		}
+	}
+}
+
+func TestGetResolvedOntology_CustomCategories(t *testing.T) {
+	t.Parallel()
+	_, ms := newTestStore(t)
+	cfg := ontology.FileOntologyStoreConfig{
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+	}
+	s := ontology.NewFileOntologyStore(ms, cfg)
+	ctx := context.Background()
+
+	stored := ontology.StoredOntology{
+		CustomBusinessCategories: []string{"logistics", "healthcare"},
+	}
+	data, err := json.Marshal(stored)
+	if err != nil {
+		t.Fatalf("marshal = %v", err)
+	}
+	if err := ms.Write(ctx, brain.Path("ontology/org/org-1/types.json"), data); err != nil {
+		t.Fatalf("Write = %v", err)
+	}
+
+	resolved, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("GetResolvedOntology = %v", err)
+	}
+
+	categorySet := make(map[string]struct{}, len(resolved.BusinessCategories))
+	for _, c := range resolved.BusinessCategories {
+		categorySet[c] = struct{}{}
+	}
+	if _, ok := categorySet["logistics"]; !ok {
+		t.Fatal("expected logistics category in resolved ontology")
+	}
+	if _, ok := categorySet["healthcare"]; !ok {
+		t.Fatal("expected healthcare category in resolved ontology")
+	}
+	if _, ok := categorySet["customer"]; !ok {
+		t.Fatal("expected built-in customer category in resolved ontology")
+	}
+}
+
+func TestGetResolvedOntology_Cached(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	resolved1, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("first GetResolvedOntology = %v", err)
+	}
+	resolved2, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("second GetResolvedOntology = %v", err)
+	}
+	if resolved1 != resolved2 {
+		t.Fatal("expected cached pointer equality")
+	}
+}
+
+func TestGetResolvedOntology_CacheInvalidatedOnUpsert(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	resolved1, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("first GetResolvedOntology = %v", err)
+	}
+
+	def := ontology.TypeDefinition{
+		Type:        "entity.fresh",
+		Label:       "Fresh",
+		Description: "A fresh type",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("UpsertType = %v", err)
+	}
+
+	resolved2, err := s.GetResolvedOntology(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("second GetResolvedOntology = %v", err)
+	}
+	if resolved1 == resolved2 {
+		t.Fatal("expected cache to be invalidated after upsert")
+	}
+}
+
+func TestUpsertType_EdgeType(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestStore(t)
+	ctx := context.Background()
+
+	def := ontology.TypeDefinition{
+		Type:        "manages",
+		Label:       "Manages",
+		Description: "Source manages target",
+		CreatedAt:   "2026-05-10T00:00:00.000Z",
+		Status:      ontology.TypeStatusActive,
+	}
+	if err := s.UpsertType(ctx, ontology.ScopeBrain, def); err != nil {
+		t.Fatalf("UpsertType edge = %v", err)
+	}
+
+	got, err := s.GetType(ctx, ontology.ScopeBrain, "manages")
+	if err != nil {
+		t.Fatalf("GetType edge = %v", err)
+	}
+	if got.Type != "manages" {
+		t.Fatalf("expected manages, got %q", got.Type)
+	}
+}
+
+func hasEntityPrefix(s string) bool {
+	return len(s) > 7 && s[:7] == "entity."
+}

--- a/go/ontology/types.go
+++ b/go/ontology/types.go
@@ -76,6 +76,15 @@ var BusinessCategories = [8]string{
 	"general",
 }
 
+// NodeTypePrefixes are the 5 valid prefixes for node type identifiers.
+var NodeTypePrefixes = [5]string{
+	"entity.",
+	"rule.",
+	"exception.",
+	"decision.",
+	"process.",
+}
+
 // nodeTypePrefixes is the mutable backing list of valid prefixes.
 // Protected by prefixMu. Starts with the 5 built-in prefixes.
 var nodeTypePrefixes = []string{
@@ -89,7 +98,7 @@ var nodeTypePrefixes = []string{
 // prefixMu protects concurrent access to nodeTypePrefixes.
 var prefixMu sync.RWMutex
 
-// NodeTypePrefixes returns a copy of the current valid prefixes.
+// NodeTypePrefixesList returns a copy of the current valid prefixes.
 // The returned slice is safe to iterate without holding any lock.
 func NodeTypePrefixesList() []string {
 	prefixMu.RLock()

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -68,3 +68,6 @@ export type {
 } from './store.js'
 
 export { createFileOntologyStore } from './store.js'
+
+export type { RegistryOptions } from './registry.js'
+export { Registry, PROPOSE_DEDUP_THRESHOLD } from './registry.js'

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -57,3 +57,14 @@ export {
   getTemplate,
   registerTemplate,
 } from './templates.js'
+
+export type {
+  FileOntologyStoreConfig,
+  ListTypesOpts,
+  OntologyStore,
+  ResolvedOntology,
+  ResolvedType,
+  StoredOntology,
+} from './store.js'
+
+export { createFileOntologyStore } from './store.js'

--- a/sdks/ts/memory/src/ontology/registry.test.ts
+++ b/sdks/ts/memory/src/ontology/registry.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import { createMemStore } from '../store/memstore.js'
+import type { OntologyTypeDefinition } from './types.js'
+import { createFileOntologyStore, type OntologyStore } from './store.js'
+import { Registry } from './registry.js'
+
+function makeRegistry(): Registry {
+  const backingStore = createMemStore()
+  const ontologyStore = createFileOntologyStore(backingStore, {
+    brainId: 'brain-1',
+    projectId: 'proj-1',
+    orgId: 'org-1',
+  })
+  return new Registry({ store: ontologyStore })
+}
+
+describe('Registry', () => {
+  let registry: Registry
+
+  beforeEach(() => {
+    registry = makeRegistry()
+  })
+
+  describe('registerType', () => {
+    it('adds a type to the store', async () => {
+      const def: OntologyTypeDefinition = {
+        type: 'entity.invoice',
+        label: 'Invoice',
+        description: 'Financial invoice',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+      }
+      await registry.registerType('brain', def)
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const invoice = resolved.nodeTypes.find((t) => t.type === 'entity.invoice')
+      expect(invoice).toBeDefined()
+      expect(invoice!.label).toBe('Invoice')
+    })
+  })
+
+  describe('deprecateType', () => {
+    it('marks a type as deprecated', async () => {
+      const def: OntologyTypeDefinition = {
+        type: 'entity.invoice',
+        label: 'Invoice',
+        description: 'Financial invoice',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+      }
+      await registry.registerType('brain', def)
+      await registry.deprecateType('brain', 'entity.invoice')
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const invoice = resolved.nodeTypes.find((t) => t.type === 'entity.invoice')
+      expect(invoice).toBeUndefined()
+    })
+
+    it('throws for nonexistent type', async () => {
+      await expect(
+        registry.deprecateType('brain', 'entity.missing'),
+      ).rejects.toThrow('not found')
+    })
+  })
+
+  describe('proposeType', () => {
+    it('creates a proposed type for genuinely new types', async () => {
+      await registry.proposeType('brain', 'nodeType', 'entity.invoice', 'Discovered in procurement docs')
+
+      // Proposed types should NOT appear in resolved (only active resolve)
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const invoice = resolved.nodeTypes.find((t) => t.type === 'entity.invoice' && t.scope === 'brain')
+      expect(invoice).toBeUndefined()
+    })
+
+    it('skips when similar type already exists', async () => {
+      // "entity.customer" is built-in. Proposing "entity.customers"
+      // should be skipped since "Customers (Entity)" is very similar
+      // to "Customer (Entity)".
+      await registry.proposeType('brain', 'nodeType', 'entity.customers', 'Should be skipped')
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const customers = resolved.nodeTypes.find((t) => t.type === 'entity.customers')
+      expect(customers).toBeUndefined()
+    })
+
+    it('creates edge type proposals', async () => {
+      await registry.proposeType('brain', 'edgeType', 'ships_to', 'Logistics relation')
+
+      // ships_to is not a built-in edge type, so it should be created as proposed
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      // It's proposed so won't appear in resolved (active only)
+      const shipsTo = resolved.edgeTypes.find((t) => t.type === 'ships_to' && t.scope === 'brain')
+      expect(shipsTo).toBeUndefined()
+    })
+  })
+
+  describe('resolve', () => {
+    it('returns all built-in types when store is empty', async () => {
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      expect(resolved.nodeTypes).toHaveLength(31)
+      expect(resolved.edgeTypes).toHaveLength(19)
+      expect(resolved.businessCategories).toHaveLength(8)
+    })
+
+    it('includes registered types in resolution', async () => {
+      const def: OntologyTypeDefinition = {
+        type: 'entity.invoice',
+        label: 'Invoice',
+        description: 'Financial invoice',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+      }
+      await registry.registerType('brain', def)
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      expect(resolved.nodeTypes).toHaveLength(32)
+    })
+  })
+})

--- a/sdks/ts/memory/src/ontology/registry.ts
+++ b/sdks/ts/memory/src/ontology/registry.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * High-level ontology Registry that wraps an OntologyStore and provides
+ * ProposeType (with Jaro-Winkler dedup guard >= 0.85), RegisterType,
+ * DeprecateType, and Resolve.
+ *
+ * Port of go/ontology/registry.go.
+ */
+
+import type { OntologyScope, OntologyTypeDefinition, TypeStatus } from './types.js'
+import type { OntologyStore, ResolvedOntology } from './store.js'
+import { formatEdgeTypeLabel, formatNodeTypeLabel } from './format.js'
+
+/**
+ * Jaro-Winkler similarity threshold above which ProposeType considers
+ * the candidate a duplicate and skips registration.
+ */
+export const PROPOSE_DEDUP_THRESHOLD = 0.85
+
+export type RegistryOptions = {
+  readonly store: OntologyStore
+}
+
+/**
+ * Registry provides high-level ontology operations on top of an
+ * OntologyStore. Adds ProposeType with fuzzy dedup guard, RegisterType,
+ * DeprecateType, and Resolve.
+ */
+export class Registry {
+  private readonly store: OntologyStore
+
+  constructor(options: RegistryOptions) {
+    this.store = options.store
+  }
+
+  /**
+   * Adds or updates a type at the specified scope.
+   */
+  async registerType(scope: OntologyScope, def: OntologyTypeDefinition): Promise<void> {
+    await this.store.upsertType(scope, def)
+  }
+
+  /**
+   * Marks a type as deprecated at the specified scope.
+   */
+  async deprecateType(scope: OntologyScope, typeName: string): Promise<void> {
+    const existing = await this.store.getType(scope, typeName)
+    if (existing === undefined) {
+      throw new Error(`ontology: type "${typeName}" not found at scope ${scope}`)
+    }
+    const deprecated: OntologyTypeDefinition = {
+      ...existing,
+      status: 'deprecated' as TypeStatus,
+    }
+    await this.store.upsertType(scope, deprecated)
+  }
+
+  /**
+   * Creates a proposed type, skipping if a fuzzy-similar type already
+   * exists (Jaro-Winkler >= 0.85). Returns without error when the type
+   * is skipped as a duplicate.
+   */
+  async proposeType(
+    scope: OntologyScope,
+    category: 'nodeType' | 'edgeType',
+    typeName: string,
+    reason: string,
+  ): Promise<void> {
+    const resolved = await this.store.getResolvedOntology('', '', '')
+
+    const existingLabels: string[] = []
+    if (category === 'nodeType') {
+      for (const rt of resolved.nodeTypes) {
+        existingLabels.push(rt.label)
+      }
+    } else {
+      for (const rt of resolved.edgeTypes) {
+        existingLabels.push(rt.label)
+      }
+    }
+
+    const proposedLabel =
+      category === 'nodeType' ? formatNodeTypeLabel(typeName) : formatEdgeTypeLabel(typeName)
+
+    for (const existing of existingLabels) {
+      const sim = jaroWinkler(proposedLabel.toLowerCase(), existing.toLowerCase())
+      if (sim >= PROPOSE_DEDUP_THRESHOLD) {
+        return
+      }
+    }
+
+    const now = new Date().toISOString()
+    const def: OntologyTypeDefinition = {
+      type: typeName,
+      label: proposedLabel,
+      description: reason,
+      discoveredFrom: 'proposal',
+      createdAt: now,
+      status: 'proposed',
+    }
+    await this.store.upsertType(scope, def)
+  }
+
+  /**
+   * Returns the fully merged ontology from the store.
+   */
+  async resolve(brainId: string, projectId: string, orgId: string): Promise<ResolvedOntology> {
+    return this.store.getResolvedOntology(brainId, projectId, orgId)
+  }
+}
+
+/**
+ * Standalone Jaro-Winkler similarity for the propose dedup guard.
+ * Avoids depending on the dedup package (P6-5).
+ */
+function jaroWinkler(s1: string, s2: string): number {
+  if (s1 === s2) return 1.0
+  if (s1.length === 0 || s2.length === 0) return 0.0
+
+  const matchWindow = Math.max(0, Math.floor(Math.max(s1.length, s2.length) / 2) - 1)
+  const s1Matches = new Array<boolean>(s1.length).fill(false)
+  const s2Matches = new Array<boolean>(s2.length).fill(false)
+
+  let matches = 0
+  let transpositions = 0
+
+  for (let i = 0; i < s1.length; i++) {
+    const start = Math.max(0, i - matchWindow)
+    const end = Math.min(i + matchWindow + 1, s2.length)
+    for (let j = start; j < end; j++) {
+      if (s2Matches[j] || s1[i] !== s2[j]) continue
+      s1Matches[i] = true
+      s2Matches[j] = true
+      matches++
+      break
+    }
+  }
+
+  if (matches === 0) return 0.0
+
+  let k = 0
+  for (let i = 0; i < s1.length; i++) {
+    if (!s1Matches[i]) continue
+    while (!s2Matches[k]) k++
+    if (s1[i] !== s2[k]) transpositions++
+    k++
+  }
+
+  const jaro =
+    (matches / s1.length + matches / s2.length + (matches - transpositions / 2) / matches) / 3
+
+  let commonPrefix = 0
+  const maxPrefix = Math.min(4, Math.min(s1.length, s2.length))
+  for (let i = 0; i < maxPrefix; i++) {
+    if (s1[i] !== s2[i]) break
+    commonPrefix++
+  }
+
+  return jaro + commonPrefix * 0.1 * (1 - jaro)
+}

--- a/sdks/ts/memory/src/ontology/store.test.ts
+++ b/sdks/ts/memory/src/ontology/store.test.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createMemStore } from '../store/memstore.js'
+import type { Store } from '../store/index.js'
+import { toPath } from '../store/path.js'
+import type { OntologyTypeDefinition } from './types.js'
+import {
+  createFileOntologyStore,
+  type FileOntologyStoreConfig,
+  type OntologyStore,
+} from './store.js'
+
+const TEST_CONFIG: FileOntologyStoreConfig = {
+  brainId: 'brain-1',
+  projectId: 'proj-1',
+  orgId: 'org-1',
+}
+
+function makeStore(): { ontologyStore: OntologyStore; backingStore: Store } {
+  const backingStore = createMemStore()
+  const ontologyStore = createFileOntologyStore(backingStore, TEST_CONFIG)
+  return { ontologyStore, backingStore }
+}
+
+function makeNodeDef(overrides: Partial<OntologyTypeDefinition> = {}): OntologyTypeDefinition {
+  return {
+    type: 'entity.invoice',
+    label: 'Invoice',
+    description: 'Financial invoice documents',
+    createdAt: '2026-05-10T00:00:00.000Z',
+    status: 'active',
+    ...overrides,
+  }
+}
+
+function makeEdgeDef(overrides: Partial<OntologyTypeDefinition> = {}): OntologyTypeDefinition {
+  return {
+    type: 'manages',
+    label: 'Manages',
+    description: 'Source manages target',
+    createdAt: '2026-05-10T00:00:00.000Z',
+    status: 'active',
+    ...overrides,
+  }
+}
+
+describe('FileOntologyStore', () => {
+  let ontologyStore: OntologyStore
+  let backingStore: Store
+
+  beforeEach(() => {
+    const stores = makeStore()
+    ontologyStore = stores.ontologyStore
+    backingStore = stores.backingStore
+  })
+
+  describe('getType', () => {
+    it('returns built-in node type without setup', async () => {
+      const def = await ontologyStore.getType('built-in', 'entity.customer')
+      expect(def).toBeDefined()
+      expect(def!.type).toBe('entity.customer')
+      expect(def!.status).toBe('active')
+      expect(def!.label).toBeTruthy()
+      expect(def!.description).toBeTruthy()
+    })
+
+    it('returns built-in edge type without setup', async () => {
+      const def = await ontologyStore.getType('built-in', 'triggers')
+      expect(def).toBeDefined()
+      expect(def!.type).toBe('triggers')
+      expect(def!.status).toBe('active')
+    })
+
+    it('returns undefined for nonexistent built-in type', async () => {
+      const def = await ontologyStore.getType('built-in', 'nonexistent.type')
+      expect(def).toBeUndefined()
+    })
+
+    it('returns type after upsert at brain scope', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef())
+      const def = await ontologyStore.getType('brain', 'entity.invoice')
+      expect(def).toBeDefined()
+      expect(def!.type).toBe('entity.invoice')
+      expect(def!.label).toBe('Invoice')
+    })
+
+    it('returns undefined for nonexistent type at brain scope', async () => {
+      const def = await ontologyStore.getType('brain', 'entity.missing')
+      expect(def).toBeUndefined()
+    })
+  })
+
+  describe('upsertType', () => {
+    it('creates a new node type at brain scope', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef())
+      const def = await ontologyStore.getType('brain', 'entity.invoice')
+      expect(def).toBeDefined()
+      expect(def!.label).toBe('Invoice')
+    })
+
+    it('overwrites existing type with same ID', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef({ label: 'V1' }))
+      await ontologyStore.upsertType('brain', makeNodeDef({ label: 'V2' }))
+      const def = await ontologyStore.getType('brain', 'entity.invoice')
+      expect(def!.label).toBe('V2')
+    })
+
+    it('creates edge type correctly', async () => {
+      await ontologyStore.upsertType('brain', makeEdgeDef())
+      const def = await ontologyStore.getType('brain', 'manages')
+      expect(def).toBeDefined()
+      expect(def!.type).toBe('manages')
+    })
+
+    it('rejects upsert to built-in scope', async () => {
+      await expect(
+        ontologyStore.upsertType('built-in', makeNodeDef()),
+      ).rejects.toThrow('cannot upsert to built-in scope')
+    })
+
+    it('rejects invalid type definition', async () => {
+      const invalid: OntologyTypeDefinition = {
+        type: 'entity.test',
+        label: '',
+        description: 'Missing label',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      }
+      await expect(ontologyStore.upsertType('brain', invalid)).rejects.toThrow()
+    })
+  })
+
+  describe('deleteType', () => {
+    it('removes node type from scope', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef())
+      await ontologyStore.deleteType('brain', 'entity.invoice')
+      const def = await ontologyStore.getType('brain', 'entity.invoice')
+      expect(def).toBeUndefined()
+    })
+
+    it('removes edge type from scope', async () => {
+      await ontologyStore.upsertType('brain', makeEdgeDef())
+      await ontologyStore.deleteType('brain', 'manages')
+      const def = await ontologyStore.getType('brain', 'manages')
+      expect(def).toBeUndefined()
+    })
+
+    it('throws for nonexistent type', async () => {
+      await expect(
+        ontologyStore.deleteType('brain', 'entity.nonexistent'),
+      ).rejects.toThrow('not found')
+    })
+
+    it('rejects delete from built-in scope', async () => {
+      await expect(
+        ontologyStore.deleteType('built-in', 'entity.customer'),
+      ).rejects.toThrow('cannot delete from built-in scope')
+    })
+  })
+
+  describe('listTypes', () => {
+    it('lists all 50 built-in types', async () => {
+      const types = await ontologyStore.listTypes('built-in')
+      expect(types).toHaveLength(50)
+    })
+
+    it('filters built-in types by prefix', async () => {
+      const types = await ontologyStore.listTypes('built-in', { prefix: 'entity.' })
+      expect(types).toHaveLength(6)
+      for (const td of types) {
+        expect(td.type.startsWith('entity.')).toBe(true)
+      }
+    })
+
+    it('filters by status', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef({ status: 'active' }))
+      await ontologyStore.upsertType('brain', makeNodeDef({
+        type: 'entity.proposed_one',
+        label: 'Proposed',
+        description: 'A proposed type',
+        status: 'proposed',
+      }))
+      const proposed = await ontologyStore.listTypes('brain', { status: 'proposed' })
+      expect(proposed).toHaveLength(1)
+      expect(proposed[0]!.type).toBe('entity.proposed_one')
+    })
+
+    it('returns empty for scope with no types', async () => {
+      const types = await ontologyStore.listTypes('brain')
+      expect(types).toHaveLength(0)
+    })
+  })
+
+  describe('getResolvedOntology', () => {
+    it('returns all built-in types when store is empty', async () => {
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      expect(resolved.nodeTypes).toHaveLength(31)
+      expect(resolved.edgeTypes).toHaveLength(19)
+      expect(resolved.businessCategories).toHaveLength(8)
+    })
+
+    it('brain scope overrides built-in', async () => {
+      await ontologyStore.upsertType('brain', {
+        type: 'entity.customer',
+        label: 'Custom Customer',
+        description: 'Brain-level override',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      const customer = resolved.nodeTypes.find((t) => t.type === 'entity.customer')
+      expect(customer).toBeDefined()
+      expect(customer!.label).toBe('Custom Customer')
+      expect(customer!.scope).toBe('brain')
+    })
+
+    it('brain overrides project overrides org', async () => {
+      await ontologyStore.upsertType('organisation', {
+        type: 'entity.tenant',
+        label: 'Org Tenant',
+        description: 'Org level',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      await ontologyStore.upsertType('project', {
+        type: 'entity.tenant',
+        label: 'Project Tenant',
+        description: 'Project level',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      await ontologyStore.upsertType('brain', {
+        type: 'entity.tenant',
+        label: 'Brain Tenant',
+        description: 'Brain level',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      const tenant = resolved.nodeTypes.find((t) => t.type === 'entity.tenant')
+      expect(tenant).toBeDefined()
+      expect(tenant!.label).toBe('Brain Tenant')
+      expect(tenant!.scope).toBe('brain')
+    })
+
+    it('project overrides org when no brain override', async () => {
+      await ontologyStore.upsertType('organisation', {
+        type: 'entity.account',
+        label: 'Org Account',
+        description: 'Org level',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      await ontologyStore.upsertType('project', {
+        type: 'entity.account',
+        label: 'Project Account',
+        description: 'Project level',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'active',
+      })
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      const account = resolved.nodeTypes.find((t) => t.type === 'entity.account')
+      expect(account).toBeDefined()
+      expect(account!.label).toBe('Project Account')
+      expect(account!.scope).toBe('project')
+    })
+
+    it('excludes deprecated types from resolution', async () => {
+      await ontologyStore.upsertType('brain', {
+        type: 'entity.legacy',
+        label: 'Legacy',
+        description: 'Deprecated type',
+        createdAt: '2026-05-10T00:00:00.000Z',
+        status: 'deprecated',
+      })
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      const legacy = resolved.nodeTypes.find((t) => t.type === 'entity.legacy')
+      expect(legacy).toBeUndefined()
+    })
+
+    it('includes custom business categories from all scopes', async () => {
+      const stored = {
+        customNodeTypes: [],
+        customEdgeTypes: [],
+        customBusinessCategories: ['logistics', 'healthcare'],
+      }
+      const data = Buffer.from(JSON.stringify(stored), 'utf-8')
+      await backingStore.write(toPath('ontology/org/org-1/types.json'), data)
+
+      const resolved = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      expect(resolved.businessCategories).toContain('logistics')
+      expect(resolved.businessCategories).toContain('healthcare')
+      expect(resolved.businessCategories).toContain('customer')
+    })
+
+    it('caches resolved ontology', async () => {
+      const resolved1 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      const resolved2 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      expect(resolved1).toBe(resolved2)
+    })
+
+    it('invalidates cache on upsert', async () => {
+      const resolved1 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      await ontologyStore.upsertType('brain', makeNodeDef())
+      const resolved2 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      expect(resolved1).not.toBe(resolved2)
+    })
+
+    it('invalidates cache on delete', async () => {
+      await ontologyStore.upsertType('brain', makeNodeDef())
+      const resolved1 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      await ontologyStore.deleteType('brain', 'entity.invoice')
+      const resolved2 = await ontologyStore.getResolvedOntology('brain-1', 'proj-1', 'org-1')
+      expect(resolved1).not.toBe(resolved2)
+    })
+  })
+})

--- a/sdks/ts/memory/src/ontology/store.ts
+++ b/sdks/ts/memory/src/ontology/store.ts
@@ -60,6 +60,22 @@ export type FileOntologyStoreConfig = {
   readonly orgId: string
 }
 
+const VALID_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
+
+/**
+ * Validates that an ID is safe for path interpolation. IDs must start with an
+ * alphanumeric character and contain only alphanumeric, underscore, or hyphen
+ * characters. This prevents path traversal attacks via ".." or "/" in IDs.
+ */
+function validateId(id: string): void {
+  if (id === '') {
+    throw new Error('ontology: ID must not be empty')
+  }
+  if (!VALID_ID_PATTERN.test(id)) {
+    throw new Error(`ontology: invalid ID "${id}": must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+  }
+}
+
 /**
  * Creates a FileOntologyStore backed by the given Store.
  * Types are stored as JSON files at well-known paths:
@@ -68,8 +84,13 @@ export type FileOntologyStoreConfig = {
  *   - Brain: ontology/brain/{brainId}/types.json
  *
  * Built-in types are hardcoded and always available without I/O.
+ * Throws if any configured ID fails validation (path traversal prevention).
  */
 export function createFileOntologyStore(store: Store, config: FileOntologyStoreConfig): OntologyStore {
+  if (config.brainId !== '') validateId(config.brainId)
+  if (config.projectId !== '') validateId(config.projectId)
+  if (config.orgId !== '') validateId(config.orgId)
+
   const cache = new Map<string, ResolvedOntology>()
 
   function idForScope(scope: OntologyScope): string {
@@ -252,6 +273,10 @@ export function createFileOntologyStore(store: Store, config: FileOntologyStoreC
     projectId: string,
     orgId: string,
   ): Promise<ResolvedOntology> {
+    if (brainId !== '') validateId(brainId)
+    if (projectId !== '') validateId(projectId)
+    if (orgId !== '') validateId(orgId)
+
     const cacheKey = `org:${orgId}:proj:${projectId}:brain:${brainId}`
     const cached = cache.get(cacheKey)
     if (cached) {
@@ -385,19 +410,29 @@ function listBuiltInTypes(): OntologyTypeDefinition[] {
   return defs
 }
 
+function isValidTypeDefinition(value: unknown): value is OntologyTypeDefinition {
+  if (value === null || typeof value !== 'object') return false
+  const obj = value as Record<string, unknown>
+  return (
+    typeof obj['type'] === 'string' &&
+    typeof obj['label'] === 'string' &&
+    typeof obj['status'] === 'string'
+  )
+}
+
 function parseStoredOntology(raw: unknown): StoredOntology {
   if (raw === null || typeof raw !== 'object') {
     return { customNodeTypes: [], customEdgeTypes: [], customBusinessCategories: [] }
   }
   const obj = raw as Record<string, unknown>
   const nodeTypes = Array.isArray(obj['customNodeTypes'])
-    ? (obj['customNodeTypes'] as OntologyTypeDefinition[])
+    ? (obj['customNodeTypes'] as unknown[]).filter(isValidTypeDefinition)
     : []
   const edgeTypes = Array.isArray(obj['customEdgeTypes'])
-    ? (obj['customEdgeTypes'] as OntologyTypeDefinition[])
+    ? (obj['customEdgeTypes'] as unknown[]).filter(isValidTypeDefinition)
     : []
   const categories = Array.isArray(obj['customBusinessCategories'])
-    ? (obj['customBusinessCategories'] as string[])
+    ? (obj['customBusinessCategories'] as unknown[]).filter((v): v is string => typeof v === 'string')
     : []
   return {
     customNodeTypes: nodeTypes,

--- a/sdks/ts/memory/src/ontology/store.ts
+++ b/sdks/ts/memory/src/ontology/store.ts
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Ontology type registry with dual-backend persistence and 4-layer scope
+ * resolution. Provides CRUD operations for custom type definitions and
+ * resolves the complete ontology by merging built-in, organisation, project,
+ * and brain scopes.
+ *
+ * Port of go/ontology/store.go and store_file.go.
+ */
+
+import type { Store } from '../store/index.js'
+import type { Path } from '../store/path.js'
+import type { OntologyScope, OntologyTypeDefinition, TypeStatus } from './types.js'
+
+import { isNotFound } from '../store/errors.js'
+import { toPath } from '../store/path.js'
+import { BUILT_IN_EDGE_TYPES, BUILT_IN_NODE_TYPES, BUSINESS_CATEGORIES, NODE_TYPE_PREFIXES } from './types.js'
+import { getBuiltInEdgeTypeDescription, getBuiltInNodeTypeDescription } from './descriptions.js'
+import { formatEdgeTypeLabel, formatNodeTypeLabel } from './format.js'
+import { validateTypeDefinition } from './validation.js'
+
+export type ListTypesOpts = {
+  readonly prefix?: string
+  readonly status?: TypeStatus
+}
+
+export type ResolvedType = OntologyTypeDefinition & {
+  readonly scope: OntologyScope
+}
+
+export type ResolvedOntology = {
+  readonly nodeTypes: readonly ResolvedType[]
+  readonly edgeTypes: readonly ResolvedType[]
+  readonly businessCategories: readonly string[]
+}
+
+export type StoredOntology = {
+  readonly customNodeTypes: readonly OntologyTypeDefinition[]
+  readonly customEdgeTypes: readonly OntologyTypeDefinition[]
+  readonly customBusinessCategories: readonly string[]
+}
+
+export type OntologyStore = {
+  getType(scope: OntologyScope, typeId: string): Promise<OntologyTypeDefinition | undefined>
+  listTypes(scope: OntologyScope, opts?: ListTypesOpts): Promise<readonly OntologyTypeDefinition[]>
+  upsertType(scope: OntologyScope, def: OntologyTypeDefinition): Promise<void>
+  deleteType(scope: OntologyScope, typeId: string): Promise<void>
+  getResolvedOntology(
+    brainId: string,
+    projectId: string,
+    orgId: string,
+  ): Promise<ResolvedOntology>
+  close(): Promise<void>
+}
+
+export type FileOntologyStoreConfig = {
+  readonly brainId: string
+  readonly projectId: string
+  readonly orgId: string
+}
+
+/**
+ * Creates a FileOntologyStore backed by the given Store.
+ * Types are stored as JSON files at well-known paths:
+ *   - Organisation: ontology/org/{orgId}/types.json
+ *   - Project: ontology/project/{projectId}/types.json
+ *   - Brain: ontology/brain/{brainId}/types.json
+ *
+ * Built-in types are hardcoded and always available without I/O.
+ */
+export function createFileOntologyStore(store: Store, config: FileOntologyStoreConfig): OntologyStore {
+  const cache = new Map<string, ResolvedOntology>()
+
+  function idForScope(scope: OntologyScope): string {
+    switch (scope) {
+      case 'organisation':
+        return config.orgId
+      case 'project':
+        return config.projectId
+      case 'brain':
+        return config.brainId
+      case 'built-in':
+        return ''
+    }
+  }
+
+  function scopePath(scope: OntologyScope, id: string): Path {
+    switch (scope) {
+      case 'organisation':
+        return toPath(`ontology/org/${id}/types.json`)
+      case 'project':
+        return toPath(`ontology/project/${id}/types.json`)
+      case 'brain':
+        return toPath(`ontology/brain/${id}/types.json`)
+      case 'built-in':
+        return toPath('ontology/types.json')
+    }
+  }
+
+  async function readScopeById(scope: OntologyScope, id: string): Promise<StoredOntology> {
+    const p = scopePath(scope, id)
+    try {
+      const data = await store.read(p)
+      const parsed: unknown = JSON.parse(data.toString('utf-8'))
+      return parseStoredOntology(parsed)
+    } catch (err: unknown) {
+      if (isNotFound(err)) {
+        return { customNodeTypes: [], customEdgeTypes: [], customBusinessCategories: [] }
+      }
+      throw err
+    }
+  }
+
+  async function writeScopeById(scope: OntologyScope, id: string, stored: StoredOntology): Promise<void> {
+    const p = scopePath(scope, id)
+    const data = Buffer.from(JSON.stringify(stored), 'utf-8')
+    await store.write(p, data)
+  }
+
+  function invalidateCache(): void {
+    cache.clear()
+  }
+
+  function hasNodeTypePrefix(typeId: string): boolean {
+    for (const prefix of NODE_TYPE_PREFIXES) {
+      if (typeId.startsWith(prefix)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  function filterTypes(
+    defs: readonly OntologyTypeDefinition[],
+    opts?: ListTypesOpts,
+  ): readonly OntologyTypeDefinition[] {
+    if (!opts?.prefix && !opts?.status) {
+      return defs
+    }
+    return defs.filter((d) => {
+      if (opts?.prefix && !d.type.startsWith(opts.prefix)) return false
+      if (opts?.status && d.status !== opts.status) return false
+      return true
+    })
+  }
+
+  async function getType(
+    scope: OntologyScope,
+    typeId: string,
+  ): Promise<OntologyTypeDefinition | undefined> {
+    if (scope === 'built-in') {
+      return getBuiltInType(typeId)
+    }
+    const stored = await readScopeById(scope, idForScope(scope))
+    for (const nt of stored.customNodeTypes) {
+      if (nt.type === typeId) return nt
+    }
+    for (const et of stored.customEdgeTypes) {
+      if (et.type === typeId) return et
+    }
+    return undefined
+  }
+
+  async function listTypes(
+    scope: OntologyScope,
+    opts?: ListTypesOpts,
+  ): Promise<readonly OntologyTypeDefinition[]> {
+    if (scope === 'built-in') {
+      return filterTypes(listBuiltInTypes(), opts)
+    }
+    const stored = await readScopeById(scope, idForScope(scope))
+    const combined = [...stored.customNodeTypes, ...stored.customEdgeTypes]
+    return filterTypes(combined, opts)
+  }
+
+  async function upsertType(scope: OntologyScope, def: OntologyTypeDefinition): Promise<void> {
+    if (scope === 'built-in') {
+      throw new Error('ontology: cannot upsert to built-in scope')
+    }
+    const validationError = validateTypeDefinition(def)
+    if (validationError !== undefined) {
+      throw new Error(validationError)
+    }
+    const id = idForScope(scope)
+    const stored = await readScopeById(scope, id)
+    const mutableNodeTypes = [...stored.customNodeTypes]
+    const mutableEdgeTypes = [...stored.customEdgeTypes]
+
+    if (hasNodeTypePrefix(def.type)) {
+      const existingIdx = mutableNodeTypes.findIndex((t) => t.type === def.type)
+      if (existingIdx >= 0) {
+        mutableNodeTypes[existingIdx] = def
+      } else {
+        mutableNodeTypes.push(def)
+      }
+    } else {
+      const existingIdx = mutableEdgeTypes.findIndex((t) => t.type === def.type)
+      if (existingIdx >= 0) {
+        mutableEdgeTypes[existingIdx] = def
+      } else {
+        mutableEdgeTypes.push(def)
+      }
+    }
+
+    await writeScopeById(scope, id, {
+      customNodeTypes: mutableNodeTypes,
+      customEdgeTypes: mutableEdgeTypes,
+      customBusinessCategories: stored.customBusinessCategories,
+    })
+    invalidateCache()
+  }
+
+  async function deleteType(scope: OntologyScope, typeId: string): Promise<void> {
+    if (scope === 'built-in') {
+      throw new Error('ontology: cannot delete from built-in scope')
+    }
+    const id = idForScope(scope)
+    const stored = await readScopeById(scope, id)
+    const mutableNodeTypes = [...stored.customNodeTypes]
+    const mutableEdgeTypes = [...stored.customEdgeTypes]
+
+    const nodeIdx = mutableNodeTypes.findIndex((t) => t.type === typeId)
+    if (nodeIdx >= 0) {
+      mutableNodeTypes.splice(nodeIdx, 1)
+      await writeScopeById(scope, id, {
+        customNodeTypes: mutableNodeTypes,
+        customEdgeTypes: mutableEdgeTypes,
+        customBusinessCategories: stored.customBusinessCategories,
+      })
+      invalidateCache()
+      return
+    }
+
+    const edgeIdx = mutableEdgeTypes.findIndex((t) => t.type === typeId)
+    if (edgeIdx >= 0) {
+      mutableEdgeTypes.splice(edgeIdx, 1)
+      await writeScopeById(scope, id, {
+        customNodeTypes: mutableNodeTypes,
+        customEdgeTypes: mutableEdgeTypes,
+        customBusinessCategories: stored.customBusinessCategories,
+      })
+      invalidateCache()
+      return
+    }
+
+    throw new Error(`ontology: type "${typeId}" not found at scope ${scope}`)
+  }
+
+  async function getResolvedOntology(
+    brainId: string,
+    projectId: string,
+    orgId: string,
+  ): Promise<ResolvedOntology> {
+    const cacheKey = `org:${orgId}:proj:${projectId}:brain:${brainId}`
+    const cached = cache.get(cacheKey)
+    if (cached) {
+      return cached
+    }
+
+    const nodeMap = new Map<string, ResolvedType>()
+    const edgeMap = new Map<string, ResolvedType>()
+    const categorySet = new Set<string>(BUSINESS_CATEGORIES)
+
+    for (const nt of BUILT_IN_NODE_TYPES) {
+      nodeMap.set(nt, {
+        type: nt,
+        label: formatNodeTypeLabel(nt),
+        description: getBuiltInNodeTypeDescription(nt),
+        createdAt: '1970-01-01T00:00:00.000Z',
+        status: 'active',
+        scope: 'built-in',
+      })
+    }
+    for (const et of BUILT_IN_EDGE_TYPES) {
+      edgeMap.set(et, {
+        type: et,
+        label: formatEdgeTypeLabel(et),
+        description: getBuiltInEdgeTypeDescription(et),
+        createdAt: '1970-01-01T00:00:00.000Z',
+        status: 'active',
+        scope: 'built-in',
+      })
+    }
+
+    const layers: ReadonlyArray<{ scope: OntologyScope; id: string }> = [
+      { scope: 'organisation', id: orgId },
+      { scope: 'project', id: projectId },
+      { scope: 'brain', id: brainId },
+    ]
+
+    for (const layer of layers) {
+      if (!layer.id) continue
+      const stored = await readScopeById(layer.scope, layer.id)
+      for (const nt of stored.customNodeTypes) {
+        nodeMap.set(nt.type, { ...nt, scope: layer.scope })
+      }
+      for (const et of stored.customEdgeTypes) {
+        edgeMap.set(et.type, { ...et, scope: layer.scope })
+      }
+      for (const cat of stored.customBusinessCategories) {
+        categorySet.add(cat)
+      }
+    }
+
+    const activeNodes: ResolvedType[] = []
+    for (const rt of nodeMap.values()) {
+      if (rt.status === 'active') activeNodes.push(rt)
+    }
+    const activeEdges: ResolvedType[] = []
+    for (const rt of edgeMap.values()) {
+      if (rt.status === 'active') activeEdges.push(rt)
+    }
+    const sortedCategories = [...categorySet].sort()
+
+    const resolved: ResolvedOntology = {
+      nodeTypes: activeNodes,
+      edgeTypes: activeEdges,
+      businessCategories: sortedCategories,
+    }
+
+    cache.set(cacheKey, resolved)
+    return resolved
+  }
+
+  async function close(): Promise<void> {
+    cache.clear()
+  }
+
+  return {
+    getType,
+    listTypes,
+    upsertType,
+    deleteType,
+    getResolvedOntology,
+    close,
+  }
+}
+
+function getBuiltInType(typeId: string): OntologyTypeDefinition | undefined {
+  const builtInNodeSet: ReadonlySet<string> = new Set(BUILT_IN_NODE_TYPES)
+  const builtInEdgeSet: ReadonlySet<string> = new Set(BUILT_IN_EDGE_TYPES)
+
+  if (builtInNodeSet.has(typeId)) {
+    return {
+      type: typeId,
+      label: formatNodeTypeLabel(typeId),
+      description: getBuiltInNodeTypeDescription(typeId),
+      createdAt: '1970-01-01T00:00:00.000Z',
+      status: 'active',
+    }
+  }
+  if (builtInEdgeSet.has(typeId)) {
+    return {
+      type: typeId,
+      label: formatEdgeTypeLabel(typeId),
+      description: getBuiltInEdgeTypeDescription(typeId),
+      createdAt: '1970-01-01T00:00:00.000Z',
+      status: 'active',
+    }
+  }
+  return undefined
+}
+
+function listBuiltInTypes(): OntologyTypeDefinition[] {
+  const defs: OntologyTypeDefinition[] = []
+  for (const nt of BUILT_IN_NODE_TYPES) {
+    defs.push({
+      type: nt,
+      label: formatNodeTypeLabel(nt),
+      description: getBuiltInNodeTypeDescription(nt),
+      createdAt: '1970-01-01T00:00:00.000Z',
+      status: 'active',
+    })
+  }
+  for (const et of BUILT_IN_EDGE_TYPES) {
+    defs.push({
+      type: et,
+      label: formatEdgeTypeLabel(et),
+      description: getBuiltInEdgeTypeDescription(et),
+      createdAt: '1970-01-01T00:00:00.000Z',
+      status: 'active',
+    })
+  }
+  return defs
+}
+
+function parseStoredOntology(raw: unknown): StoredOntology {
+  if (raw === null || typeof raw !== 'object') {
+    return { customNodeTypes: [], customEdgeTypes: [], customBusinessCategories: [] }
+  }
+  const obj = raw as Record<string, unknown>
+  const nodeTypes = Array.isArray(obj['customNodeTypes'])
+    ? (obj['customNodeTypes'] as OntologyTypeDefinition[])
+    : []
+  const edgeTypes = Array.isArray(obj['customEdgeTypes'])
+    ? (obj['customEdgeTypes'] as OntologyTypeDefinition[])
+    : []
+  const categories = Array.isArray(obj['customBusinessCategories'])
+    ? (obj['customBusinessCategories'] as string[])
+    : []
+  return {
+    customNodeTypes: nodeTypes,
+    customEdgeTypes: edgeTypes,
+    customBusinessCategories: categories,
+  }
+}


### PR DESCRIPTION
## Summary
- OntologyStore interface: GetType, ListTypes, UpsertType, DeleteType, GetResolvedOntology
- FileOntologyStore: JSON files via brain.Store, in-memory cache with invalidation
- 4-layer scope resolution: built-in → organisation → project → brain (higher shadows lower)
- ID validation: rejects path traversal attempts (IDs must match `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
- JSON parse validation: filters invalid elements rather than unsafe casting
- Built-in types (31 node + 19 edge + 8 category) available without setup

## Test plan
- [ ] Built-in types available immediately
- [ ] UpsertType at brain scope, then GetType returns it
- [ ] GetResolvedOntology merges 4 layers with shadowing
- [ ] ListTypes filters by prefix/category/status
- [ ] Invalid IDs rejected (path traversal prevented)
- [ ] 22 Go + 27 TS tests pass

Closes LLE-9791