### PR TITLE
Add memory correction and hygiene helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "sdks/ts/memory": {
       "name": "@jeffs-brain/memory",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "memory": "./dist/cli.js",
       },

--- a/go/memory/correction.go
+++ b/go/memory/correction.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Correction is the structured result of DetectCorrection.
+type Correction struct {
+	Snippet string
+	Phrase  string
+}
+
+// CorrectionReminderOptions configures BuildCorrectionReminderWithOptions.
+type CorrectionReminderOptions struct {
+	SearchTool    string
+	CreateTool    string
+	UpdateTool    string
+	RemoveTool    string
+	MentionChange bool
+}
+
+var correctionPhrases = []string{
+	"that's wrong",
+	"thats wrong",
+	"you got that wrong",
+	"you have that wrong",
+	"you're wrong",
+	"youre wrong",
+	"you are wrong",
+	"actually it's",
+	"actually its",
+	"actually it is",
+	"it's actually",
+	"its actually",
+	"it is actually",
+	"stop saying",
+	"don't say",
+	"do not say",
+	"not right",
+	"wrong, it's",
+	"wrong, its",
+	"wrong it's",
+	"i never said",
+	"i didn't say",
+	"i did not say",
+	"that's not",
+	"thats not",
+	"that is not",
+	"correct that",
+	"correction:",
+	"please correct",
+	"please update",
+	"please remove",
+	"please forget",
+	"forget that",
+	"forget what",
+	"remember instead",
+	"the correct",
+}
+
+var soloCorrectionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)^\s*no[\s,\-]+(it'?s|the|that|it is|its|that is|its actually)\b`),
+	regexp.MustCompile(`(?i)^\s*(wrong|incorrect)[\s,!\.]`),
+	regexp.MustCompile(`(?i)^\s*actually[,\s\-]`),
+}
+
+var falsePositiveSubstrings = []string{
+	"no problem",
+	"no idea",
+	"no worries",
+	"no rush",
+	"no big deal",
+	"wrong end of the stick",
+	"wrong number",
+	"wrong place",
+	"nothing wrong",
+	"not wrong",
+	"no, before that",
+	"no, but",
+}
+
+// DetectCorrection returns a Correction when latestUserText looks like a
+// correction of a previously stated fact or preference.
+func DetectCorrection(latestUserText string) (Correction, bool) {
+	if latestUserText == "" {
+		return Correction{}, false
+	}
+
+	clean := strings.ToLower(latestUserText)
+	clean = strings.TrimSpace(clean)
+	if clean == "" {
+		return Correction{}, false
+	}
+
+	for _, fp := range falsePositiveSubstrings {
+		if strings.Contains(clean, fp) {
+			return Correction{}, false
+		}
+	}
+
+	for _, phrase := range correctionPhrases {
+		if idx := strings.Index(clean, phrase); idx >= 0 {
+			return Correction{
+				Snippet: extractCorrectionSnippet(latestUserText, idx),
+				Phrase:  phrase,
+			}, true
+		}
+	}
+
+	for _, re := range soloCorrectionPatterns {
+		if loc := re.FindStringIndex(clean); loc != nil {
+			return Correction{
+				Snippet: extractCorrectionSnippet(latestUserText, loc[0]),
+				Phrase:  re.String(),
+			}, true
+		}
+	}
+
+	return Correction{}, false
+}
+
+// BuildCorrectionReminder returns a default memory-tool reminder for a
+// correction-looking turn, or the empty string when no correction is detected.
+func BuildCorrectionReminder(userInput string) string {
+	return BuildCorrectionReminderWithOptions(userInput, CorrectionReminderOptions{
+		SearchTool:    "memory_search",
+		UpdateTool:    "memory_update",
+		RemoveTool:    "memory_remove",
+		CreateTool:    "memory_create",
+		MentionChange: true,
+	})
+}
+
+// BuildCorrectionReminderWithOptions returns a per-turn instruction that
+// nudges an assistant to repair stale memory before answering.
+func BuildCorrectionReminderWithOptions(userInput string, opts CorrectionReminderOptions) string {
+	c, ok := DetectCorrection(userInput)
+	if !ok {
+		return ""
+	}
+	snippet := c.Snippet
+	if snippet == "" {
+		snippet = userInput
+	}
+
+	searchTool := defaultString(opts.SearchTool, "memory_search")
+	updateTool := defaultString(opts.UpdateTool, "memory_update")
+	removeTool := defaultString(opts.RemoveTool, "memory_remove")
+	createTool := defaultString(opts.CreateTool, "memory_create")
+
+	reminder := fmt.Sprintf(
+		"User correction detected (%q). Before answering, call %s for the disputed topic. If a stale entry exists, call %s or %s with a reason. If no entry exists yet but the correction is durable, call %s.",
+		snippet,
+		searchTool,
+		updateTool,
+		removeTool,
+		createTool,
+	)
+	if opts.MentionChange {
+		reminder += " Mention in your reply what you changed."
+	}
+	return reminder
+}
+
+func extractCorrectionSnippet(original string, matchStart int) string {
+	const maxLen = 160
+	runes := []rune(original)
+	if len(runes) <= maxLen {
+		return strings.TrimSpace(string(runes))
+	}
+
+	runeStart := 0
+	for i := range original {
+		if i >= matchStart {
+			break
+		}
+		runeStart++
+	}
+	start := runeStart - maxLen/3
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxLen
+	if end > len(runes) {
+		end = len(runes)
+		start = end - maxLen
+		if start < 0 {
+			start = 0
+		}
+	}
+	prefix := ""
+	if start > 0 {
+		prefix = "..."
+	}
+	suffix := ""
+	if end < len(runes) {
+		suffix = "..."
+	}
+	return strings.TrimSpace(prefix + string(runes[start:end]) + suffix)
+}
+
+func defaultString(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/go/memory/correction_test.go
+++ b/go/memory/correction_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectCorrectionPositive(t *testing.T) {
+	cases := []string{
+		"No, it's actually 7am, not 8am.",
+		"That's wrong, the meeting is on Tuesday.",
+		"You got that wrong, the project is called Roo not Roe.",
+		"Actually, it's blue not red.",
+		"Stop saying I live in London, I live in Amersfoort.",
+		"Wrong, it's Anthropic not OpenAI.",
+		"I never said I wanted Slack messages, I wanted Telegram.",
+		"That's not what I meant, please update memory.",
+		"Please forget that I work at Google.",
+		"Correction: my wife's name is Nadia, not Nadya.",
+		"You're wrong about my role.",
+		"Actually it's a Pi 4B, not a Pi 5.",
+		"I didn't say that. I never use docker compose for this.",
+		"It is actually 4 children, not 3.",
+	}
+	for _, c := range cases {
+		got, ok := DetectCorrection(c)
+		if !ok {
+			t.Errorf("expected correction for %q", c)
+			continue
+		}
+		if got.Snippet == "" {
+			t.Errorf("expected snippet for %q", c)
+		}
+	}
+}
+
+func TestDetectCorrectionNegative(t *testing.T) {
+	cases := []string{
+		"No problem, I'll handle it.",
+		"No idea what that means.",
+		"No worries, take your time.",
+		"You got the wrong end of the stick earlier.",
+		"There's nothing wrong with the build.",
+		"Not wrong per se, just not what I'd pick.",
+		"No, before that I asked you to set up Slack.",
+		"I think you're right about the route.",
+		"Yes, that's right.",
+		"Can you fix the bug in app.go?",
+		"What is the status of the deploy?",
+		"I see no problem with that approach.",
+		"No, but seriously can you try again?",
+	}
+	for _, c := range cases {
+		got, ok := DetectCorrection(c)
+		if ok {
+			t.Errorf("unexpected correction for %q: phrase=%q", c, got.Phrase)
+		}
+	}
+}
+
+func TestDetectCorrectionEmptyInput(t *testing.T) {
+	if _, ok := DetectCorrection(""); ok {
+		t.Errorf("expected no correction for empty input")
+	}
+	if _, ok := DetectCorrection("   \n\t  "); ok {
+		t.Errorf("expected no correction for whitespace-only input")
+	}
+}
+
+func TestDetectCorrectionSnippetCarriesOriginalCasing(t *testing.T) {
+	input := "Actually it's Anthropic, not OpenAI - get it right next time."
+	got, ok := DetectCorrection(input)
+	if !ok {
+		t.Fatalf("expected correction")
+	}
+	if !strings.Contains(strings.ToLower(got.Snippet), "anthropic") {
+		t.Errorf("snippet %q should contain anthropic", got.Snippet)
+	}
+	if !strings.Contains(got.Snippet, "Anthropic") {
+		t.Errorf("snippet %q should preserve original casing", got.Snippet)
+	}
+}
+
+func TestBuildCorrectionReminder(t *testing.T) {
+	got := BuildCorrectionReminder("Actually it's 7am not 8am, please update memory.")
+	for _, want := range []string{"memory_search", "memory_update", "memory_remove", "memory_create", "Mention"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reminder %q missing %q", got, want)
+		}
+	}
+}
+
+func TestBuildCorrectionReminderWithOptions(t *testing.T) {
+	got := BuildCorrectionReminderWithOptions("Wrong, it is Tuesday.", CorrectionReminderOptions{
+		SearchTool: "lookup",
+		UpdateTool: "patch",
+		RemoveTool: "retire",
+		CreateTool: "create",
+	})
+	for _, want := range []string{"lookup", "patch", "retire", "create"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("reminder %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "Mention") {
+		t.Fatalf("unexpected mention instruction: %q", got)
+	}
+}

--- a/go/memory/hygiene.go
+++ b/go/memory/hygiene.go
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+// DefaultRetiredAgeDays is the default age before a superseded memory
+// file is stamped with retired: true by the hygiene pass.
+const DefaultRetiredAgeDays = 30
+
+// HygieneOptions tunes a single hygiene pass.
+type HygieneOptions struct {
+	// RetiredAgeDays controls when superseded entries are soft-retired.
+	// Zero or negative means use DefaultRetiredAgeDays.
+	RetiredAgeDays int
+
+	// Apply controls whether the pass writes changes. When false the pass
+	// populates the report but never mutates the store.
+	Apply bool
+
+	// Now pins time for tests and reproducible reports. Zero means time.Now.
+	Now time.Time
+}
+
+// HygieneReport summarises what the contradiction and aging pass found.
+type HygieneReport struct {
+	Contradictions []ContradictionGroup
+	AgingRetired   []AgingRetirement
+	Errors         []string
+}
+
+// ContradictionGroup describes live memory files that cover the same
+// topic. When Apply is set, every entry except Canonical is stamped with
+// superseded_by pointing at Canonical.
+type ContradictionGroup struct {
+	Key       string
+	KeyReason string
+	Scope     string
+	Project   string
+	Members   []TopicFile
+	Canonical brain.Path
+}
+
+// AgingRetirement describes a superseded file that should be soft-retired.
+type AgingRetirement struct {
+	Path brain.Path
+	Age  time.Duration
+}
+
+// RunHygiene performs a contradiction and aging pass across every memory
+// scope. Dry-run mode reports intended changes. Apply mode writes one
+// batch per scope.
+func (c *Consolidator) RunHygiene(ctx context.Context, opts HygieneOptions) (*HygieneReport, error) {
+	c.mu.Lock()
+	if c.inProgress {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("consolidation already in progress")
+	}
+	c.inProgress = true
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		c.inProgress = false
+		c.mu.Unlock()
+	}()
+
+	report := &HygieneReport{}
+
+	maxAgeDays := opts.RetiredAgeDays
+	if maxAgeDays <= 0 {
+		maxAgeDays = DefaultRetiredAgeDays
+	}
+	maxAge := time.Duration(maxAgeDays) * 24 * time.Hour
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	prefixes := c.scopePrefixes(ctx)
+	for _, prefix := range prefixes {
+		c.detectContradictionsForPrefix(ctx, prefix, report)
+		c.ageRetireSupersededForPrefix(ctx, prefix, now, maxAge, report)
+	}
+
+	if !opts.Apply {
+		for i := range report.Contradictions {
+			report.Contradictions[i].Canonical = ""
+		}
+		return report, nil
+	}
+
+	for _, prefix := range prefixes {
+		c.applyHygieneForPrefix(ctx, prefix, report, now)
+	}
+
+	return report, nil
+}
+
+func (c *Consolidator) detectContradictionsForPrefix(ctx context.Context, prefix brain.Path, report *HygieneReport) {
+	scope, project := hygieneScopeForPrefix(prefix)
+
+	entries, err := c.mem.store.List(ctx, prefix, brain.ListOpts{IncludeGenerated: true})
+	if err != nil {
+		if !errors.Is(err, brain.ErrNotFound) {
+			report.Errors = append(report.Errors, fmt.Sprintf("listing %s: %s", prefix, err))
+		}
+		return
+	}
+
+	groupsByClaim := map[string][]TopicFile{}
+	groupsByName := map[string][]TopicFile{}
+
+	for _, e := range entries {
+		if e.IsDir {
+			continue
+		}
+		base := path.Base(string(e.Path))
+		if !strings.HasSuffix(base, ".md") || strings.EqualFold(base, "MEMORY.md") {
+			continue
+		}
+		data, err := c.mem.store.Read(ctx, e.Path)
+		if err != nil {
+			continue
+		}
+		fm, _ := ParseFrontmatter(string(data))
+		if fm.SupersededBy != "" || fm.Retired {
+			continue
+		}
+		topic := TopicFile{
+			Name:        fm.Name,
+			Description: fm.Description,
+			Type:        fm.Type,
+			Path:        e.Path,
+			Created:     fm.Created,
+			Modified:    fm.Modified,
+			Tags:        fm.Tags,
+			Confidence:  fm.Confidence,
+			Source:      fm.Source,
+			Scope:       scope,
+		}
+
+		if fm.ClaimKey != "" {
+			groupsByClaim[fm.ClaimKey] = append(groupsByClaim[fm.ClaimKey], topic)
+		}
+		if fm.Name != "" {
+			key := strings.ToLower(strings.TrimSpace(fm.Name))
+			groupsByName[key] = append(groupsByName[key], topic)
+		}
+	}
+
+	emitContradictionGroups(report, groupsByClaim, "claim_key", scope, project)
+	emitContradictionGroups(report, groupsByName, "name", scope, project)
+}
+
+func emitContradictionGroups(report *HygieneReport, groupsByKey map[string][]TopicFile, reason, scope, project string) {
+	keys := make([]string, 0, len(groupsByKey))
+	for k := range groupsByKey {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		members := groupsByKey[k]
+		if len(members) < 2 {
+			continue
+		}
+		seen := map[brain.Path]bool{}
+		unique := make([]TopicFile, 0, len(members))
+		for _, m := range members {
+			if seen[m.Path] {
+				continue
+			}
+			seen[m.Path] = true
+			unique = append(unique, m)
+		}
+		if len(unique) < 2 {
+			continue
+		}
+		report.Contradictions = append(report.Contradictions, ContradictionGroup{
+			Key:       k,
+			KeyReason: reason,
+			Scope:     scope,
+			Project:   project,
+			Members:   unique,
+		})
+	}
+}
+
+func pickCanonical(members []TopicFile) TopicFile {
+	if len(members) == 0 {
+		return TopicFile{}
+	}
+	confidenceRank := func(s string) int {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "high":
+			return 3
+		case "medium":
+			return 2
+		case "low":
+			return 1
+		}
+		return 0
+	}
+	sorted := make([]TopicFile, len(members))
+	copy(sorted, members)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ri, rj := confidenceRank(sorted[i].Confidence), confidenceRank(sorted[j].Confidence)
+		if ri != rj {
+			return ri > rj
+		}
+		ti := parseHygieneModified(sorted[i].Modified)
+		tj := parseHygieneModified(sorted[j].Modified)
+		if !ti.Equal(tj) {
+			return ti.After(tj)
+		}
+		return string(sorted[i].Path) < string(sorted[j].Path)
+	})
+	return sorted[0]
+}
+
+func parseHygieneModified(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+func (c *Consolidator) ageRetireSupersededForPrefix(ctx context.Context, prefix brain.Path, now time.Time, maxAge time.Duration, report *HygieneReport) {
+	threshold := now.Add(-maxAge)
+
+	entries, err := c.mem.store.List(ctx, prefix, brain.ListOpts{IncludeGenerated: true})
+	if err != nil {
+		if !errors.Is(err, brain.ErrNotFound) {
+			report.Errors = append(report.Errors, fmt.Sprintf("listing %s: %s", prefix, err))
+		}
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir {
+			continue
+		}
+		base := path.Base(string(e.Path))
+		if !strings.HasSuffix(base, ".md") || strings.EqualFold(base, "MEMORY.md") {
+			continue
+		}
+		data, err := c.mem.store.Read(ctx, e.Path)
+		if err != nil {
+			continue
+		}
+		fm, _ := ParseFrontmatter(string(data))
+		if fm.SupersededBy == "" || fm.Retired {
+			continue
+		}
+		modified := parseHygieneModified(fm.Modified)
+		if modified.IsZero() || !modified.Before(threshold) {
+			continue
+		}
+		report.AgingRetired = append(report.AgingRetired, AgingRetirement{
+			Path: e.Path,
+			Age:  now.Sub(modified),
+		})
+	}
+}
+
+func (c *Consolidator) applyHygieneForPrefix(ctx context.Context, prefix brain.Path, report *HygieneReport, now time.Time) {
+	scope, project := hygieneScopeForPrefix(prefix)
+
+	var groupsHere []*ContradictionGroup
+	for i := range report.Contradictions {
+		g := &report.Contradictions[i]
+		if g.Scope == scope && g.Project == project {
+			groupsHere = append(groupsHere, g)
+		}
+	}
+	var retireHere []*AgingRetirement
+	for i := range report.AgingRetired {
+		a := &report.AgingRetired[i]
+		if strings.HasPrefix(string(a.Path), string(prefix)+"/") {
+			retireHere = append(retireHere, a)
+		}
+	}
+	if len(groupsHere) == 0 && len(retireHere) == 0 {
+		return
+	}
+
+	err := c.mem.store.Batch(ctx, brain.BatchOptions{Reason: "memory:hygiene " + scope + hygieneProjectSuffix(project)}, func(b brain.Batch) error {
+		for _, g := range groupsHere {
+			canonical := pickCanonical(g.Members)
+			g.Canonical = canonical.Path
+			canonicalFile := path.Base(string(canonical.Path))
+			for _, m := range g.Members {
+				if m.Path == canonical.Path {
+					continue
+				}
+				if _, err := stampSupersededBy(ctx, b, m.Path, canonicalFile); err != nil {
+					report.Errors = append(report.Errors, fmt.Sprintf("stamp %s: %s", m.Path, err))
+				}
+			}
+		}
+		for _, a := range retireHere {
+			existing, err := b.Read(ctx, a.Path)
+			if err != nil {
+				report.Errors = append(report.Errors, fmt.Sprintf("read %s: %s", a.Path, err))
+				continue
+			}
+			reason := fmt.Sprintf("auto-retired by hygiene: superseded for %s", a.Age.Round(24*time.Hour))
+			stamped := retireFrontmatterInPlace(existing, now, reason)
+			if err := b.Write(ctx, a.Path, stamped); err != nil {
+				report.Errors = append(report.Errors, fmt.Sprintf("retire %s: %s", a.Path, err))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		report.Errors = append(report.Errors, fmt.Sprintf("hygiene batch %s: %s", prefix, err))
+	}
+}
+
+func retireFrontmatterInPlace(existing []byte, now time.Time, reason string) []byte {
+	content := string(existing)
+	lines := strings.Split(content, "\n")
+	if len(lines) < 2 || strings.TrimSpace(lines[0]) != "---" {
+		return existing
+	}
+	closeIdx := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			closeIdx = i
+			break
+		}
+	}
+	if closeIdx < 0 {
+		return existing
+	}
+	for i := 1; i < closeIdx; i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "retired:") {
+			return existing
+		}
+	}
+
+	insert := []string{
+		"retired: true",
+		"retired_on: " + now.UTC().Format("2006-01-02"),
+	}
+	if reason != "" {
+		insert = append(insert, "retired_reason: "+reason)
+	}
+	merged := make([]string, 0, len(lines)+len(insert))
+	merged = append(merged, lines[:closeIdx]...)
+	merged = append(merged, insert...)
+	merged = append(merged, lines[closeIdx:]...)
+	return []byte(strings.Join(merged, "\n"))
+}
+
+func hygieneScopeForPrefix(prefix brain.Path) (scope, project string) {
+	s := string(prefix)
+	if s == "memory/global" {
+		return "global", ""
+	}
+	if strings.HasPrefix(s, "memory/project/") {
+		return "project", strings.TrimPrefix(s, "memory/project/")
+	}
+	return "", ""
+}
+
+func hygieneProjectSuffix(project string) string {
+	if project == "" {
+		return ""
+	}
+	return "/" + project
+}

--- a/go/memory/hygiene_test.go
+++ b/go/memory/hygiene_test.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+func writeMemoryFile(t *testing.T, store brain.Store, p brain.Path, fm map[string]string, body string) {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	for k, v := range fm {
+		fmt.Fprintf(&sb, "%s: %s\n", k, v)
+	}
+	sb.WriteString("---\n\n")
+	sb.WriteString(body)
+	writeTopic(t, store, p, sb.String())
+}
+
+func TestRunHygieneDetectsContradictionByName(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("gym_time_a"),
+		map[string]string{
+			"name":       "Gym time",
+			"modified":   now.Format(time.RFC3339),
+			"confidence": "medium",
+		}, "Trains at 8am.")
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("gym_time_b"),
+		map[string]string{
+			"name":       "Gym time",
+			"modified":   now.Format(time.RFC3339),
+			"confidence": "high",
+		}, "Trains at 7am.")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{Now: now})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.Contradictions) != 1 {
+		t.Fatalf("expected 1 contradiction group, got %d", len(report.Contradictions))
+	}
+	g := report.Contradictions[0]
+	if g.KeyReason != "name" {
+		t.Errorf("expected key reason name, got %q", g.KeyReason)
+	}
+	if len(g.Members) != 2 {
+		t.Errorf("expected 2 members, got %d", len(g.Members))
+	}
+	if g.Canonical != "" {
+		t.Errorf("dry-run should not pick canonical, got %s", g.Canonical)
+	}
+}
+
+func TestRunHygieneApplyStampsSupersededBy(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("gym_time_a"),
+		map[string]string{
+			"name":       "Gym time",
+			"modified":   now.Add(-time.Hour).Format(time.RFC3339),
+			"confidence": "medium",
+		}, "Trains at 8am.")
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("gym_time_b"),
+		map[string]string{
+			"name":       "Gym time",
+			"modified":   now.Format(time.RFC3339),
+			"confidence": "high",
+		}, "Trains at 7am.")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{Apply: true, Now: now})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.Contradictions) != 1 {
+		t.Fatalf("expected 1 contradiction group, got %d", len(report.Contradictions))
+	}
+	if report.Contradictions[0].Canonical != brain.MemoryGlobalTopic("gym_time_b") {
+		t.Errorf("expected high-confidence and newer to win, got canonical %s", report.Contradictions[0].Canonical)
+	}
+
+	oldData, err := store.Read(context.Background(), brain.MemoryGlobalTopic("gym_time_a"))
+	if err != nil {
+		t.Fatalf("read old: %v", err)
+	}
+	if !strings.Contains(string(oldData), "superseded_by: gym_time_b.md") {
+		t.Errorf("expected old file stamped with superseded_by, got:\n%s", oldData)
+	}
+}
+
+func TestRunHygieneGroupsByClaimKey(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("a"),
+		map[string]string{"name": "A", "modified": now, "claim_key": "weather_forecast"},
+		"sunny")
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("b"),
+		map[string]string{"name": "B", "modified": now, "claim_key": "weather_forecast"},
+		"rainy")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.Contradictions) != 1 {
+		t.Fatalf("expected 1 contradiction group, got %d", len(report.Contradictions))
+	}
+	if report.Contradictions[0].KeyReason != "claim_key" {
+		t.Errorf("expected key reason claim_key, got %q", report.Contradictions[0].KeyReason)
+	}
+}
+
+func TestRunHygieneAgesOutSupersededFile(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	old := now.AddDate(0, 0, -45).Format(time.RFC3339)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("old_fact"),
+		map[string]string{
+			"name":          "Old",
+			"modified":      old,
+			"superseded_by": "new_fact.md",
+		}, "old body")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{
+		Apply:          true,
+		RetiredAgeDays: 30,
+		Now:            now,
+	})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.AgingRetired) != 1 {
+		t.Fatalf("expected 1 aging-retired, got %d", len(report.AgingRetired))
+	}
+
+	target := brain.MemoryGlobalTopic("old_fact")
+	if ok, _ := store.Exists(context.Background(), target); !ok {
+		t.Fatalf("expected old file to remain at %s", target)
+	}
+	data, err := store.Read(context.Background(), target)
+	if err != nil {
+		t.Fatalf("read after retire: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "retired: true") {
+		t.Errorf("expected retired: true frontmatter, got:\n%s", data)
+	}
+	if !strings.Contains(content, "retired_on: 2026-05-15") {
+		t.Errorf("expected pinned retired_on date, got:\n%s", data)
+	}
+}
+
+func TestRunHygieneRetainsRecentSupersededFile(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	recent := now.AddDate(0, 0, -5).Format(time.RFC3339)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("recent_super"),
+		map[string]string{
+			"name":          "Recent",
+			"modified":      recent,
+			"superseded_by": "new.md",
+		}, "body")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{
+		Apply:          true,
+		RetiredAgeDays: 30,
+		Now:            now,
+	})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.AgingRetired) != 0 {
+		t.Errorf("expected no aging retirements, got %d", len(report.AgingRetired))
+	}
+}
+
+func TestRunHygieneIgnoresAlreadyRetired(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("retired_a"),
+		map[string]string{
+			"name":     "Same",
+			"modified": now,
+			"retired":  "true",
+		}, "")
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("live_b"),
+		map[string]string{
+			"name":     "Same",
+			"modified": now,
+		}, "")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.Contradictions) != 0 {
+		t.Errorf("retired file should not contribute to contradictions, got %d groups", len(report.Contradictions))
+	}
+}
+
+func TestPickCanonicalConfidenceWinsOverRecency(t *testing.T) {
+	older := time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	newer := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	got := pickCanonical([]TopicFile{
+		{Path: "memory/global/low.md", Confidence: "low", Modified: newer},
+		{Path: "memory/global/high.md", Confidence: "high", Modified: older},
+	})
+	if got.Path != "memory/global/high.md" {
+		t.Errorf("expected high-confidence winner, got %s", got.Path)
+	}
+}
+
+func TestPickCanonicalRecencyAsTieBreaker(t *testing.T) {
+	older := time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	newer := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	got := pickCanonical([]TopicFile{
+		{Path: "memory/global/older.md", Confidence: "medium", Modified: older},
+		{Path: "memory/global/newer.md", Confidence: "medium", Modified: newer},
+	})
+	if got.Path != "memory/global/newer.md" {
+		t.Errorf("expected newer winner on tie, got %s", got.Path)
+	}
+}
+
+func TestRunHygieneDistinctSubjectsWithSameStateKeyAreNotContradictions(t *testing.T) {
+	mem, store := newTestMemory(t)
+	cons := NewConsolidator(nil, "", mem)
+
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("alex"),
+		map[string]string{"name": "Alex context", "modified": now, "state_key": "state.owned.item.set.context", "state_subject": "alex"},
+		"alex body")
+	writeMemoryFile(t, store, brain.MemoryGlobalTopic("boudewijn"),
+		map[string]string{"name": "Boudewijn context", "modified": now, "state_key": "state.owned.item.set.context", "state_subject": "boudewijn"},
+		"boudewijn body")
+
+	report, err := cons.RunHygiene(context.Background(), HygieneOptions{})
+	if err != nil {
+		t.Fatalf("RunHygiene: %v", err)
+	}
+	if len(report.Contradictions) != 0 {
+		t.Errorf("distinct subjects sharing a schema should not contradict, got %d groups", len(report.Contradictions))
+	}
+}

--- a/go/memory/store.go
+++ b/go/memory/store.go
@@ -41,6 +41,11 @@ type Frontmatter struct {
 	Source       string
 	Supersedes   string
 	SupersededBy string
+	ClaimKey     string
+	StateKey     string
+	StateSubject string
+	Retired      bool
+	RetiredOn    string
 }
 
 // LoadIndexAt reads a MEMORY.md at the given logical path, capped at
@@ -221,6 +226,16 @@ func ParseFrontmatter(content string) (Frontmatter, string) {
 			fm.Supersedes = val
 		case "superseded_by":
 			fm.SupersededBy = val
+		case "claim_key":
+			fm.ClaimKey = val
+		case "state_key":
+			fm.StateKey = val
+		case "state_subject":
+			fm.StateSubject = val
+		case "retired":
+			fm.Retired = strings.EqualFold(val, "true")
+		case "retired_on":
+			fm.RetiredOn = val
 		case "tags":
 			for _, tag := range strings.Split(val, ",") {
 				tag = strings.TrimSpace(tag)

--- a/sdks/ts/memory/src/eval/costs.test.ts
+++ b/sdks/ts/memory/src/eval/costs.test.ts
@@ -18,7 +18,12 @@ describe('estimateUSD', () => {
   })
 
   it('calculates cost for gpt-4o correctly', () => {
-    const usage: Usage = { inputTokens: 1_000_000, outputTokens: 1_000_000, cacheRead: 0, cacheCreate: 0 }
+    const usage: Usage = {
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheRead: 0,
+      cacheCreate: 0,
+    }
     // input: 1M * $2.50/M = $2.50, output: 1M * $10/M = $10.00
     expect(estimateUSD('gpt-4o', usage)).toBeCloseTo(12.5, 8)
   })
@@ -36,7 +41,12 @@ describe('estimateUSD', () => {
   })
 
   it('handles zero-priced models', () => {
-    const usage: Usage = { inputTokens: 10_000_000, outputTokens: 10_000_000, cacheRead: 0, cacheCreate: 0 }
+    const usage: Usage = {
+      inputTokens: 10_000_000,
+      outputTokens: 10_000_000,
+      cacheRead: 0,
+      cacheCreate: 0,
+    }
     expect(estimateUSD('gemma-4-31B-it', usage)).toBe(0)
   })
 
@@ -180,7 +190,12 @@ describe('addCostAccounting', () => {
 
   it('handles many small additions without drift', () => {
     let running = zeroCostAccounting()
-    const small: CostAccounting = { ingestUSD: 0.0001, agentUSD: 0.0002, judgeUSD: 0.0003, totalUSD: 0.0006 }
+    const small: CostAccounting = {
+      ingestUSD: 0.0001,
+      agentUSD: 0.0002,
+      judgeUSD: 0.0003,
+      totalUSD: 0.0006,
+    }
     for (let i = 0; i < 10_000; i++) {
       running = addCostAccounting(running, small)
     }

--- a/sdks/ts/memory/src/memory/correction.test.ts
+++ b/sdks/ts/memory/src/memory/correction.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildCorrectionReminder,
+  buildCorrectionReminderWithOptions,
+  detectCorrection,
+} from './correction.js'
+
+describe('correction detection', () => {
+  it('detects correction-shaped user turns', () => {
+    const cases = [
+      "No, it's actually 7am, not 8am.",
+      "That's wrong, the meeting is on Tuesday.",
+      'You got that wrong, the project is called Roo not Roe.',
+      "Actually, it's blue not red.",
+      'Stop saying I live in London, I live in Amersfoort.',
+      "Wrong, it's Anthropic not OpenAI.",
+      'I never said I wanted Slack messages, I wanted Telegram.',
+      "That's not what I meant, please update memory.",
+      'Please forget that I work at Google.',
+      "Correction: my wife's name is Nadia, not Nadya.",
+      "You're wrong about my role.",
+      "Actually it's a Pi 4B, not a Pi 5.",
+      "I didn't say that. I never use docker compose for this.",
+      'It is actually 4 children, not 3.',
+    ]
+
+    for (const input of cases) {
+      const correction = detectCorrection(input)
+      expect(correction, input).toBeDefined()
+      expect(correction?.snippet).not.toBe('')
+    }
+  })
+
+  it('ignores common false positives', () => {
+    const cases = [
+      "No problem, I'll handle it.",
+      'No idea what that means.',
+      'No worries, take your time.',
+      'You got the wrong end of the stick earlier.',
+      "There's nothing wrong with the build.",
+      "Not wrong per se, just not what I'd pick.",
+      'No, before that I asked you to set up Slack.',
+      "I think you're right about the route.",
+      "Yes, that's right.",
+      'Can you fix the bug in app.go?',
+      'What is the status of the deploy?',
+      'I see no problem with that approach.',
+      'No, but seriously can you try again?',
+    ]
+
+    for (const input of cases) {
+      expect(detectCorrection(input), input).toBeUndefined()
+    }
+  })
+
+  it('builds a default memory reminder', () => {
+    const reminder = buildCorrectionReminder('Actually it is 7am not 8am.')
+    for (const expected of [
+      'memory_search',
+      'memory_update',
+      'memory_remove',
+      'memory_create',
+      'Mention',
+    ]) {
+      expect(reminder).toContain(expected)
+    }
+  })
+
+  it('builds a reminder with custom tool names', () => {
+    const reminder = buildCorrectionReminderWithOptions('Wrong, it is Tuesday.', {
+      searchTool: 'lookup',
+      updateTool: 'patch',
+      removeTool: 'retire',
+      createTool: 'create',
+    })
+    for (const expected of ['lookup', 'patch', 'retire', 'create']) {
+      expect(reminder).toContain(expected)
+    }
+    expect(reminder).not.toContain('Mention')
+  })
+})

--- a/sdks/ts/memory/src/memory/correction.ts
+++ b/sdks/ts/memory/src/memory/correction.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type Correction = {
+  readonly snippet: string
+  readonly phrase: string
+}
+
+export type CorrectionReminderOptions = {
+  readonly searchTool?: string
+  readonly createTool?: string
+  readonly updateTool?: string
+  readonly removeTool?: string
+  readonly mentionChange?: boolean
+}
+
+const CORRECTION_PHRASES = [
+  "that's wrong",
+  'thats wrong',
+  'you got that wrong',
+  'you have that wrong',
+  "you're wrong",
+  'youre wrong',
+  'you are wrong',
+  "actually it's",
+  'actually its',
+  'actually it is',
+  "it's actually",
+  'its actually',
+  'it is actually',
+  'stop saying',
+  "don't say",
+  'do not say',
+  'not right',
+  "wrong, it's",
+  'wrong, its',
+  "wrong it's",
+  'i never said',
+  "i didn't say",
+  'i did not say',
+  "that's not",
+  'thats not',
+  'that is not',
+  'correct that',
+  'correction:',
+  'please correct',
+  'please update',
+  'please remove',
+  'please forget',
+  'forget that',
+  'forget what',
+  'remember instead',
+  'the correct',
+] as const
+
+const SOLO_CORRECTION_PATTERNS = [
+  /^\s*no[\s,\-]+(it'?s|the|that|it is|its|that is|its actually)\b/i,
+  /^\s*(wrong|incorrect)[\s,!.]/i,
+  /^\s*actually[,\s\-]/i,
+] as const
+
+const FALSE_POSITIVE_SUBSTRINGS = [
+  'no problem',
+  'no idea',
+  'no worries',
+  'no rush',
+  'no big deal',
+  'wrong end of the stick',
+  'wrong number',
+  'wrong place',
+  'nothing wrong',
+  'not wrong',
+  'no, before that',
+  'no, but',
+] as const
+
+export const detectCorrection = (latestUserText: string): Correction | undefined => {
+  if (latestUserText === '') return undefined
+
+  const clean = latestUserText.toLowerCase().trim()
+  if (clean === '') return undefined
+
+  for (const falsePositive of FALSE_POSITIVE_SUBSTRINGS) {
+    if (clean.includes(falsePositive)) return undefined
+  }
+
+  for (const phrase of CORRECTION_PHRASES) {
+    const index = clean.indexOf(phrase)
+    if (index >= 0) {
+      return {
+        snippet: extractCorrectionSnippet(latestUserText, index),
+        phrase,
+      }
+    }
+  }
+
+  for (const pattern of SOLO_CORRECTION_PATTERNS) {
+    const match = pattern.exec(clean)
+    if (match?.index !== undefined) {
+      return {
+        snippet: extractCorrectionSnippet(latestUserText, match.index),
+        phrase: pattern.source,
+      }
+    }
+  }
+
+  return undefined
+}
+
+export const buildCorrectionReminder = (userInput: string): string =>
+  buildCorrectionReminderWithOptions(userInput, {
+    searchTool: 'memory_search',
+    updateTool: 'memory_update',
+    removeTool: 'memory_remove',
+    createTool: 'memory_create',
+    mentionChange: true,
+  })
+
+export const buildCorrectionReminderWithOptions = (
+  userInput: string,
+  opts: CorrectionReminderOptions = {},
+): string => {
+  const correction = detectCorrection(userInput)
+  if (correction === undefined) return ''
+
+  const snippet = correction.snippet || userInput
+  const searchTool = defaultString(opts.searchTool, 'memory_search')
+  const updateTool = defaultString(opts.updateTool, 'memory_update')
+  const removeTool = defaultString(opts.removeTool, 'memory_remove')
+  const createTool = defaultString(opts.createTool, 'memory_create')
+
+  let reminder = `User correction detected (${JSON.stringify(snippet)}). Before answering, call ${searchTool} for the disputed topic. If a stale entry exists, call ${updateTool} or ${removeTool} with a reason. If no entry exists yet but the correction is durable, call ${createTool}.`
+  if (opts.mentionChange === true) {
+    reminder += ' Mention in your reply what you changed.'
+  }
+  return reminder
+}
+
+const extractCorrectionSnippet = (original: string, matchStart: number): string => {
+  const maxLen = 160
+  const runes = Array.from(original)
+  if (runes.length <= maxLen) return original.trim()
+
+  const runeStart = Array.from(original.slice(0, matchStart)).length
+  let start = runeStart - Math.floor(maxLen / 3)
+  if (start < 0) start = 0
+
+  let end = start + maxLen
+  if (end > runes.length) {
+    end = runes.length
+    start = Math.max(0, end - maxLen)
+  }
+
+  const prefix = start > 0 ? '...' : ''
+  const suffix = end < runes.length ? '...' : ''
+  return `${prefix}${runes.slice(start, end).join('')}${suffix}`.trim()
+}
+
+const defaultString = (value: string | undefined, fallback: string): string => {
+  const trimmed = value?.trim()
+  return trimmed && trimmed !== '' ? trimmed : fallback
+}

--- a/sdks/ts/memory/src/memory/feedback/classifier.test.ts
+++ b/sdks/ts/memory/src/memory/feedback/classifier.test.ts
@@ -126,7 +126,7 @@ describe('FeedbackClassifier', () => {
 
     it('truncates snippet to 200 characters', () => {
       const c = createFeedbackClassifier()
-      const longInput = 'perfect ' + 'x'.repeat(300)
+      const longInput = `perfect ${'x'.repeat(300)}`
       const result = c.classify(longInput, [testPath])
 
       expect(result.events).toHaveLength(1)
@@ -137,7 +137,7 @@ describe('FeedbackClassifier', () => {
 
     it('truncates turnContent to 500 characters', () => {
       const c = createFeedbackClassifier()
-      const longInput = 'perfect ' + 'x'.repeat(600)
+      const longInput = `perfect ${'x'.repeat(600)}`
       const result = c.classify(longInput, [testPath])
 
       expect(result.turnContent.length).toBeLessThanOrEqual(503)

--- a/sdks/ts/memory/src/memory/frontmatter.ts
+++ b/sdks/ts/memory/src/memory/frontmatter.ts
@@ -18,6 +18,12 @@ export type Frontmatter = {
   source?: string
   supersedes?: string
   superseded_by?: string
+  claim_key?: string
+  state_key?: string
+  state_subject?: string
+  retired?: boolean
+  retired_on?: string
+  retired_reason?: string
   scope?: string
   session_id?: string
   session_date?: string
@@ -106,6 +112,24 @@ export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; b
       case 'superseded_by':
         fm.superseded_by = val
         break
+      case 'claim_key':
+        fm.claim_key = val
+        break
+      case 'state_key':
+        fm.state_key = val
+        break
+      case 'state_subject':
+        fm.state_subject = val
+        break
+      case 'retired':
+        fm.retired = val.toLowerCase() === 'true'
+        break
+      case 'retired_on':
+        fm.retired_on = val
+        break
+      case 'retired_reason':
+        fm.retired_reason = val
+        break
       case 'scope':
         fm.scope = val
         break
@@ -160,6 +184,12 @@ export const buildFrontmatter = (fm: Frontmatter): string => {
   if (fm.source) out.push(`source: ${fm.source}`)
   if (fm.supersedes) out.push(`supersedes: ${fm.supersedes}`)
   if (fm.superseded_by) out.push(`superseded_by: ${fm.superseded_by}`)
+  if (fm.claim_key) out.push(`claim_key: ${fm.claim_key}`)
+  if (fm.state_key) out.push(`state_key: ${fm.state_key}`)
+  if (fm.state_subject) out.push(`state_subject: ${fm.state_subject}`)
+  if (fm.retired !== undefined) out.push(`retired: ${fm.retired ? 'true' : 'false'}`)
+  if (fm.retired_on) out.push(`retired_on: ${fm.retired_on}`)
+  if (fm.retired_reason) out.push(`retired_reason: ${fm.retired_reason}`)
   if (fm.session_id) out.push(`session_id: ${fm.session_id}`)
   if (fm.session_date) out.push(`session_date: ${fm.session_date}`)
   if (fm.observed_on) out.push(`observed_on: ${fm.observed_on}`)

--- a/sdks/ts/memory/src/memory/hygiene.test.ts
+++ b/sdks/ts/memory/src/memory/hygiene.test.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  Provider,
+  StructuredRequest,
+} from '../llm/index.js'
+import { createMemStore } from '../store/memstore.js'
+import { toPath } from '../store/path.js'
+import { createStoreBackedCursorStore } from './cursor.js'
+import { type Frontmatter, buildFrontmatter, parseFrontmatter } from './frontmatter.js'
+import { runMemoryHygiene } from './hygiene.js'
+import { createMemory } from './index.js'
+
+const dummyProvider = (): Provider => ({
+  name: () => 'stub',
+  modelName: () => 'stub-model',
+  async *stream() {
+    yield { type: 'done', stopReason: 'end_turn' as const }
+  },
+  complete: async (_req: CompletionRequest): Promise<CompletionResponse> => ({
+    content: '',
+    toolCalls: [],
+    usage: { inputTokens: 0, outputTokens: 0 },
+    stopReason: 'end_turn',
+  }),
+  supportsStructuredDecoding: () => false,
+  structured: async (_req: StructuredRequest) => '',
+})
+
+const writeMemoryFile = async (
+  store: ReturnType<typeof createMemStore>,
+  path: string,
+  frontmatter: Partial<Frontmatter>,
+  body: string,
+): Promise<void> => {
+  const fm: Frontmatter = {
+    name: frontmatter.name ?? path.split('/').pop() ?? path,
+    type: frontmatter.type ?? 'project',
+    scope: frontmatter.scope ?? 'project',
+    modified: frontmatter.modified ?? '2026-05-15T10:00:00.000Z',
+    extra: frontmatter.extra ?? {},
+    ...(frontmatter.description !== undefined ? { description: frontmatter.description } : {}),
+    ...(frontmatter.created !== undefined ? { created: frontmatter.created } : {}),
+    ...(frontmatter.confidence !== undefined ? { confidence: frontmatter.confidence } : {}),
+    ...(frontmatter.source !== undefined ? { source: frontmatter.source } : {}),
+    ...(frontmatter.supersedes !== undefined ? { supersedes: frontmatter.supersedes } : {}),
+    ...(frontmatter.superseded_by !== undefined
+      ? { superseded_by: frontmatter.superseded_by }
+      : {}),
+    ...(frontmatter.claim_key !== undefined ? { claim_key: frontmatter.claim_key } : {}),
+    ...(frontmatter.state_key !== undefined ? { state_key: frontmatter.state_key } : {}),
+    ...(frontmatter.state_subject !== undefined
+      ? { state_subject: frontmatter.state_subject }
+      : {}),
+    ...(frontmatter.retired !== undefined ? { retired: frontmatter.retired } : {}),
+    ...(frontmatter.retired_on !== undefined ? { retired_on: frontmatter.retired_on } : {}),
+    ...(frontmatter.retired_reason !== undefined
+      ? { retired_reason: frontmatter.retired_reason }
+      : {}),
+    ...(frontmatter.tags !== undefined ? { tags: frontmatter.tags } : {}),
+  }
+  await store.write(toPath(path), Buffer.from(`${buildFrontmatter(fm)}\n${body}\n`, 'utf8'))
+}
+
+describe('memory hygiene', () => {
+  it('detects contradiction groups by name in dry-run mode', async () => {
+    const store = createMemStore()
+    await writeMemoryFile(
+      store,
+      'memory/global/gym-time-a.md',
+      { name: 'Gym time', scope: 'global', confidence: 'medium' },
+      'Trains at 8am.',
+    )
+    await writeMemoryFile(
+      store,
+      'memory/global/gym-time-b.md',
+      { name: 'Gym time', scope: 'global', confidence: 'high' },
+      'Trains at 7am.',
+    )
+
+    const report = await runMemoryHygiene({ store, scope: 'global', actorId: 'tenant-a' })
+    expect(report.contradictions).toHaveLength(1)
+    expect(report.contradictions[0]?.keyReason).toBe('name')
+    expect(report.contradictions[0]?.members).toHaveLength(2)
+    expect(report.contradictions[0]?.canonical).toBeUndefined()
+  })
+
+  it('applies superseded_by to non-canonical contradictions', async () => {
+    const store = createMemStore()
+    await writeMemoryFile(
+      store,
+      'memory/global/gym-time-a.md',
+      {
+        name: 'Gym time',
+        scope: 'global',
+        confidence: 'medium',
+        modified: '2026-05-15T09:00:00.000Z',
+      },
+      'Trains at 8am.',
+    )
+    await writeMemoryFile(
+      store,
+      'memory/global/gym-time-b.md',
+      {
+        name: 'Gym time',
+        scope: 'global',
+        confidence: 'high',
+        modified: '2026-05-15T10:00:00.000Z',
+      },
+      'Trains at 7am.',
+    )
+
+    const report = await runMemoryHygiene({
+      store,
+      scope: 'global',
+      actorId: 'tenant-a',
+      apply: true,
+      now: '2026-05-15T10:00:00.000Z',
+    })
+
+    expect(report.contradictions[0]?.canonical).toBe(toPath('memory/global/gym-time-b.md'))
+    const old = parseFrontmatter(
+      (await store.read(toPath('memory/global/gym-time-a.md'))).toString('utf8'),
+    )
+    expect(old.frontmatter.superseded_by).toBe('gym-time-b.md')
+  })
+
+  it('soft-retires old superseded files in place', async () => {
+    const store = createMemStore()
+    await writeMemoryFile(
+      store,
+      'memory/global/old-fact.md',
+      {
+        name: 'Old',
+        scope: 'global',
+        modified: '2026-03-31T10:00:00.000Z',
+        superseded_by: 'new-fact.md',
+      },
+      'old body',
+    )
+
+    const report = await runMemoryHygiene({
+      store,
+      scope: 'global',
+      actorId: 'tenant-a',
+      apply: true,
+      retiredAgeDays: 30,
+      now: '2026-05-15T10:00:00.000Z',
+    })
+
+    expect(report.agingRetired).toHaveLength(1)
+    const retired = parseFrontmatter(
+      (await store.read(toPath('memory/global/old-fact.md'))).toString('utf8'),
+    )
+    expect(retired.frontmatter.retired).toBe(true)
+    expect(retired.frontmatter.retired_on).toBe('2026-05-15')
+  })
+
+  it('does not treat distinct subjects sharing a state schema as contradictions', async () => {
+    const store = createMemStore()
+    await writeMemoryFile(
+      store,
+      'memory/global/alex.md',
+      {
+        name: 'Alex context',
+        scope: 'global',
+        state_key: 'state.owned.item.set.context',
+        state_subject: 'alex',
+      },
+      'alex body',
+    )
+    await writeMemoryFile(
+      store,
+      'memory/global/boudewijn.md',
+      {
+        name: 'Boudewijn context',
+        scope: 'global',
+        state_key: 'state.owned.item.set.context',
+        state_subject: 'boudewijn',
+      },
+      'boudewijn body',
+    )
+
+    const report = await runMemoryHygiene({ store, scope: 'global', actorId: 'tenant-a' })
+    expect(report.contradictions).toHaveLength(0)
+  })
+
+  it('is exposed on createMemory with default actor and scope wiring', async () => {
+    const store = createMemStore()
+    const cursorStore = createStoreBackedCursorStore(store)
+    await writeMemoryFile(
+      store,
+      'memory/project/tenant-a/a.md',
+      { name: 'Project setting', confidence: 'low' },
+      'old',
+    )
+    await writeMemoryFile(
+      store,
+      'memory/project/tenant-a/b.md',
+      { name: 'Project setting', confidence: 'high' },
+      'new',
+    )
+
+    const memory = createMemory({
+      store,
+      provider: dummyProvider(),
+      cursorStore,
+      scope: 'project',
+      actorId: 'tenant-a',
+    })
+
+    const report = await memory.hygiene({ apply: true })
+    expect(report.contradictions[0]?.canonical).toBe(toPath('memory/project/tenant-a/b.md'))
+  })
+})

--- a/sdks/ts/memory/src/memory/hygiene.ts
+++ b/sdks/ts/memory/src/memory/hygiene.ts
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ErrNotFound } from '../store/errors.js'
+import type { Batch, Store } from '../store/index.js'
+import { type Path, lastSegment } from '../store/path.js'
+import { type Frontmatter, buildFrontmatter, parseFrontmatter } from './frontmatter.js'
+import { scopePrefix } from './paths.js'
+import type { Scope } from './types.js'
+
+export const DEFAULT_RETIRED_AGE_DAYS = 30
+
+export type MemoryHygieneArgs = {
+  readonly scope?: Scope
+  readonly actorId?: string
+  readonly retiredAgeDays?: number
+  readonly apply?: boolean
+  readonly now?: Date | string
+}
+
+export type RunMemoryHygieneOptions = MemoryHygieneArgs & {
+  readonly store: Store
+  readonly scope: Scope
+  readonly actorId: string
+}
+
+export type MemoryHygieneTopic = {
+  readonly name: string
+  readonly description: string
+  readonly type: string
+  readonly path: Path
+  readonly created?: string
+  readonly modified?: string
+  readonly tags: readonly string[]
+  readonly confidence?: string
+  readonly source?: string
+  readonly scope: Scope
+}
+
+export type MemoryContradictionGroup = {
+  readonly key: string
+  readonly keyReason: 'claim_key' | 'name'
+  readonly scope: Scope
+  readonly actorId: string
+  readonly members: readonly MemoryHygieneTopic[]
+  readonly canonical?: Path
+}
+
+export type MemoryAgingRetirement = {
+  readonly path: Path
+  readonly ageMs: number
+}
+
+export type MemoryHygieneReport = {
+  readonly contradictions: readonly MemoryContradictionGroup[]
+  readonly agingRetired: readonly MemoryAgingRetirement[]
+  readonly errors: readonly string[]
+}
+
+type TopicRecord = MemoryHygieneTopic & {
+  readonly frontmatter: Frontmatter
+  readonly content: string
+  readonly body: string
+}
+
+export const runMemoryHygiene = async (
+  opts: RunMemoryHygieneOptions,
+): Promise<MemoryHygieneReport> => {
+  const now = coerceDate(opts.now) ?? new Date()
+  const retiredAgeDays =
+    opts.retiredAgeDays === undefined || opts.retiredAgeDays <= 0
+      ? DEFAULT_RETIRED_AGE_DAYS
+      : opts.retiredAgeDays
+  const maxAgeMs = retiredAgeDays * 24 * 60 * 60 * 1000
+  const prefix = scopePrefix(opts.scope, opts.actorId)
+  const errors: string[] = []
+  const topics = await listTopicRecords(opts.store, prefix, opts.scope, errors)
+
+  const contradictions = detectContradictions(topics, opts.scope, opts.actorId)
+  const agingRetired = detectAgingRetirements(topics, now, maxAgeMs)
+
+  if (opts.apply === true && (contradictions.length > 0 || agingRetired.length > 0)) {
+    await applyHygiene(opts.store, {
+      scope: opts.scope,
+      actorId: opts.actorId,
+      now,
+      contradictions,
+      agingRetired,
+      errors,
+    })
+  }
+
+  return {
+    contradictions:
+      opts.apply === true
+        ? contradictions
+        : contradictions.map(({ canonical: _canonical, ...group }) => group),
+    agingRetired,
+    errors,
+  }
+}
+
+const detectContradictions = (
+  topics: readonly TopicRecord[],
+  scope: Scope,
+  actorId: string,
+): MemoryContradictionGroup[] => {
+  const groupsByClaim = new Map<string, TopicRecord[]>()
+  const groupsByName = new Map<string, TopicRecord[]>()
+
+  for (const topic of topics) {
+    if (topic.frontmatter.superseded_by || topic.frontmatter.retired === true) continue
+    if (topic.frontmatter.claim_key) {
+      appendGroup(groupsByClaim, topic.frontmatter.claim_key, topic)
+    }
+    if (topic.frontmatter.name) {
+      appendGroup(groupsByName, topic.frontmatter.name.trim().toLowerCase(), topic)
+    }
+  }
+
+  return [
+    ...emitContradictionGroups(groupsByClaim, 'claim_key', scope, actorId),
+    ...emitContradictionGroups(groupsByName, 'name', scope, actorId),
+  ]
+}
+
+const appendGroup = (groups: Map<string, TopicRecord[]>, key: string, topic: TopicRecord): void => {
+  const existing = groups.get(key)
+  if (existing === undefined) {
+    groups.set(key, [topic])
+    return
+  }
+  existing.push(topic)
+}
+
+const emitContradictionGroups = (
+  groups: ReadonlyMap<string, readonly TopicRecord[]>,
+  keyReason: MemoryContradictionGroup['keyReason'],
+  scope: Scope,
+  actorId: string,
+): MemoryContradictionGroup[] => {
+  const out: MemoryContradictionGroup[] = []
+  const keys = [...groups.keys()].sort()
+  for (const key of keys) {
+    const members = uniqueTopics(groups.get(key) ?? [])
+    if (members.length < 2) continue
+    out.push({
+      key,
+      keyReason,
+      scope,
+      actorId,
+      members,
+    })
+  }
+  return out
+}
+
+const detectAgingRetirements = (
+  topics: readonly TopicRecord[],
+  now: Date,
+  maxAgeMs: number,
+): MemoryAgingRetirement[] => {
+  const out: MemoryAgingRetirement[] = []
+  const threshold = now.getTime() - maxAgeMs
+  for (const topic of topics) {
+    if (!topic.frontmatter.superseded_by || topic.frontmatter.retired === true) continue
+    const modified = parseDate(topic.frontmatter.modified)
+    if (modified === undefined || modified.getTime() >= threshold) continue
+    out.push({
+      path: topic.path,
+      ageMs: now.getTime() - modified.getTime(),
+    })
+  }
+  return out
+}
+
+const applyHygiene = async (
+  store: Store,
+  input: {
+    readonly scope: Scope
+    readonly actorId: string
+    readonly now: Date
+    readonly contradictions: MemoryContradictionGroup[]
+    readonly agingRetired: readonly MemoryAgingRetirement[]
+    readonly errors: string[]
+  },
+): Promise<void> => {
+  try {
+    await store.batch(
+      { reason: `memory:hygiene ${input.scope}${projectSuffix(input)}` },
+      async (b) => {
+        for (let index = 0; index < input.contradictions.length; index++) {
+          const group = input.contradictions[index]
+          if (group === undefined) continue
+          const canonical = pickCanonical(group.members)
+          if (canonical === undefined) continue
+          input.contradictions[index] = { ...group, canonical: canonical.path }
+          const canonicalFile = lastSegment(canonical.path)
+          for (const member of group.members) {
+            if (member.path === canonical.path) continue
+            try {
+              await stampSupersededBy(b, member.path, canonicalFile)
+            } catch (err) {
+              input.errors.push(
+                `stamp ${member.path}: ${err instanceof Error ? err.message : String(err)}`,
+              )
+            }
+          }
+        }
+
+        for (const retirement of input.agingRetired) {
+          try {
+            const existing = (await b.read(retirement.path)).toString('utf8')
+            const reason = `auto-retired by hygiene: superseded for ${formatAge(retirement.ageMs)}`
+            const stamped = retireFrontmatterInPlace(existing, input.now, reason)
+            await b.write(retirement.path, Buffer.from(stamped, 'utf8'))
+          } catch (err) {
+            input.errors.push(
+              `retire ${retirement.path}: ${err instanceof Error ? err.message : String(err)}`,
+            )
+          }
+        }
+      },
+    )
+  } catch (err) {
+    input.errors.push(`hygiene batch failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+const listTopicRecords = async (
+  store: Store,
+  prefix: Path,
+  scope: Scope,
+  errors: string[],
+): Promise<TopicRecord[]> => {
+  let entries: Awaited<ReturnType<Store['list']>>
+  try {
+    entries = await store.list(prefix, { recursive: true, includeGenerated: true })
+  } catch (err) {
+    if (err instanceof ErrNotFound) return []
+    errors.push(`listing ${prefix}: ${err instanceof Error ? err.message : String(err)}`)
+    return []
+  }
+
+  const topics: TopicRecord[] = []
+  for (const entry of entries) {
+    if (entry.isDir) continue
+    const filename = lastSegment(entry.path)
+    if (!filename.endsWith('.md') || filename === 'MEMORY.md') continue
+    try {
+      const content = (await store.read(entry.path)).toString('utf8')
+      const parsed = parseFrontmatter(content)
+      const topicName = parsed.frontmatter.name ?? filename.replace(/\.md$/, '')
+      topics.push({
+        name: topicName,
+        description: parsed.frontmatter.description ?? '',
+        type: parsed.frontmatter.type ?? '',
+        path: entry.path,
+        tags: parsed.frontmatter.tags ?? [],
+        scope,
+        frontmatter: parsed.frontmatter,
+        content,
+        body: parsed.body,
+        ...(parsed.frontmatter.created !== undefined
+          ? { created: parsed.frontmatter.created }
+          : {}),
+        ...(parsed.frontmatter.modified !== undefined
+          ? { modified: parsed.frontmatter.modified }
+          : {}),
+        ...(parsed.frontmatter.confidence !== undefined
+          ? { confidence: parsed.frontmatter.confidence }
+          : {}),
+        ...(parsed.frontmatter.source !== undefined ? { source: parsed.frontmatter.source } : {}),
+      })
+    } catch (err) {
+      errors.push(`reading ${entry.path}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  return topics
+}
+
+const pickCanonical = (members: readonly MemoryHygieneTopic[]): MemoryHygieneTopic | undefined => {
+  return [...members].sort((left, right) => {
+    const confidenceDelta = confidenceRank(right.confidence) - confidenceRank(left.confidence)
+    if (confidenceDelta !== 0) return confidenceDelta
+    const leftModified = parseDate(left.modified)?.getTime() ?? 0
+    const rightModified = parseDate(right.modified)?.getTime() ?? 0
+    if (leftModified !== rightModified) return rightModified - leftModified
+    return left.path.localeCompare(right.path)
+  })[0]
+}
+
+const stampSupersededBy = async (batch: Batch, path: Path, newFile: string): Promise<void> => {
+  const content = (await batch.read(path)).toString('utf8')
+  if (!hasFrontmatter(content)) return
+  const parsed = parseFrontmatter(content)
+  const next = buildNoteContent(
+    {
+      ...parsed.frontmatter,
+      superseded_by: newFile,
+    },
+    parsed.body,
+  )
+  await batch.write(path, Buffer.from(next, 'utf8'))
+}
+
+const retireFrontmatterInPlace = (content: string, now: Date, reason: string): string => {
+  if (!hasFrontmatter(content)) return content
+  const parsed = parseFrontmatter(content)
+  if (parsed.frontmatter.retired === true) return content
+  return buildNoteContent(
+    {
+      ...parsed.frontmatter,
+      retired: true,
+      retired_on: formatDateOnly(now),
+      ...(reason !== '' ? { retired_reason: reason } : {}),
+    },
+    parsed.body,
+  )
+}
+
+const buildNoteContent = (frontmatter: Frontmatter, body: string): string => {
+  const built = buildFrontmatter(frontmatter)
+  const trimmedBody = body.trim()
+  return trimmedBody === '' ? `${built}\n` : `${built}\n${trimmedBody}\n`
+}
+
+const uniqueTopics = (topics: readonly TopicRecord[]): MemoryHygieneTopic[] => {
+  const out: MemoryHygieneTopic[] = []
+  const seen = new Set<string>()
+  for (const topic of topics) {
+    if (seen.has(topic.path)) continue
+    seen.add(topic.path)
+    out.push(topic)
+  }
+  return out
+}
+
+const confidenceRank = (value: string | undefined): number => {
+  switch (value?.trim().toLowerCase()) {
+    case 'high':
+      return 3
+    case 'medium':
+      return 2
+    case 'low':
+      return 1
+    default:
+      return 0
+  }
+}
+
+const parseDate = (value: string | undefined): Date | undefined => {
+  if (value === undefined || value.trim() === '') return undefined
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed
+}
+
+const coerceDate = (value: Date | string | undefined): Date | undefined => {
+  if (value === undefined) return undefined
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value
+  return parseDate(value)
+}
+
+const hasFrontmatter = (content: string): boolean => content.split('\n')[0]?.trim() === '---'
+
+const formatDateOnly = (date: Date): string => date.toISOString().slice(0, 10)
+
+const formatAge = (ageMs: number): string => {
+  const days = Math.round(ageMs / (24 * 60 * 60 * 1000))
+  return `${days * 24}h0m0s`
+}
+
+const projectSuffix = (input: { readonly scope: Scope; readonly actorId: string }): string =>
+  input.scope === 'project' ? `/${input.actorId}` : ''

--- a/sdks/ts/memory/src/memory/index.ts
+++ b/sdks/ts/memory/src/memory/index.ts
@@ -14,6 +14,7 @@ import { createContextualPrefixBuilder } from './contextual-prefix.js'
 import { createContextualise } from './contextualise.js'
 import { createEpisodeRecorder } from './episodes.js'
 import { createExtract, createPreviewExtract, defaultExtractConfig } from './extract.js'
+import { runMemoryHygiene } from './hygiene.js'
 import { createMemoryLifecycle } from './lifecycle.js'
 import { createStoreBackedProceduralStore } from './procedural-store.js'
 import { createRecall } from './recall.js'
@@ -109,6 +110,15 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     recall,
     reflect,
     consolidate,
+    hygiene: async (args = {}) =>
+      runMemoryHygiene({
+        store: opts.store,
+        scope: args.scope ?? opts.scope,
+        actorId: args.actorId ?? opts.actorId,
+        ...(args.retiredAgeDays !== undefined ? { retiredAgeDays: args.retiredAgeDays } : {}),
+        ...(args.apply !== undefined ? { apply: args.apply } : {}),
+        ...(args.now !== undefined ? { now: args.now } : {}),
+      }),
     contextualise,
     recordEpisode: episodes.record,
     getEpisode: episodes.get,
@@ -184,6 +194,8 @@ export type {
   L0Outcome,
   Memory,
   MemoryDetectAndPersistProceduralRecordsArgs,
+  MemoryHygieneArgs,
+  MemoryHygieneReport,
   MemoryNote,
   MemoryOpts,
   MemoryPersistProceduralRecordsArgs,
@@ -205,6 +217,23 @@ export type {
   Semver,
   DetectProceduralRecordsOptions,
 } from './types.js'
+
+export {
+  DEFAULT_RETIRED_AGE_DAYS,
+  runMemoryHygiene,
+  type MemoryAgingRetirement,
+  type MemoryContradictionGroup,
+  type MemoryHygieneTopic,
+  type RunMemoryHygieneOptions,
+} from './hygiene.js'
+
+export {
+  buildCorrectionReminder,
+  buildCorrectionReminderWithOptions,
+  detectCorrection,
+  type Correction,
+  type CorrectionReminderOptions,
+} from './correction.js'
 
 export {
   CONTEXTUAL_PREFIX_MARKER,

--- a/sdks/ts/memory/src/memory/types.ts
+++ b/sdks/ts/memory/src/memory/types.ts
@@ -19,6 +19,7 @@ import type {
   EpisodeRecordArgs,
   RecordEpisodeResult,
 } from './episodes.js'
+import type { MemoryHygieneArgs, MemoryHygieneReport } from './hygiene.js'
 import type {
   DetectAndPersistProceduralRecordsArgs,
   ListProceduralRecordsArgs,
@@ -27,6 +28,8 @@ import type {
   QueryProceduralRecordsArgs,
   StoredProceduralRecord,
 } from './procedural-store.js'
+
+export type { MemoryHygieneArgs, MemoryHygieneReport } from './hygiene.js'
 
 /** Scope of a memory note. Mirrors the Go `scope` enum. */
 export type Scope = 'global' | 'project' | 'agent'
@@ -362,6 +365,7 @@ export type Memory = {
   recall(opts: RecallOpts): Promise<readonly RecallHit[]>
   reflect(args: ReflectArgs): Promise<ReflectionResult | undefined>
   consolidate(args?: ConsolidateArgs): Promise<ConsolidationReport>
+  hygiene(args?: MemoryHygieneArgs): Promise<MemoryHygieneReport>
   contextualise(args: ContextualiseArgs): Promise<PromptContext>
   recordEpisode?: (args: EpisodeRecordArgs) => Promise<RecordEpisodeResult>
   getEpisode?: (sessionId: string) => Promise<EpisodeRecord | undefined>


### PR DESCRIPTION
## Summary
- Add reusable Go and TypeScript correction detection and correction reminder helpers.
- Add reusable Go and TypeScript memory hygiene passes for contradiction detection, superseded_by stamping, and soft-retiring old superseded memories.
- Extend frontmatter parsing for claim/state/retired metadata and expose the TS hygiene API through createMemory.
- Fix package lint blockers in existing TS tests.

## Validation
- go test ./... (go)
- bun run typecheck
- bun run lint
- bun run test
- bun test sdks/ts/memory/src/memory/correction.test.ts sdks/ts/memory/src/memory/hygiene.test.ts