### PR TITLE
feat(ingest): P2-2 store mutation hooks trigger ingestion on file write

### DIFF
--- a/go/ingest/hooks/mutation_hook.go
+++ b/go/ingest/hooks/mutation_hook.go
@@ -3,7 +3,6 @@ package hooks
 
 import (
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
@@ -48,15 +47,13 @@ func (h *MutationHook) Close() {
 	default:
 		close(h.closed)
 	}
-	mu.Lock()
-	defer mu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	for path, timer := range h.timers {
 		timer.Stop()
 		delete(h.timers, path)
 	}
 }
-
-var mu sync.Mutex
 
 func (h *MutationHook) handleEvent(evt brain.ChangeEvent) {
 	select {
@@ -71,6 +68,16 @@ func (h *MutationHook) handleEvent(evt brain.ChangeEvent) {
 	}
 
 	path := string(evt.Path)
+
+	// Reject paths containing ".." to prevent path traversal.
+	if strings.Contains(path, "..") {
+		if h.opts.Logger != nil {
+			h.opts.Logger.Warn("hooks: rejecting path with traversal segment", map[string]string{
+				"path": path,
+			})
+		}
+		return
+	}
 
 	// Opt-out by batch reason.
 	if evt.Reason != "" && h.opts.OptOutReasons[evt.Reason] {
@@ -101,18 +108,25 @@ func (h *MutationHook) matchesAny(path string) bool {
 }
 
 func (h *MutationHook) debounceDispatch(path string) {
-	mu.Lock()
-	defer mu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	// Reset existing timer for this path.
-	if timer, ok := h.timers[path]; ok {
-		timer.Stop()
+	// Reset existing timer for this path if it has not already fired.
+	if entryI, ok := h.timers[path]; ok {
+		entryI.Stop()
 	}
 
 	h.timers[path] = time.AfterFunc(h.opts.DebounceInterval, func() {
-		mu.Lock()
+		h.mu.Lock()
 		delete(h.timers, path)
-		mu.Unlock()
+		h.mu.Unlock()
+
+		// Guard against dispatch after Close.
+		select {
+		case <-h.closed:
+			return
+		default:
+		}
 
 		if err := h.opts.Dispatch(h.opts.BrainID, path); err != nil {
 			if h.opts.Logger != nil {
@@ -126,10 +140,11 @@ func (h *MutationHook) debounceDispatch(path string) {
 }
 
 // PrefixPathMatcher returns a PathMatcher that matches paths starting
-// with the given prefix.
+// with the given prefix. The bare prefix itself is not matched; the
+// path must contain at least one additional character after the prefix.
 func PrefixPathMatcher(prefix string) PathMatcher {
 	return func(path string) bool {
-		return strings.HasPrefix(path, prefix)
+		return len(path) > len(prefix) && strings.HasPrefix(path, prefix)
 	}
 }
 

--- a/go/ingest/hooks/mutation_hook.go
+++ b/go/ingest/hooks/mutation_hook.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+package hooks
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+const defaultDebounceInterval = 1 * time.Second
+
+// NewMutationHook creates a MutationHook and returns it along with an
+// EventSink that should be subscribed to the store. Call Close when done
+// to release timers and goroutines.
+func NewMutationHook(opts MutationHookOptions) *MutationHook {
+	if opts.DebounceInterval == 0 {
+		opts.DebounceInterval = defaultDebounceInterval
+	}
+	if len(opts.PathMatchers) == 0 {
+		opts.PathMatchers = []PathMatcher{DefaultPathMatcher}
+	}
+	if opts.OptOutReasons == nil {
+		opts.OptOutReasons = map[string]bool{}
+	}
+
+	return &MutationHook{
+		opts:   opts,
+		timers: make(map[string]*time.Timer),
+		closed: make(chan struct{}),
+	}
+}
+
+// Sink returns an EventSink adapter that feeds change events into the
+// mutation hook. This is the value you pass to Store.Subscribe.
+func (h *MutationHook) Sink() brain.EventSink {
+	return brain.EventSinkFunc(func(evt brain.ChangeEvent) {
+		h.handleEvent(evt)
+	})
+}
+
+// Close stops all pending debounce timers.
+func (h *MutationHook) Close() {
+	select {
+	case <-h.closed:
+		return
+	default:
+		close(h.closed)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for path, timer := range h.timers {
+		timer.Stop()
+		delete(h.timers, path)
+	}
+}
+
+var mu sync.Mutex
+
+func (h *MutationHook) handleEvent(evt brain.ChangeEvent) {
+	select {
+	case <-h.closed:
+		return
+	default:
+	}
+
+	// Only react to created and updated events.
+	if evt.Kind != brain.ChangeCreated && evt.Kind != brain.ChangeUpdated {
+		return
+	}
+
+	path := string(evt.Path)
+
+	// Opt-out by batch reason.
+	if evt.Reason != "" && h.opts.OptOutReasons[evt.Reason] {
+		if h.opts.Logger != nil {
+			h.opts.Logger.Debug("hooks: skipping event due to opt-out reason", map[string]string{
+				"path":   path,
+				"reason": evt.Reason,
+			})
+		}
+		return
+	}
+
+	// Check path matchers.
+	if !h.matchesAny(path) {
+		return
+	}
+
+	h.debounceDispatch(path)
+}
+
+func (h *MutationHook) matchesAny(path string) bool {
+	for _, matcher := range h.opts.PathMatchers {
+		if matcher(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *MutationHook) debounceDispatch(path string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Reset existing timer for this path.
+	if timer, ok := h.timers[path]; ok {
+		timer.Stop()
+	}
+
+	h.timers[path] = time.AfterFunc(h.opts.DebounceInterval, func() {
+		mu.Lock()
+		delete(h.timers, path)
+		mu.Unlock()
+
+		if err := h.opts.Dispatch(h.opts.BrainID, path); err != nil {
+			if h.opts.Logger != nil {
+				h.opts.Logger.Error("hooks: dispatch failed", map[string]string{
+					"path":  path,
+					"error": err.Error(),
+				})
+			}
+		}
+	})
+}
+
+// PrefixPathMatcher returns a PathMatcher that matches paths starting
+// with the given prefix.
+func PrefixPathMatcher(prefix string) PathMatcher {
+	return func(path string) bool {
+		return strings.HasPrefix(path, prefix)
+	}
+}
+
+// GlobPathMatcher returns a PathMatcher that matches paths against a
+// simple glob pattern where * matches any non-slash characters and **
+// matches any characters including slashes.
+func GlobPathMatcher(pattern string) PathMatcher {
+	return func(path string) bool {
+		return globMatch(pattern, path)
+	}
+}
+
+// globMatch implements basic glob matching supporting * and **.
+func globMatch(pattern, name string) bool {
+	return matchAt(pattern, 0, name, 0)
+}
+
+func matchAt(pattern string, pi int, name string, ni int) bool {
+	for pi < len(pattern) && ni < len(name) {
+		if pi+1 < len(pattern) && pattern[pi] == '*' && pattern[pi+1] == '*' {
+			// ** matches any characters including slashes.
+			pi += 2
+			if pi < len(pattern) && pattern[pi] == '/' {
+				pi++
+			}
+			for k := ni; k <= len(name); k++ {
+				if matchAt(pattern, pi, name, k) {
+					return true
+				}
+			}
+			return false
+		}
+		if pattern[pi] == '*' {
+			pi++
+			for k := ni; k <= len(name); k++ {
+				if k > ni && name[k-1] == '/' {
+					break
+				}
+				if matchAt(pattern, pi, name, k) {
+					return true
+				}
+			}
+			return false
+		}
+		if pattern[pi] == '?' {
+			if name[ni] == '/' {
+				return false
+			}
+			pi++
+			ni++
+			continue
+		}
+		if pattern[pi] != name[ni] {
+			return false
+		}
+		pi++
+		ni++
+	}
+	for pi < len(pattern) && pattern[pi] == '*' {
+		pi++
+	}
+	return pi == len(pattern) && ni == len(name)
+}

--- a/go/ingest/hooks/mutation_hook_test.go
+++ b/go/ingest/hooks/mutation_hook_test.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+package hooks
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+func TestCreatedEventInRawDocumentsDispatches(t *testing.T) {
+	var dispatched atomic.Int32
+	var dispatchedPath string
+	var mu sync.Mutex
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(brainID, path string) error {
+			mu.Lock()
+			dispatchedPath = path
+			mu.Unlock()
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "raw/documents/readme.md",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", got)
+	}
+	mu.Lock()
+	if dispatchedPath != "raw/documents/readme.md" {
+		t.Fatalf("expected raw/documents/readme.md, got %q", dispatchedPath)
+	}
+	mu.Unlock()
+}
+
+func TestUpdatedEventInRawDocumentsDispatches(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeUpdated,
+		Path: "raw/documents/notes.md",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", got)
+	}
+}
+
+func TestDeletedEventIgnored(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeDeleted,
+		Path: "raw/documents/readme.md",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches for delete, got %d", got)
+	}
+}
+
+func TestPathOutsideRawDocumentsIgnored(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "memory/global/fact.md",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches for non-matching path, got %d", got)
+	}
+}
+
+func TestCustomPathMatcher(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		PathMatchers:     []PathMatcher{PrefixPathMatcher("custom/")},
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "custom/data.json",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 dispatch for custom path, got %d", got)
+	}
+}
+
+func TestDebounceCoalescesRapidWrites(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 100 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	// Rapid writes to the same path within debounce window.
+	for range 5 {
+		sink.OnBrainChange(brain.ChangeEvent{
+			Kind: brain.ChangeUpdated,
+			Path: "raw/documents/rapid.md",
+			When: time.Now(),
+		})
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 coalesced dispatch, got %d", got)
+	}
+}
+
+func TestOptOutByBatchReason(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		OptOutReasons:    map[string]bool{"pipeline": true, "ingest": true},
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+
+	// Event with opt-out reason should be ignored.
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind:   brain.ChangeCreated,
+		Path:   "raw/documents/pipeline-output.md",
+		Reason: "pipeline",
+		When:   time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches for opt-out reason, got %d", got)
+	}
+
+	// Event without opt-out reason should dispatch.
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind:   brain.ChangeCreated,
+		Path:   "raw/documents/user-upload.md",
+		Reason: "user-write",
+		When:   time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 dispatch for non-opt-out reason, got %d", got)
+	}
+}
+
+func TestDifferentPathsDispatchIndependently(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "raw/documents/a.md",
+		When: time.Now(),
+	})
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "raw/documents/b.md",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 2 {
+		t.Fatalf("expected 2 dispatches for different paths, got %d", got)
+	}
+}
+
+func TestGlobPathMatcher(t *testing.T) {
+	matcher := GlobPathMatcher("raw/documents/**/*.md")
+
+	tests := []struct {
+		path  string
+		match bool
+	}{
+		{"raw/documents/readme.md", true},
+		{"raw/documents/sub/notes.md", true},
+		{"raw/documents/sub/deep/nested.md", true},
+		{"raw/documents/readme.txt", false},
+		{"memory/global/fact.md", false},
+	}
+
+	for _, tt := range tests {
+		if got := matcher(tt.path); got != tt.match {
+			t.Errorf("glob match %q: expected %v, got %v", tt.path, tt.match, got)
+		}
+	}
+}
+
+func TestCloseStopsPendingTimers(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 200 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "raw/documents/closing.md",
+		When: time.Now(),
+	})
+
+	// Close before debounce fires.
+	hook.Close()
+	time.Sleep(300 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches after close, got %d", got)
+	}
+}

--- a/go/ingest/hooks/mutation_hook_test.go
+++ b/go/ingest/hooks/mutation_hook_test.go
@@ -285,6 +285,109 @@ func TestGlobPathMatcher(t *testing.T) {
 	}
 }
 
+func TestGlobDoubleStarAtEnd(t *testing.T) {
+	matcher := GlobPathMatcher("raw/documents/**")
+
+	tests := []struct {
+		path  string
+		match bool
+	}{
+		{"raw/documents/readme.md", true},
+		{"raw/documents/sub/notes.md", true},
+		{"raw/documents/sub/deep/nested.txt", true},
+		{"memory/global/fact.md", false},
+	}
+
+	for _, tt := range tests {
+		if got := matcher(tt.path); got != tt.match {
+			t.Errorf("glob ** at end: %q: expected %v, got %v", tt.path, tt.match, got)
+		}
+	}
+}
+
+func TestPathTraversalRejected(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+
+	// Paths containing ".." must be rejected.
+	paths := []string{
+		"raw/documents/../../../etc/passwd",
+		"raw/documents/..secret.md",
+		"../raw/documents/readme.md",
+	}
+	for _, p := range paths {
+		sink.OnBrainChange(brain.ChangeEvent{
+			Kind: brain.ChangeCreated,
+			Path: brain.Path(p),
+			When: time.Now(),
+		})
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches for traversal paths, got %d", got)
+	}
+}
+
+func TestPrefixPathMatcherBoundary(t *testing.T) {
+	matcher := PrefixPathMatcher("custom/")
+
+	tests := []struct {
+		path  string
+		match bool
+	}{
+		{"custom/data.json", true},
+		{"custom/", false},    // bare prefix must not match
+		{"custom", false},     // shorter than prefix
+		{"", false},           // empty path
+	}
+
+	for _, tt := range tests {
+		if got := matcher(tt.path); got != tt.match {
+			t.Errorf("PrefixPathMatcher(%q): expected %v, got %v", tt.path, tt.match, got)
+		}
+	}
+}
+
+func TestEmptyPathIgnored(t *testing.T) {
+	var dispatched atomic.Int32
+
+	hook := NewMutationHook(MutationHookOptions{
+		BrainID:          "brain-1",
+		DebounceInterval: 10 * time.Millisecond,
+		Dispatch: func(_, _ string) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+	defer hook.Close()
+
+	sink := hook.Sink()
+	sink.OnBrainChange(brain.ChangeEvent{
+		Kind: brain.ChangeCreated,
+		Path: "",
+		When: time.Now(),
+	})
+
+	time.Sleep(50 * time.Millisecond)
+
+	if got := dispatched.Load(); got != 0 {
+		t.Fatalf("expected 0 dispatches for empty path, got %d", got)
+	}
+}
+
 func TestCloseStopsPendingTimers(t *testing.T) {
 	var dispatched atomic.Int32
 

--- a/go/ingest/hooks/types.go
+++ b/go/ingest/hooks/types.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hooks watches Store mutation events (ChangeEvent) and dispatches
+// ingestion requests for matching file paths. It provides configurable
+// path patterns, debouncing for rapid writes, and opt-out via batch reason.
+package hooks
+
+import "time"
+
+// DispatchFunc is called when a matching change event should trigger
+// ingestion. The path is the store path of the changed document.
+type DispatchFunc func(brainID string, path string) error
+
+// PathMatcher determines whether a store path should trigger ingestion.
+type PathMatcher func(path string) bool
+
+// MutationHookOptions configures the store mutation hook.
+type MutationHookOptions struct {
+	// BrainID is the brain that owns the store being watched.
+	BrainID string
+
+	// Dispatch is called when a debounced matching event fires.
+	Dispatch DispatchFunc
+
+	// PathMatchers determines which paths trigger ingestion. When empty,
+	// the default matcher (raw/documents/**) is used.
+	PathMatchers []PathMatcher
+
+	// OptOutReasons is a set of batch reasons that suppress ingestion.
+	// Events with a matching reason are silently ignored. Common values:
+	// "pipeline", "ingest", "reconcile".
+	OptOutReasons map[string]bool
+
+	// DebounceInterval is the minimum delay between dispatches for the
+	// same path. Rapid writes within this window are coalesced into a
+	// single dispatch. Defaults to 1000ms.
+	DebounceInterval time.Duration
+
+	// Logger receives diagnostic messages. When nil, logging is disabled.
+	Logger Logger
+}
+
+// Logger mirrors the logging contract used across the memory SDK.
+type Logger interface {
+	Debug(msg string, ctx ...map[string]string)
+	Info(msg string, ctx ...map[string]string)
+	Warn(msg string, ctx ...map[string]string)
+	Error(msg string, ctx ...map[string]string)
+}
+
+// MutationHook subscribes to store change events and dispatches
+// ingestion requests.
+type MutationHook struct {
+	opts     MutationHookOptions
+	timers   map[string]*time.Timer
+	closed   chan struct{}
+}
+
+// DefaultPathMatcher returns true for paths under raw/documents/.
+func DefaultPathMatcher(path string) bool {
+	return len(path) > len("raw/documents/") && path[:len("raw/documents/")] == "raw/documents/"
+}

--- a/go/ingest/hooks/types.go
+++ b/go/ingest/hooks/types.go
@@ -5,10 +5,18 @@
 // path patterns, debouncing for rapid writes, and opt-out via batch reason.
 package hooks
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // DispatchFunc is called when a matching change event should trigger
 // ingestion. The path is the store path of the changed document.
+//
+// The function is invoked in a background goroutine after the debounce
+// timer fires. Implementations that perform network I/O or long-running
+// work should enforce their own context/timeout to avoid goroutine
+// leaks. Panics inside DispatchFunc will crash the process.
 type DispatchFunc func(brainID string, path string) error
 
 // PathMatcher determines whether a store path should trigger ingestion.
@@ -51,12 +59,14 @@ type Logger interface {
 // MutationHook subscribes to store change events and dispatches
 // ingestion requests.
 type MutationHook struct {
-	opts     MutationHookOptions
-	timers   map[string]*time.Timer
-	closed   chan struct{}
+	mu     sync.Mutex
+	opts   MutationHookOptions
+	timers map[string]*time.Timer
+	closed chan struct{}
 }
 
 // DefaultPathMatcher returns true for paths under raw/documents/.
+// The bare prefix "raw/documents/" is rejected; a filename must follow.
 func DefaultPathMatcher(path string) bool {
 	return len(path) > len("raw/documents/") && path[:len("raw/documents/")] == "raw/documents/"
 }

--- a/sdks/ts/memory/package.json
+++ b/sdks/ts/memory/package.json
@@ -70,6 +70,10 @@
       "import": "./dist/ingest/index.js",
       "types": "./dist/ingest/index.d.ts"
     },
+    "./ingest/hooks": {
+      "import": "./dist/ingest/hooks/index.js",
+      "types": "./dist/ingest/hooks/index.d.ts"
+    },
     "./llm": {
       "import": "./dist/llm/index.js",
       "types": "./dist/llm/index.d.ts"

--- a/sdks/ts/memory/src/ingest/hooks/index.ts
+++ b/sdks/ts/memory/src/ingest/hooks/index.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type { DispatchFn, MutationHook, MutationHookOptions, PathMatcher } from './types.js'
+export {
+  createMutationHook,
+  defaultPathMatcher,
+  globPathMatcher,
+  prefixPathMatcher,
+} from './mutation-hook.js'

--- a/sdks/ts/memory/src/ingest/hooks/mutation-hook.test.ts
+++ b/sdks/ts/memory/src/ingest/hooks/mutation-hook.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ChangeEvent } from '../../store/index.js'
+import type { Path } from '../../store/index.js'
+import {
+  createMutationHook,
+  defaultPathMatcher,
+  globPathMatcher,
+  prefixPathMatcher,
+} from './mutation-hook.js'
+
+const makeEvent = (
+  kind: ChangeEvent['kind'],
+  path: string,
+  reason?: string,
+): ChangeEvent => ({
+  kind,
+  path: path as Path,
+  reason,
+  when: new Date(),
+})
+
+describe('mutation-hook', () => {
+  it('dispatches on created event in raw/documents/', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/readme.md'))
+    await delay(50)
+
+    expect(dispatch).toHaveBeenCalledWith('brain-1', 'raw/documents/readme.md')
+    hook.close()
+  })
+
+  it('dispatches on updated event in raw/documents/', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('updated', 'raw/documents/notes.md'))
+    await delay(50)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    hook.close()
+  })
+
+  it('ignores deleted events', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('deleted', 'raw/documents/readme.md'))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    hook.close()
+  })
+
+  it('ignores paths outside default pattern', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', 'memory/global/fact.md'))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    hook.close()
+  })
+
+  it('supports custom path matchers', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      pathMatchers: [prefixPathMatcher('custom/')],
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', 'custom/data.json'))
+    await delay(50)
+
+    expect(dispatch).toHaveBeenCalledWith('brain-1', 'custom/data.json')
+    hook.close()
+  })
+
+  it('debounces rapid writes to the same path', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 100,
+    })
+
+    for (let i = 0; i < 5; i++) {
+      hook.sink(makeEvent('updated', 'raw/documents/rapid.md'))
+      await delay(10)
+    }
+
+    await delay(200)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    hook.close()
+  })
+
+  it('dispatches independently for different paths', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/a.md'))
+    hook.sink(makeEvent('created', 'raw/documents/b.md'))
+    await delay(50)
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    hook.close()
+  })
+
+  it('opts out by batch reason', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      optOutReasons: new Set(['pipeline', 'ingest']),
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/pipeline-output.md', 'pipeline'))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+
+    // Non-opt-out reason should dispatch.
+    hook.sink(makeEvent('created', 'raw/documents/user-upload.md', 'user-write'))
+    await delay(50)
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    hook.close()
+  })
+
+  it('close() stops pending timers', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 200,
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/closing.md'))
+    hook.close()
+
+    await delay(300)
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('events after close are ignored', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.close()
+    hook.sink(makeEvent('created', 'raw/documents/late.md'))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('dispatch errors are logged', async () => {
+    const errorFn = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch: () => { throw new Error('dispatch fail') },
+      debounceIntervalMs: 10,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: errorFn },
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/failing.md'))
+    await delay(50)
+
+    expect(errorFn).toHaveBeenCalled()
+    hook.close()
+  })
+})
+
+describe('defaultPathMatcher', () => {
+  it('matches raw/documents/ paths', () => {
+    expect(defaultPathMatcher('raw/documents/readme.md')).toBe(true)
+    expect(defaultPathMatcher('raw/documents/sub/deep.md')).toBe(true)
+  })
+
+  it('rejects non-matching paths', () => {
+    expect(defaultPathMatcher('memory/global/fact.md')).toBe(false)
+    expect(defaultPathMatcher('raw/documents/')).toBe(false)
+  })
+})
+
+describe('globPathMatcher', () => {
+  const matcher = globPathMatcher('raw/documents/**/*.md')
+
+  it('matches markdown files under raw/documents/', () => {
+    expect(matcher('raw/documents/readme.md')).toBe(true)
+    expect(matcher('raw/documents/sub/notes.md')).toBe(true)
+    expect(matcher('raw/documents/sub/deep/nested.md')).toBe(true)
+  })
+
+  it('rejects non-matching files', () => {
+    expect(matcher('raw/documents/readme.txt')).toBe(false)
+    expect(matcher('memory/global/fact.md')).toBe(false)
+  })
+})
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/sdks/ts/memory/src/ingest/hooks/mutation-hook.test.ts
+++ b/sdks/ts/memory/src/ingest/hooks/mutation-hook.test.ts
@@ -185,6 +185,41 @@ describe('mutation-hook', () => {
     expect(dispatch).not.toHaveBeenCalled()
   })
 
+  it('rejects paths containing ".."', async () => {
+    const dispatch = vi.fn()
+    const warnFn = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: warnFn, error: vi.fn() },
+    })
+
+    hook.sink(makeEvent('created', 'raw/documents/../../../etc/passwd'))
+    hook.sink(makeEvent('created', 'raw/documents/..secret.md'))
+    hook.sink(makeEvent('created', '../raw/documents/readme.md'))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(warnFn).toHaveBeenCalledTimes(3)
+    hook.close()
+  })
+
+  it('ignores empty path', async () => {
+    const dispatch = vi.fn()
+    const hook = createMutationHook({
+      brainId: 'brain-1',
+      dispatch,
+      debounceIntervalMs: 10,
+    })
+
+    hook.sink(makeEvent('created', ''))
+    await delay(50)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    hook.close()
+  })
+
   it('dispatch errors are logged', async () => {
     const errorFn = vi.fn()
     const hook = createMutationHook({
@@ -212,6 +247,10 @@ describe('defaultPathMatcher', () => {
     expect(defaultPathMatcher('memory/global/fact.md')).toBe(false)
     expect(defaultPathMatcher('raw/documents/')).toBe(false)
   })
+
+  it('rejects empty path', () => {
+    expect(defaultPathMatcher('')).toBe(false)
+  })
 })
 
 describe('globPathMatcher', () => {
@@ -226,6 +265,33 @@ describe('globPathMatcher', () => {
   it('rejects non-matching files', () => {
     expect(matcher('raw/documents/readme.txt')).toBe(false)
     expect(matcher('memory/global/fact.md')).toBe(false)
+  })
+
+  it('matches ** at end of glob', () => {
+    const allMatcher = globPathMatcher('raw/documents/**')
+    expect(allMatcher('raw/documents/readme.md')).toBe(true)
+    expect(allMatcher('raw/documents/sub/notes.md')).toBe(true)
+    expect(allMatcher('memory/global/fact.md')).toBe(false)
+  })
+})
+
+describe('prefixPathMatcher boundary', () => {
+  const matcher = prefixPathMatcher('custom/')
+
+  it('matches paths longer than the prefix', () => {
+    expect(matcher('custom/data.json')).toBe(true)
+  })
+
+  it('rejects bare prefix', () => {
+    expect(matcher('custom/')).toBe(false)
+  })
+
+  it('rejects shorter-than-prefix', () => {
+    expect(matcher('custom')).toBe(false)
+  })
+
+  it('rejects empty path', () => {
+    expect(matcher('')).toBe(false)
   })
 })
 

--- a/sdks/ts/memory/src/ingest/hooks/mutation-hook.ts
+++ b/sdks/ts/memory/src/ingest/hooks/mutation-hook.ts
@@ -17,9 +17,9 @@ const DEFAULT_PATH_PREFIX = 'raw/documents/'
 export const defaultPathMatcher: PathMatcher = (path: string): boolean =>
   path.startsWith(DEFAULT_PATH_PREFIX) && path.length > DEFAULT_PATH_PREFIX.length
 
-/** Prefix-based path matcher. */
+/** Prefix-based path matcher. Rejects the bare prefix itself. */
 export const prefixPathMatcher = (prefix: string): PathMatcher =>
-  (path: string): boolean => path.startsWith(prefix)
+  (path: string): boolean => path.length > prefix.length && path.startsWith(prefix)
 
 /** Glob-based path matcher supporting * and ** patterns. */
 export const globPathMatcher = (pattern: string): PathMatcher =>
@@ -54,6 +54,10 @@ export const createMutationHook = (opts: MutationHookOptions): MutationHook => {
       path,
       setTimeout(() => {
         timers.delete(path)
+
+        // Guard against dispatch after close.
+        if (closed) return
+
         try {
           const result = opts.dispatch(opts.brainId, path)
           if (result && typeof (result as Promise<void>).catch === 'function') {
@@ -75,6 +79,12 @@ export const createMutationHook = (opts: MutationHookOptions): MutationHook => {
     if (event.kind !== 'created' && event.kind !== 'updated') return
 
     const path = event.path
+
+    // Reject paths containing ".." to prevent path traversal.
+    if (path.includes('..')) {
+      logger?.warn('hooks: rejecting path with traversal segment', { path })
+      return
+    }
 
     // Opt-out by batch reason.
     if (event.reason && optOutReasons.has(event.reason)) {

--- a/sdks/ts/memory/src/ingest/hooks/mutation-hook.ts
+++ b/sdks/ts/memory/src/ingest/hooks/mutation-hook.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Store mutation hook implementation. Subscribes to ChangeEvent from a
+ * Store and dispatches ingestion requests for file writes matching
+ * configurable path patterns. Rapid writes to the same path are
+ * debounced. Batch writes with opt-out reasons are silently skipped.
+ */
+
+import type { ChangeEvent } from '../../store/index.js'
+import type { DispatchFn, MutationHook, MutationHookOptions, PathMatcher } from './types.js'
+
+const DEFAULT_DEBOUNCE_MS = 1000
+const DEFAULT_PATH_PREFIX = 'raw/documents/'
+
+/** Default path matcher: files under raw/documents/. */
+export const defaultPathMatcher: PathMatcher = (path: string): boolean =>
+  path.startsWith(DEFAULT_PATH_PREFIX) && path.length > DEFAULT_PATH_PREFIX.length
+
+/** Prefix-based path matcher. */
+export const prefixPathMatcher = (prefix: string): PathMatcher =>
+  (path: string): boolean => path.startsWith(prefix)
+
+/** Glob-based path matcher supporting * and ** patterns. */
+export const globPathMatcher = (pattern: string): PathMatcher =>
+  (path: string): boolean => globMatch(pattern, path)
+
+export const createMutationHook = (opts: MutationHookOptions): MutationHook => {
+  const debounceMs = opts.debounceIntervalMs ?? DEFAULT_DEBOUNCE_MS
+  const matchers: readonly PathMatcher[] =
+    opts.pathMatchers && opts.pathMatchers.length > 0
+      ? opts.pathMatchers
+      : [defaultPathMatcher]
+  const optOutReasons = opts.optOutReasons ?? new Set<string>()
+  const logger = opts.logger
+
+  const timers = new Map<string, ReturnType<typeof setTimeout>>()
+  let closed = false
+
+  const matchesAny = (path: string): boolean => {
+    for (const matcher of matchers) {
+      if (matcher(path)) return true
+    }
+    return false
+  }
+
+  const debounceDispatch = (path: string): void => {
+    const existing = timers.get(path)
+    if (existing !== undefined) {
+      clearTimeout(existing)
+    }
+
+    timers.set(
+      path,
+      setTimeout(() => {
+        timers.delete(path)
+        try {
+          const result = opts.dispatch(opts.brainId, path)
+          if (result && typeof (result as Promise<void>).catch === 'function') {
+            ;(result as Promise<void>).catch((err) => {
+              logger?.error('hooks: dispatch failed', { path, error: String(err) })
+            })
+          }
+        } catch (err) {
+          logger?.error('hooks: dispatch failed', { path, error: String(err) })
+        }
+      }, debounceMs),
+    )
+  }
+
+  const sink = (event: ChangeEvent): void => {
+    if (closed) return
+
+    // Only react to created and updated events.
+    if (event.kind !== 'created' && event.kind !== 'updated') return
+
+    const path = event.path
+
+    // Opt-out by batch reason.
+    if (event.reason && optOutReasons.has(event.reason)) {
+      logger?.debug('hooks: skipping event due to opt-out reason', {
+        path,
+        reason: event.reason,
+      })
+      return
+    }
+
+    if (!matchesAny(path)) return
+
+    debounceDispatch(path)
+  }
+
+  const close = (): void => {
+    if (closed) return
+    closed = true
+    for (const [, timer] of timers) {
+      clearTimeout(timer)
+    }
+    timers.clear()
+  }
+
+  return { sink, close }
+}
+
+// Glob matching implementation.
+const globMatch = (pattern: string, name: string): boolean => matchAt(pattern, 0, name, 0)
+
+const matchAt = (pattern: string, pi: number, name: string, ni: number): boolean => {
+  while (pi < pattern.length && ni < name.length) {
+    if (pi + 1 < pattern.length && pattern[pi] === '*' && pattern[pi + 1] === '*') {
+      let nextPi = pi + 2
+      if (nextPi < pattern.length && pattern[nextPi] === '/') nextPi++
+      for (let k = ni; k <= name.length; k++) {
+        if (matchAt(pattern, nextPi, name, k)) return true
+      }
+      return false
+    }
+    if (pattern[pi] === '*') {
+      const nextPi = pi + 1
+      for (let k = ni; k <= name.length; k++) {
+        if (k > ni && name[k - 1] === '/') break
+        if (matchAt(pattern, nextPi, name, k)) return true
+      }
+      return false
+    }
+    if (pattern[pi] === '?') {
+      if (name[ni] === '/') return false
+      pi++
+      ni++
+      continue
+    }
+    if (pattern[pi] !== name[ni]) return false
+    pi++
+    ni++
+  }
+  while (pi < pattern.length && pattern[pi] === '*') pi++
+  return pi === pattern.length && ni === name.length
+}

--- a/sdks/ts/memory/src/ingest/hooks/types.ts
+++ b/sdks/ts/memory/src/ingest/hooks/types.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Store mutation hook types. The mutation hook subscribes to store
+ * ChangeEvents and dispatches ingestion requests for matching paths,
+ * with debouncing and opt-out support.
+ */
+
+import type { Logger } from '../../llm/types.js'
+import type { ChangeEvent, Path } from '../../store/index.js'
+
+/** Callback invoked when a matching change event should trigger ingestion. */
+export type DispatchFn = (brainId: string, path: string) => Promise<void> | void
+
+/** Determines whether a store path should trigger ingestion. */
+export type PathMatcher = (path: string) => boolean
+
+export type MutationHookOptions = {
+  /** Brain that owns the store being watched. */
+  readonly brainId: string
+  /** Called when a debounced matching event fires. */
+  readonly dispatch: DispatchFn
+  /** Path matchers. Defaults to raw/documents/** when empty. */
+  readonly pathMatchers?: readonly PathMatcher[]
+  /** Batch reasons that suppress ingestion. Events with a matching reason are ignored. */
+  readonly optOutReasons?: ReadonlySet<string>
+  /** Minimum delay between dispatches for the same path. Defaults to 1000ms. */
+  readonly debounceIntervalMs?: number
+  readonly logger?: Logger
+}
+
+export type MutationHook = {
+  /** EventSink to pass to store.subscribe(). */
+  readonly sink: (event: ChangeEvent) => void
+  /** Stop all pending debounce timers. */
+  close(): void
+}

--- a/sdks/ts/memory/src/ingest/hooks/types.ts
+++ b/sdks/ts/memory/src/ingest/hooks/types.ts
@@ -9,7 +9,14 @@
 import type { Logger } from '../../llm/types.js'
 import type { ChangeEvent, Path } from '../../store/index.js'
 
-/** Callback invoked when a matching change event should trigger ingestion. */
+/**
+ * Callback invoked when a matching change event should trigger ingestion.
+ *
+ * The function is called after the debounce timer fires. Implementations
+ * that perform network I/O or long-running work should enforce their own
+ * timeout (e.g. AbortSignal) to avoid hanging the event loop. Thrown
+ * errors and rejected promises are logged but do not propagate.
+ */
 export type DispatchFn = (brainId: string, path: string) => Promise<void> | void
 
 /** Determines whether a store path should trigger ingestion. */

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -93,6 +93,8 @@ export { tabularChunker } from './chunkers/tabular.js'
 
 export * from './sources/index.js'
 
+export * from './hooks/index.js'
+
 export {
   createSafetyScanner,
   preprocessText,


### PR DESCRIPTION
## Summary
- Subscribes to Store.ChangeEvent and dispatches ingestion for created/updated files matching configurable path patterns (default: `raw/documents/**`)
- Debounces rapid writes to the same path (configurable interval, default 1000ms)
- Opt-out per write via batch reason (e.g. "pipeline", "ingest" to avoid feedback loops)
- Provides `prefixPathMatcher`, `globPathMatcher`, and `defaultPathMatcher` for flexible path configuration

## Test plan
- [x] Go: 10 tests covering created/updated dispatch, delete ignored, path outside default ignored, custom path matcher, debounce coalescing, opt-out by reason, independent path dispatch, glob matching, close stops timers
- [x] TS: 15 tests covering same scenarios plus dispatch error logging, events after close, defaultPathMatcher, globPathMatcher