### PR TITLE
feat: P2-5 directory ingest MCP tool (LLE-9801)

### DIFF
--- a/go/cmd/memory-mcp/main_test.go
+++ b/go/cmd/memory-mcp/main_test.go
@@ -122,6 +122,7 @@ func TestListToolsReturnsTwelveTools(t *testing.T) {
 		"memory_search",
 		"memory_ask",
 		"memory_ingest_batch",
+		"memory_ingest_directory",
 		"memory_ingest_file",
 		"memory_ingest_url",
 		"memory_extract",

--- a/go/cmd/memory-mcp/tools/ingest_directory.go
+++ b/go/cmd/memory-mcp/tools/ingest_directory.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/jeffs-brain/memory/go/ingest"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const maxDirectoryFiles = 500
+
+// IngestDirectoryArgs is the input shape for memory_ingest_directory.
+type IngestDirectoryArgs struct {
+	Directory string `json:"directory"`
+	Glob      string `json:"glob,omitempty"`
+	Brain     string `json:"brain,omitempty"`
+	Recursive *bool  `json:"recursive,omitempty"`
+	MaxFiles  int    `json:"maxFiles,omitempty"`
+}
+
+func registerIngestDirectory(server *mcp.Server, client MemoryClient) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"directory": {Type: "string", MinLength: ptrInt(1)},
+			"glob":      {Type: "string"},
+			"brain":     {Type: "string"},
+			"recursive": {Type: "boolean"},
+			"maxFiles":  {Type: "integer", Minimum: ptrFloat(1), Maximum: ptrFloat(float64(maxDirectoryFiles))},
+		},
+		Required: []string{"directory"},
+	}
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "memory_ingest_directory",
+		Description: "Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering.",
+		InputSchema: schema,
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args IngestDirectoryArgs) (*mcp.CallToolResult, any, error) {
+		recursive := true
+		if args.Recursive != nil {
+			recursive = *args.Recursive
+		}
+		maxFiles := 100
+		if args.MaxFiles > 0 {
+			if args.MaxFiles > maxDirectoryFiles {
+				return nil, nil, fmt.Errorf("memory_ingest_directory: maxFiles exceeds maximum of %d", maxDirectoryFiles)
+			}
+			maxFiles = args.MaxFiles
+		}
+
+		enumerated, skipped, err := ingest.EnumerateFiles(ctx, ingest.EnumerateOptions{
+			Directory: args.Directory,
+			Glob:      args.Glob,
+			Recursive: recursive,
+			MaxFiles:  maxFiles,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("memory_ingest_directory: enumerate: %w", err)
+		}
+
+		progress := progressFromRequest(ctx, req)
+		total := len(enumerated)
+		succeeded := 0
+		failed := 0
+		results := make([]map[string]any, 0, total)
+
+		for i, file := range enumerated {
+			ingestArgs := IngestFileArgs{
+				Path:  file.Path,
+				Brain: args.Brain,
+			}
+
+			result, ingestErr := client.IngestFile(ctx, ingestArgs, progress)
+			if ingestErr != nil {
+				results = append(results, map[string]any{
+					"path":   file.Path,
+					"status": "error",
+					"error":  ingestErr.Error(),
+				})
+				failed++
+			} else {
+				entry := map[string]any{
+					"path":   file.Path,
+					"status": "success",
+				}
+				if docID, ok := result["document_id"]; ok {
+					entry["documentId"] = docID
+				}
+				if hash, ok := result["hash"]; ok {
+					entry["hash"] = hash
+				}
+				if byteSize, ok := result["byte_size"]; ok {
+					entry["bytes"] = byteSize
+				}
+				results = append(results, entry)
+				succeeded++
+			}
+
+			if progress != nil {
+				progress(float64(i+1), fmt.Sprintf("%d/%d %s", i+1, total, file.Path))
+			}
+		}
+
+		payload := map[string]any{
+			"total":          total,
+			"succeeded":      succeeded,
+			"failed":         failed,
+			"skipped":        len(skipped),
+			"skippedReasons": skipped,
+			"results":        results,
+		}
+		return structuredResult(payload)
+	})
+}

--- a/go/cmd/memory-mcp/tools/ingest_directory.go
+++ b/go/cmd/memory-mcp/tools/ingest_directory.go
@@ -5,6 +5,8 @@ package tools
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/jeffs-brain/memory/go/ingest"
@@ -40,6 +42,15 @@ func registerIngestDirectory(server *mcp.Server, client MemoryClient) {
 		Description: "Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering.",
 		InputSchema: schema,
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args IngestDirectoryArgs) (*mcp.CallToolResult, any, error) {
+		// Sanitise directory path to prevent traversal.
+		cleanedDir := filepath.Clean(args.Directory)
+		if !filepath.IsAbs(cleanedDir) {
+			return nil, nil, fmt.Errorf("memory_ingest_directory: directory must be an absolute path")
+		}
+		if strings.Contains(cleanedDir, "..") {
+			return nil, nil, fmt.Errorf("memory_ingest_directory: directory path must not contain '..'")
+		}
+
 		recursive := true
 		if args.Recursive != nil {
 			recursive = *args.Recursive
@@ -53,7 +64,7 @@ func registerIngestDirectory(server *mcp.Server, client MemoryClient) {
 		}
 
 		enumerated, skipped, err := ingest.EnumerateFiles(ctx, ingest.EnumerateOptions{
-			Directory: args.Directory,
+			Directory: cleanedDir,
 			Glob:      args.Glob,
 			Recursive: recursive,
 			MaxFiles:  maxFiles,

--- a/go/cmd/memory-mcp/tools/ingest_directory.go
+++ b/go/cmd/memory-mcp/tools/ingest_directory.go
@@ -7,13 +7,19 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/jeffs-brain/memory/go/ingest"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/sync/errgroup"
 )
 
-const maxDirectoryFiles = 500
+const (
+	maxDirectoryFiles       = 500
+	maxDirectoryConcurrency = 5
+)
 
 // IngestDirectoryArgs is the input shape for memory_ingest_directory.
 type IngestDirectoryArgs struct {
@@ -75,51 +81,65 @@ func registerIngestDirectory(server *mcp.Server, client MemoryClient) {
 
 		progress := progressFromRequest(ctx, req)
 		total := len(enumerated)
-		succeeded := 0
-		failed := 0
-		results := make([]map[string]any, 0, total)
+		var succeededCount atomic.Int64
+		var failedCount atomic.Int64
+		var completedCount atomic.Int64
+		results := make([]map[string]any, total)
+		var mu sync.Mutex
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(maxDirectoryConcurrency)
 
 		for i, file := range enumerated {
-			ingestArgs := IngestFileArgs{
-				Path:  file.Path,
-				Brain: args.Brain,
-			}
+			g.Go(func() error {
+				ingestArgs := IngestFileArgs{
+					Path:  file.Path,
+					Brain: args.Brain,
+				}
 
-			result, ingestErr := client.IngestFile(ctx, ingestArgs, progress)
-			if ingestErr != nil {
-				results = append(results, map[string]any{
-					"path":   file.Path,
-					"status": "error",
-					"error":  ingestErr.Error(),
-				})
-				failed++
-			} else {
-				entry := map[string]any{
-					"path":   file.Path,
-					"status": "success",
+				result, ingestErr := client.IngestFile(gctx, ingestArgs, progress)
+				if ingestErr != nil {
+					results[i] = map[string]any{
+						"path":   file.Path,
+						"status": "error",
+						"error":  ingestErr.Error(),
+					}
+					failedCount.Add(1)
+				} else {
+					entry := map[string]any{
+						"path":   file.Path,
+						"status": "success",
+					}
+					if docID, ok := result["document_id"]; ok {
+						entry["documentId"] = docID
+					}
+					if hash, ok := result["hash"]; ok {
+						entry["hash"] = hash
+					}
+					if byteSize, ok := result["byte_size"]; ok {
+						entry["bytes"] = byteSize
+					}
+					results[i] = entry
+					succeededCount.Add(1)
 				}
-				if docID, ok := result["document_id"]; ok {
-					entry["documentId"] = docID
-				}
-				if hash, ok := result["hash"]; ok {
-					entry["hash"] = hash
-				}
-				if byteSize, ok := result["byte_size"]; ok {
-					entry["bytes"] = byteSize
-				}
-				results = append(results, entry)
-				succeeded++
-			}
 
-			if progress != nil {
-				progress(float64(i+1), fmt.Sprintf("%d/%d %s", i+1, total, file.Path))
-			}
+				done := completedCount.Add(1)
+				if progress != nil {
+					mu.Lock()
+					progress(float64(done), fmt.Sprintf("%d/%d %s", done, total, file.Path))
+					mu.Unlock()
+				}
+
+				return nil
+			})
 		}
+
+		_ = g.Wait()
 
 		payload := map[string]any{
 			"total":          total,
-			"succeeded":      succeeded,
-			"failed":         failed,
+			"succeeded":      succeededCount.Load(),
+			"failed":         failedCount.Load(),
 			"skipped":        len(skipped),
 			"skippedReasons": skipped,
 			"results":        results,

--- a/go/cmd/memory-mcp/tools/ingest_directory_test.go
+++ b/go/cmd/memory-mcp/tools/ingest_directory_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -119,10 +120,13 @@ func TestIngestDirectory_EnumeratesAndIngests(t *testing.T) {
 		}
 	}
 
-	calls := []string{}
+	var mu sync.Mutex
+	var callCount int
 	client := &mockDirMemoryClient{
 		ingestFileFn: func(_ context.Context, args IngestFileArgs, _ ProgressEmitter) (map[string]any, error) {
-			calls = append(calls, args.Path)
+			mu.Lock()
+			callCount++
+			mu.Unlock()
 			return map[string]any{
 				"status":      "completed",
 				"document_id": "doc-" + filepath.Base(args.Path),
@@ -146,9 +150,11 @@ func TestIngestDirectory_EnumeratesAndIngests(t *testing.T) {
 	if payload["failed"] != float64(0) {
 		t.Errorf("expected failed=0, got %v", payload["failed"])
 	}
-	if len(calls) != 3 {
-		t.Errorf("expected 3 ingest calls, got %d", len(calls))
+	mu.Lock()
+	if callCount != 3 {
+		t.Errorf("expected 3 ingest calls, got %d", callCount)
 	}
+	mu.Unlock()
 }
 
 func TestIngestDirectory_MaxFilesOver500Rejected(t *testing.T) {

--- a/go/cmd/memory-mcp/tools/ingest_directory_test.go
+++ b/go/cmd/memory-mcp/tools/ingest_directory_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// mockDirMemoryClient is a minimal MemoryClient for testing directory ingest.
+type mockDirMemoryClient struct {
+	ingestFileFn func(ctx context.Context, args IngestFileArgs, progress ProgressEmitter) (map[string]any, error)
+}
+
+func (m *mockDirMemoryClient) Remember(context.Context, RememberArgs) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Search(context.Context, SearchArgs) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Recall(context.Context, RecallArgs) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Ask(context.Context, AskArgs, ProgressEmitter) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) IngestFile(ctx context.Context, args IngestFileArgs, progress ProgressEmitter) (map[string]any, error) {
+	if m.ingestFileFn != nil {
+		return m.ingestFileFn(ctx, args, progress)
+	}
+	return map[string]any{
+		"status":      "completed",
+		"document_id": "doc-" + filepath.Base(args.Path),
+		"hash":        "hash-" + filepath.Base(args.Path),
+		"byte_size":   100,
+	}, nil
+}
+func (m *mockDirMemoryClient) IngestURL(context.Context, IngestURLArgs, ProgressEmitter) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Extract(context.Context, ExtractArgs, ProgressEmitter) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Reflect(context.Context, ReflectArgs, ProgressEmitter) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) Consolidate(context.Context, ConsolidateArgs, ProgressEmitter) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) CreateBrain(context.Context, CreateBrainArgs) (map[string]any, error) {
+	return nil, nil
+}
+func (m *mockDirMemoryClient) ListBrains(context.Context) (map[string]any, error) { return nil, nil }
+
+func setupDirTestServer(t *testing.T, client MemoryClient) *mcp.ClientSession {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.0"}, nil)
+	registerIngestDirectory(server, client)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	session, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func callDirTool(t *testing.T, session *mcp.ClientSession, args map[string]any) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: "memory_ingest_directory", Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		txt := ""
+		for _, c := range res.Content {
+			if tc, ok := c.(*mcp.TextContent); ok {
+				txt = tc.Text
+			}
+		}
+		t.Fatalf("memory_ingest_directory returned error: %s", txt)
+	}
+
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			var out map[string]any
+			if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			return out
+		}
+	}
+	t.Fatal("no text content in response")
+	return nil
+}
+
+func TestIngestDirectory_EnumeratesAndIngests(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.md", "b.md", "c.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("# "+name), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	calls := []string{}
+	client := &mockDirMemoryClient{
+		ingestFileFn: func(_ context.Context, args IngestFileArgs, _ ProgressEmitter) (map[string]any, error) {
+			calls = append(calls, args.Path)
+			return map[string]any{
+				"status":      "completed",
+				"document_id": "doc-" + filepath.Base(args.Path),
+				"hash":        "hash-" + filepath.Base(args.Path),
+				"byte_size":   100,
+			}, nil
+		},
+	}
+	session := setupDirTestServer(t, client)
+
+	payload := callDirTool(t, session, map[string]any{
+		"directory": dir,
+	})
+
+	if payload["total"] != float64(3) {
+		t.Errorf("expected total=3, got %v", payload["total"])
+	}
+	if payload["succeeded"] != float64(3) {
+		t.Errorf("expected succeeded=3, got %v", payload["succeeded"])
+	}
+	if payload["failed"] != float64(0) {
+		t.Errorf("expected failed=0, got %v", payload["failed"])
+	}
+	if len(calls) != 3 {
+		t.Errorf("expected 3 ingest calls, got %d", len(calls))
+	}
+}
+
+func TestIngestDirectory_MaxFilesOver500Rejected(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &mockDirMemoryClient{}
+	session := setupDirTestServer(t, client)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "memory_ingest_directory",
+		Arguments: map[string]any{
+			"directory": dir,
+			"maxFiles":  501,
+		},
+	})
+	// The MCP SDK may reject via schema validation (error) or via
+	// the handler guard (IsError response). Either is acceptable.
+	if err != nil {
+		return // Schema validation rejected it.
+	}
+	if !res.IsError {
+		t.Fatal("expected error for maxFiles > 500, but got success")
+	}
+}

--- a/go/cmd/memory-mcp/tools/tools.go
+++ b/go/cmd/memory-mcp/tools/tools.go
@@ -139,6 +139,7 @@ func Register(server *mcp.Server, client MemoryClient) {
 	registerSearch(server, client)
 	registerAsk(server, client)
 	registerIngestBatch(server, client)
+	registerIngestDirectory(server, client)
 	registerIngestFile(server, client)
 	registerIngestURL(server, client)
 	registerExtract(server, client)

--- a/go/ingest/directory.go
+++ b/go/ingest/directory.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ingest
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const fileSizeLimit = 25 * 1024 * 1024 // 25 MiB
+
+// knownTextExtensions lists file extensions treated as ingestable text.
+var knownTextExtensions = map[string]bool{
+	".md": true, ".markdown": true, ".txt": true, ".text": true,
+	".pdf": true, ".json": true, ".html": true, ".htm": true,
+	".csv": true, ".tsv": true, ".xml": true, ".yaml": true,
+	".yml": true, ".toml": true, ".rst": true, ".adoc": true,
+	".org": true, ".tex": true, ".rtf": true,
+}
+
+// EnumerateOptions configures directory file enumeration.
+type EnumerateOptions struct {
+	Directory string
+	Glob      string
+	Recursive bool
+	MaxFiles  int
+}
+
+// EnumeratedFile describes a single file found during enumeration.
+type EnumeratedFile struct {
+	Path string
+	Size int64
+}
+
+// EnumerateFiles walks a directory and returns files suitable for ingestion.
+//
+// It excludes hidden files (dot-prefix), does not follow symlinks, respects
+// .gitignore patterns when present, applies glob filter if provided, enforces
+// maxFiles limit, and skips files over 25 MiB.
+func EnumerateFiles(ctx context.Context, opts EnumerateOptions) ([]EnumeratedFile, []string, error) {
+	if opts.MaxFiles <= 0 {
+		opts.MaxFiles = 100
+	}
+
+	gitignorePatterns := loadGitignore(opts.Directory)
+
+	var files []EnumeratedFile
+	var skipped []string
+	limitReached := false
+
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			skipped = append(skipped, fmt.Sprintf("%s: %s", path, err.Error()))
+			return nil
+		}
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Skip hidden entries
+		if strings.HasPrefix(d.Name(), ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		relPath, relErr := filepath.Rel(opts.Directory, path)
+		if relErr != nil {
+			relPath = path
+		}
+
+		// Check .gitignore
+		if matchesGitignore(relPath, gitignorePatterns) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Non-recursive: skip subdirectories
+		if d.IsDir() {
+			if !opts.Recursive && path != opts.Directory {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Skip symlinks
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			skipped = append(skipped, fmt.Sprintf("%s: %s", relPath, infoErr.Error()))
+			return nil
+		}
+		if info.Mode()&fs.ModeSymlink != 0 {
+			return nil
+		}
+
+		// Max files check
+		if len(files) >= opts.MaxFiles {
+			if !limitReached {
+				skipped = append(skipped, fmt.Sprintf("max files limit (%d) reached", opts.MaxFiles))
+				limitReached = true
+			}
+			return nil
+		}
+
+		// Size check
+		if info.Size() > fileSizeLimit {
+			skipped = append(skipped, fmt.Sprintf("%s: exceeds 25 MiB limit (%d MiB)", relPath, info.Size()/(1024*1024)))
+			return nil
+		}
+
+		// Glob filter
+		if opts.Glob != "" && !matchGlob(relPath, opts.Glob) {
+			return nil
+		}
+
+		// Extension filter
+		ext := strings.ToLower(filepath.Ext(d.Name()))
+		if ext != "" && !knownTextExtensions[ext] {
+			return nil
+		}
+
+		files = append(files, EnumeratedFile{Path: path, Size: info.Size()})
+		return nil
+	}
+
+	if err := filepath.WalkDir(opts.Directory, walkFn); err != nil {
+		return files, skipped, err
+	}
+
+	return files, skipped, nil
+}
+
+// loadGitignore reads .gitignore from the directory root if present.
+func loadGitignore(dir string) []string {
+	f, err := os.Open(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var patterns []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		patterns = append(patterns, line)
+	}
+	return patterns
+}
+
+// matchesGitignore checks if a relative path matches any gitignore pattern.
+func matchesGitignore(relPath string, patterns []string) bool {
+	segments := strings.Split(relPath, string(filepath.Separator))
+	for _, pattern := range patterns {
+		cleaned := strings.TrimRight(pattern, "/")
+		// Segment match (e.g. "node_modules")
+		for _, seg := range segments {
+			if seg == cleaned {
+				return true
+			}
+		}
+		// Wildcard prefix (e.g. "*.log")
+		if strings.HasPrefix(cleaned, "*") && strings.HasSuffix(relPath, cleaned[1:]) {
+			return true
+		}
+		// Root-relative (e.g. "/dist")
+		if strings.HasPrefix(cleaned, "/") && strings.HasPrefix(relPath, cleaned[1:]) {
+			return true
+		}
+		// Direct prefix
+		if strings.HasPrefix(relPath, cleaned) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob performs simple glob matching on a relative path.
+func matchGlob(relPath string, pattern string) bool {
+	// Handle **/ prefix
+	normalised := strings.TrimPrefix(pattern, "**/")
+	// Try matching against both full path and basename
+	matched, _ := filepath.Match(normalised, relPath)
+	if matched {
+		return true
+	}
+	matched, _ = filepath.Match(normalised, filepath.Base(relPath))
+	return matched
+}

--- a/go/ingest/directory.go
+++ b/go/ingest/directory.go
@@ -42,10 +42,16 @@ type EnumeratedFile struct {
 // It excludes hidden files (dot-prefix), does not follow symlinks, respects
 // .gitignore patterns when present, applies glob filter if provided, enforces
 // maxFiles limit, and skips files over 25 MiB.
+//
+// The directory path is sanitised with filepath.Clean, and all enumerated
+// file paths are verified to reside within the cleaned directory boundary
+// to prevent path-traversal attacks.
 func EnumerateFiles(ctx context.Context, opts EnumerateOptions) ([]EnumeratedFile, []string, error) {
 	if opts.MaxFiles <= 0 {
 		opts.MaxFiles = 100
 	}
+
+	opts.Directory = filepath.Clean(opts.Directory)
 
 	gitignorePatterns := loadGitignore(opts.Directory)
 
@@ -89,6 +95,13 @@ func EnumerateFiles(ctx context.Context, opts EnumerateOptions) ([]EnumeratedFil
 			if !opts.Recursive && path != opts.Directory {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+
+		// Boundary check: ensure file is within the directory root.
+		cleaned := filepath.Clean(path)
+		if !strings.HasPrefix(cleaned, opts.Directory+string(filepath.Separator)) && cleaned != opts.Directory {
+			skipped = append(skipped, fmt.Sprintf("%s: path escapes directory boundary", relPath))
 			return nil
 		}
 
@@ -175,11 +188,14 @@ func matchesGitignore(relPath string, patterns []string) bool {
 			return true
 		}
 		// Root-relative (e.g. "/dist")
-		if strings.HasPrefix(cleaned, "/") && strings.HasPrefix(relPath, cleaned[1:]) {
-			return true
+		if strings.HasPrefix(cleaned, "/") {
+			trimmed := cleaned[1:]
+			if relPath == trimmed || strings.HasPrefix(relPath, trimmed+"/") {
+				return true
+			}
 		}
-		// Direct prefix
-		if strings.HasPrefix(relPath, cleaned) {
+		// Direct prefix (with path separator boundary)
+		if relPath == cleaned || strings.HasPrefix(relPath, cleaned+"/") {
 			return true
 		}
 	}

--- a/go/ingest/directory_test.go
+++ b/go/ingest/directory_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ingest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestEnumerateFiles_FlatDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), "# A")
+	writeTestFile(t, filepath.Join(dir, "b.md"), "# B")
+	writeTestFile(t, filepath.Join(dir, "c.md"), "# C")
+
+	files, skipped, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 3 {
+		t.Errorf("expected 3 files, got %d", len(files))
+	}
+	if len(skipped) != 0 {
+		t.Errorf("expected 0 skipped, got %d: %v", len(skipped), skipped)
+	}
+}
+
+func TestEnumerateFiles_GlobFilter(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), "markdown")
+	writeTestFile(t, filepath.Join(dir, "b.txt"), "text")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Glob:      "*.md",
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_NonRecursive(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "top.md"), "top")
+	writeTestFile(t, filepath.Join(dir, "sub", "nested.md"), "nested")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: false,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_MaxFilesLimit(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		writeTestFile(t, filepath.Join(dir, filepath.Base(t.Name())+string(rune('a'+i))+".md"), "content")
+	}
+
+	files, skipped, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  2,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+	found := false
+	for _, s := range skipped {
+		if s == "max files limit (2) reached" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected max files limit skip reason, got %v", skipped)
+	}
+}
+
+func TestEnumerateFiles_HiddenFilesExcluded(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, ".hidden.md"), "hidden")
+	writeTestFile(t, filepath.Join(dir, "visible.md"), "visible")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_GitignoreRespected(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, ".gitignore"), "node_modules\n*.log\n")
+	writeTestFile(t, filepath.Join(dir, "node_modules", "pkg.txt"), "pkg")
+	writeTestFile(t, filepath.Join(dir, "debug.log"), "logs")
+	writeTestFile(t, filepath.Join(dir, "readme.md"), "readme")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file (readme.md), got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_RecursiveByDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "top.md"), "top")
+	writeTestFile(t, filepath.Join(dir, "sub", "nested.md"), "nested")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_UnknownExtensionsSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "image.png"), "binary")
+	writeTestFile(t, filepath.Join(dir, "doc.md"), "markdown")
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}

--- a/go/ingest/directory_test.go
+++ b/go/ingest/directory_test.go
@@ -163,6 +163,57 @@ func TestEnumerateFiles_RecursiveByDefault(t *testing.T) {
 	}
 }
 
+func TestEnumerateFiles_MaxFilesOver500Rejection(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "a.md"), "content")
+
+	// EnumerateFiles respects maxFiles but does not enforce 500; the MCP tool
+	// layer enforces the 500 cap. Verify that maxFiles=501 still works at the
+	// library level (the restriction is in the tool, not here).
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  501,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestEnumerateFiles_SymlinksSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "real.md"), "real file")
+
+	// Create a symlink to a file outside the directory.
+	outsideDir := t.TempDir()
+	writeTestFile(t, filepath.Join(outsideDir, "secret.md"), "secret")
+	symPath := filepath.Join(dir, "link.md")
+	if err := os.Symlink(filepath.Join(outsideDir, "secret.md"), symPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	files, _, err := EnumerateFiles(context.Background(), EnumerateOptions{
+		Directory: dir,
+		Recursive: true,
+		MaxFiles:  100,
+	})
+	if err != nil {
+		t.Fatalf("enumerate: %v", err)
+	}
+	// Only the real file should be returned; symlink should be skipped.
+	if len(files) != 1 {
+		t.Errorf("expected 1 file (real.md only), got %d", len(files))
+	}
+	for _, f := range files {
+		if filepath.Base(f.Path) == "link.md" {
+			t.Error("symlink should have been skipped")
+		}
+	}
+}
+
 func TestEnumerateFiles_UnknownExtensionsSkipped(t *testing.T) {
 	dir := t.TempDir()
 	writeTestFile(t, filepath.Join(dir, "image.png"), "binary")

--- a/mcp/ts/src/server.test.ts
+++ b/mcp/ts/src/server.test.ts
@@ -70,6 +70,7 @@ describe('memory-mcp server', () => {
         'memory_create_brain',
         'memory_extract',
         'memory_ingest_batch',
+        'memory_ingest_directory',
         'memory_ingest_file',
         'memory_ingest_url',
         'memory_list_brains',

--- a/mcp/ts/src/tools/index.ts
+++ b/mcp/ts/src/tools/index.ts
@@ -5,6 +5,7 @@ import { consolidateTool } from './consolidate.js'
 import { createBrainTool } from './create-brain.js'
 import { extractTool } from './extract.js'
 import { ingestBatchTool } from './ingest-batch.js'
+import { ingestDirectoryTool } from './ingest-directory.js'
 import { ingestFileTool } from './ingest-file.js'
 import { ingestUrlTool } from './ingest-url.js'
 import { listBrainsTool } from './list-brains.js'
@@ -20,6 +21,7 @@ export const tools: readonly Tool[] = [
   searchTool,
   askTool,
   ingestBatchTool,
+  ingestDirectoryTool,
   ingestFileTool,
   ingestUrlTool,
   extractTool,

--- a/mcp/ts/src/tools/ingest-directory.ts
+++ b/mcp/ts/src/tools/ingest-directory.ts
@@ -6,6 +6,7 @@ import { enumerateFiles } from '@jeffs-brain/memory/ingest'
 import { type Tool, jsonContent } from './types.js'
 
 const MAX_FILES = 500
+const MAX_CONCURRENCY = 5
 
 const schema = z.object({
   directory: z.string().min(1).describe('Absolute path to directory'),
@@ -65,13 +66,14 @@ export const ingestDirectoryTool: Tool<typeof schema> = {
     })
 
     const total = enumerated.files.length
-    const results: DirectoryIngestFileResult[] = []
+    const results: DirectoryIngestFileResult[] = new Array(total)
     let succeeded = 0
     let failed = 0
+    let completed = 0
 
-    for (let i = 0; i < total; i++) {
-      const file = enumerated.files[i]
-      if (file === undefined) continue
+    const processFile = async (index: number): Promise<void> => {
+      const file = enumerated.files[index]
+      if (file === undefined) return
 
       try {
         const raw = await client.ingestFile(
@@ -84,26 +86,40 @@ export const ingestDirectoryTool: Tool<typeof schema> = {
 
         const ingestResult: IngestResult = isIngestResult(raw) ? raw : {}
 
-        results.push({
+        results[index] = {
           path: file.path,
           status: 'success',
           documentId: ingestResult.document_id,
           hash: ingestResult.hash,
           bytes: ingestResult.byte_size,
-        })
+        }
         succeeded++
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
-        results.push({
+        results[index] = {
           path: file.path,
           status: 'error',
           error: message,
-        })
+        }
         failed++
       }
 
-      ctx?.progress?.(i + 1, `${i + 1}/${total} ${file.path}`)
+      completed++
+      ctx?.progress?.(completed, `${completed}/${total} ${file.path}`)
     }
+
+    // Bounded concurrency pool: process up to MAX_CONCURRENCY files at a time.
+    const executing: Set<Promise<void>> = new Set()
+    for (let i = 0; i < total; i++) {
+      const task = processFile(i).then(() => {
+        executing.delete(task)
+      })
+      executing.add(task)
+      if (executing.size >= MAX_CONCURRENCY) {
+        await Promise.race(executing)
+      }
+    }
+    await Promise.all(executing)
 
     const directoryResult: DirectoryIngestResult = {
       total,
@@ -111,7 +127,7 @@ export const ingestDirectoryTool: Tool<typeof schema> = {
       failed,
       skipped: enumerated.skipped.length,
       skippedReasons: enumerated.skipped,
-      results,
+      results: results.filter((r): r is DirectoryIngestFileResult => r !== undefined),
     }
 
     return jsonContent(directoryResult)

--- a/mcp/ts/src/tools/ingest-directory.ts
+++ b/mcp/ts/src/tools/ingest-directory.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { isAbsolute, normalize, resolve } from 'node:path'
 import { z } from 'zod'
 import { enumerateFiles } from '@jeffs-brain/memory/ingest'
 import { type Tool, jsonContent } from './types.js'
@@ -13,6 +14,16 @@ const schema = z.object({
   recursive: z.boolean().optional().default(true),
   maxFiles: z.number().int().positive().max(MAX_FILES).optional().default(100),
 })
+
+/** Typed subset of the ingest response relevant to result reporting. */
+type IngestResult = {
+  readonly document_id?: string
+  readonly hash?: string
+  readonly byte_size?: number
+}
+
+const isIngestResult = (value: unknown): value is IngestResult =>
+  typeof value === 'object' && value !== null
 
 export type DirectoryIngestFileResult = {
   readonly path: string
@@ -38,8 +49,16 @@ export const ingestDirectoryTool: Tool<typeof schema> = {
     'Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering.',
   inputSchema: schema,
   async handler(args, client, ctx) {
+    const cleanedDir = resolve(normalize(args.directory))
+    if (!isAbsolute(cleanedDir)) {
+      throw new Error('memory_ingest_directory: directory must be an absolute path')
+    }
+    if (cleanedDir.includes('..')) {
+      throw new Error("memory_ingest_directory: directory path must not contain '..'")
+    }
+
     const enumerated = await enumerateFiles({
-      directory: args.directory,
+      directory: cleanedDir,
       glob: args.glob,
       recursive: args.recursive,
       maxFiles: args.maxFiles,
@@ -55,20 +74,22 @@ export const ingestDirectoryTool: Tool<typeof schema> = {
       if (file === undefined) continue
 
       try {
-        const ingestResult = (await client.ingestFile(
+        const raw = await client.ingestFile(
           {
             path: file.path,
             brain: args.brain,
           },
           ctx?.progress,
-        )) as Record<string, unknown>
+        )
+
+        const ingestResult: IngestResult = isIngestResult(raw) ? raw : {}
 
         results.push({
           path: file.path,
           status: 'success',
-          documentId: ingestResult.document_id as string | undefined,
-          hash: ingestResult.hash as string | undefined,
-          bytes: ingestResult.byte_size as number | undefined,
+          documentId: ingestResult.document_id,
+          hash: ingestResult.hash,
+          bytes: ingestResult.byte_size,
         })
         succeeded++
       } catch (err: unknown) {

--- a/mcp/ts/src/tools/ingest-directory.ts
+++ b/mcp/ts/src/tools/ingest-directory.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { z } from 'zod'
+import { enumerateFiles } from '@jeffs-brain/memory/ingest'
+import { type Tool, jsonContent } from './types.js'
+
+const MAX_FILES = 500
+
+const schema = z.object({
+  directory: z.string().min(1).describe('Absolute path to directory'),
+  glob: z.string().optional().describe('Glob pattern filter (e.g. "**/*.md")'),
+  brain: z.string().optional(),
+  recursive: z.boolean().optional().default(true),
+  maxFiles: z.number().int().positive().max(MAX_FILES).optional().default(100),
+})
+
+export type DirectoryIngestFileResult = {
+  readonly path: string
+  readonly status: 'success' | 'error' | 'skipped'
+  readonly documentId?: string | undefined
+  readonly hash?: string | undefined
+  readonly bytes?: number | undefined
+  readonly error?: string | undefined
+}
+
+export type DirectoryIngestResult = {
+  readonly total: number
+  readonly succeeded: number
+  readonly failed: number
+  readonly skipped: number
+  readonly skippedReasons: readonly string[]
+  readonly results: readonly DirectoryIngestFileResult[]
+}
+
+export const ingestDirectoryTool: Tool<typeof schema> = {
+  name: 'memory_ingest_directory',
+  description:
+    'Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering.',
+  inputSchema: schema,
+  async handler(args, client, ctx) {
+    const enumerated = await enumerateFiles({
+      directory: args.directory,
+      glob: args.glob,
+      recursive: args.recursive,
+      maxFiles: args.maxFiles,
+    })
+
+    const total = enumerated.files.length
+    const results: DirectoryIngestFileResult[] = []
+    let succeeded = 0
+    let failed = 0
+
+    for (let i = 0; i < total; i++) {
+      const file = enumerated.files[i]
+      if (file === undefined) continue
+
+      try {
+        const ingestResult = (await client.ingestFile(
+          {
+            path: file.path,
+            brain: args.brain,
+          },
+          ctx?.progress,
+        )) as Record<string, unknown>
+
+        results.push({
+          path: file.path,
+          status: 'success',
+          documentId: ingestResult.document_id as string | undefined,
+          hash: ingestResult.hash as string | undefined,
+          bytes: ingestResult.byte_size as number | undefined,
+        })
+        succeeded++
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        results.push({
+          path: file.path,
+          status: 'error',
+          error: message,
+        })
+        failed++
+      }
+
+      ctx?.progress?.(i + 1, `${i + 1}/${total} ${file.path}`)
+    }
+
+    const directoryResult: DirectoryIngestResult = {
+      total,
+      succeeded,
+      failed,
+      skipped: enumerated.skipped.length,
+      skippedReasons: enumerated.skipped,
+      results,
+    }
+
+    return jsonContent(directoryResult)
+  },
+}

--- a/sdks/ts/memory/src/ingest/directory.test.ts
+++ b/sdks/ts/memory/src/ingest/directory.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { enumerateFiles } from './directory.js'
+
+describe('enumerateFiles', () => {
+  let tmp: string
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'dir-enum-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true })
+  })
+
+  it('enumerates markdown files in a flat directory', async () => {
+    await writeFile(join(tmp, 'a.md'), '# A\nContent A')
+    await writeFile(join(tmp, 'b.md'), '# B\nContent B')
+    await writeFile(join(tmp, 'c.md'), '# C\nContent C')
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(3)
+    expect(result.skipped).toHaveLength(0)
+  })
+
+  it('applies glob filter to only match *.md files', async () => {
+    await writeFile(join(tmp, 'a.md'), 'markdown')
+    await writeFile(join(tmp, 'b.txt'), 'text')
+
+    const result = await enumerateFiles({ directory: tmp, glob: '*.md' })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('a.md')
+  })
+
+  it('respects recursive=false and only returns top-level files', async () => {
+    await writeFile(join(tmp, 'top.md'), 'top')
+    await mkdir(join(tmp, 'sub'))
+    await writeFile(join(tmp, 'sub', 'nested.md'), 'nested')
+
+    const result = await enumerateFiles({ directory: tmp, recursive: false })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('top.md')
+  })
+
+  it('respects maxFiles limit and reports skipped reason', async () => {
+    await writeFile(join(tmp, 'a.md'), 'a')
+    await writeFile(join(tmp, 'b.md'), 'b')
+    await writeFile(join(tmp, 'c.md'), 'c')
+    await writeFile(join(tmp, 'd.md'), 'd')
+    await writeFile(join(tmp, 'e.md'), 'e')
+
+    const result = await enumerateFiles({ directory: tmp, maxFiles: 2 })
+    expect(result.files).toHaveLength(2)
+    expect(result.skipped.some((s) => s.includes('max files limit'))).toBe(true)
+  })
+
+  it('excludes hidden files', async () => {
+    await writeFile(join(tmp, '.hidden.md'), 'hidden')
+    await writeFile(join(tmp, 'visible.md'), 'visible')
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('visible.md')
+  })
+
+  it('skips files with unknown extensions', async () => {
+    await writeFile(join(tmp, 'image.png'), 'binary')
+    await writeFile(join(tmp, 'doc.md'), 'markdown')
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('doc.md')
+  })
+
+  it('respects .gitignore patterns', async () => {
+    await writeFile(join(tmp, '.gitignore'), 'node_modules\n*.log\n')
+    await mkdir(join(tmp, 'node_modules'))
+    await writeFile(join(tmp, 'node_modules', 'pkg.txt'), 'pkg')
+    await writeFile(join(tmp, 'debug.log'), 'logs')
+    await writeFile(join(tmp, 'readme.md'), 'readme')
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('readme.md')
+  })
+
+  it('handles non-existent directory gracefully', async () => {
+    const result = await enumerateFiles({ directory: join(tmp, 'nonexistent') })
+    expect(result.files).toHaveLength(0)
+    expect(result.skipped.length).toBeGreaterThan(0)
+  })
+
+  it('walks subdirectories recursively by default', async () => {
+    await mkdir(join(tmp, 'sub'))
+    await writeFile(join(tmp, 'top.md'), 'top')
+    await writeFile(join(tmp, 'sub', 'nested.md'), 'nested')
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(2)
+  })
+})

--- a/sdks/ts/memory/src/ingest/directory.test.ts
+++ b/sdks/ts/memory/src/ingest/directory.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -102,5 +102,29 @@ describe('enumerateFiles', () => {
 
     const result = await enumerateFiles({ directory: tmp })
     expect(result.files).toHaveLength(2)
+  })
+
+  it('skips symlinks and only returns real files', async () => {
+    await writeFile(join(tmp, 'real.md'), 'real content')
+    const outsideDir = await mkdtemp(join(tmpdir(), 'dir-enum-outside-'))
+    await writeFile(join(outsideDir, 'secret.md'), 'secret')
+    try {
+      await symlink(join(outsideDir, 'secret.md'), join(tmp, 'link.md'))
+    } catch {
+      // Symlinks may not be supported on all platforms; skip test.
+      return
+    }
+
+    const result = await enumerateFiles({ directory: tmp })
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]?.path).toContain('real.md')
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('maxFiles > 500 still works at library level (cap is in MCP tool layer)', async () => {
+    await writeFile(join(tmp, 'a.md'), 'content')
+
+    const result = await enumerateFiles({ directory: tmp, maxFiles: 501 })
+    expect(result.files).toHaveLength(1)
   })
 })

--- a/sdks/ts/memory/src/ingest/directory.ts
+++ b/sdks/ts/memory/src/ingest/directory.ts
@@ -7,7 +7,7 @@
  */
 
 import { lstat, readFile, readdir } from 'node:fs/promises'
-import { extname, join, relative } from 'node:path'
+import { extname, join, normalize, relative, resolve } from 'node:path'
 
 const FILE_SIZE_LIMIT = 25 * 1024 * 1024
 const KNOWN_EXTENSIONS = new Set([
@@ -72,10 +72,13 @@ const matchesGitignore = (relativePath: string, patterns: readonly string[]): bo
     if (segments.some((seg) => seg === cleaned)) return true
     // Pattern with wildcard prefix (e.g. "*.log")
     if (cleaned.startsWith('*') && relativePath.endsWith(cleaned.slice(1))) return true
-    // Pattern starting with / means root-relative
-    if (cleaned.startsWith('/') && relativePath.startsWith(cleaned.slice(1))) return true
-    // Direct prefix match
-    if (relativePath.startsWith(cleaned)) return true
+    // Pattern starting with / means root-relative (with separator boundary)
+    if (cleaned.startsWith('/')) {
+      const trimmed = cleaned.slice(1)
+      if (relativePath === trimmed || relativePath.startsWith(trimmed + '/')) return true
+    }
+    // Direct prefix match (with separator boundary)
+    if (relativePath === cleaned || relativePath.startsWith(cleaned + '/')) return true
   }
   return false
 }
@@ -110,13 +113,14 @@ const matchesGlob = (filename: string, pattern: string): boolean => {
 export const enumerateFiles = async (opts: EnumerateOptions): Promise<EnumerateResult> => {
   const maxFiles = opts.maxFiles ?? 100
   const recursive = opts.recursive ?? true
+  const cleanedDirectory = resolve(normalize(opts.directory))
   const files: EnumeratedFile[] = []
   const skipped: string[] = []
 
   // Try to load .gitignore
   let gitignorePatterns: readonly string[] = []
   try {
-    const gitignoreContent = await readFile(join(opts.directory, '.gitignore'), 'utf8')
+    const gitignoreContent = await readFile(join(cleanedDirectory, '.gitignore'), 'utf8')
     gitignorePatterns = parseGitignore(gitignoreContent)
   } catch {
     // No .gitignore or unreadable — proceed without patterns
@@ -144,7 +148,11 @@ export const enumerateFiles = async (opts: EnumerateOptions): Promise<EnumerateR
       if (entry.name.startsWith('.')) continue
 
       const fullPath = join(dir, entry.name)
-      const relativePath = relative(opts.directory, fullPath)
+      const normalizedFull = resolve(normalize(fullPath))
+      const relativePath = relative(cleanedDirectory, normalizedFull)
+
+      // Boundary check: ensure path stays within the directory root.
+      if (relativePath.startsWith('..')) continue
 
       // Check .gitignore patterns
       if (gitignorePatterns.length > 0 && matchesGitignore(relativePath, gitignorePatterns)) {
@@ -190,6 +198,6 @@ export const enumerateFiles = async (opts: EnumerateOptions): Promise<EnumerateR
     }
   }
 
-  await walk(opts.directory)
+  await walk(cleanedDirectory)
   return { files, skipped }
 }

--- a/sdks/ts/memory/src/ingest/directory.ts
+++ b/sdks/ts/memory/src/ingest/directory.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Directory enumeration for the ingest pipeline. Walks a directory
+ * recursively, applies glob filtering, respects .gitignore patterns,
+ * and excludes hidden files and symlinks.
+ */
+
+import { lstat, readFile, readdir } from 'node:fs/promises'
+import { extname, join, relative } from 'node:path'
+
+const FILE_SIZE_LIMIT = 25 * 1024 * 1024
+const KNOWN_EXTENSIONS = new Set([
+  '.md',
+  '.markdown',
+  '.txt',
+  '.text',
+  '.pdf',
+  '.json',
+  '.html',
+  '.htm',
+  '.csv',
+  '.tsv',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.rst',
+  '.adoc',
+  '.org',
+  '.tex',
+  '.rtf',
+])
+
+export type EnumerateOptions = {
+  readonly directory: string
+  readonly glob?: string | undefined
+  readonly recursive?: boolean | undefined
+  readonly maxFiles?: number | undefined
+}
+
+export type EnumeratedFile = {
+  readonly path: string
+  readonly size: number
+}
+
+export type EnumerateResult = {
+  readonly files: readonly EnumeratedFile[]
+  readonly skipped: readonly string[]
+}
+
+/**
+ * Parse a simple .gitignore file into an array of patterns.
+ * Supports basic patterns: exact matches, leading /, trailing /,
+ * leading *, and negation is ignored for simplicity.
+ */
+const parseGitignore = (content: string): readonly string[] =>
+  content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '' && !line.startsWith('#') && !line.startsWith('!'))
+
+/**
+ * Check whether a relative path matches any of the gitignore patterns.
+ * This is a simplified matcher that handles the most common patterns.
+ */
+const matchesGitignore = (relativePath: string, patterns: readonly string[]): boolean => {
+  const segments = relativePath.split('/')
+  for (const pattern of patterns) {
+    const cleaned = pattern.replace(/\/$/, '')
+    // Direct segment match (e.g. "node_modules" matches any segment)
+    if (segments.some((seg) => seg === cleaned)) return true
+    // Pattern with wildcard prefix (e.g. "*.log")
+    if (cleaned.startsWith('*') && relativePath.endsWith(cleaned.slice(1))) return true
+    // Pattern starting with / means root-relative
+    if (cleaned.startsWith('/') && relativePath.startsWith(cleaned.slice(1))) return true
+    // Direct prefix match
+    if (relativePath.startsWith(cleaned)) return true
+  }
+  return false
+}
+
+/**
+ * Check whether a filename matches a glob pattern.
+ * Supports simple glob patterns: * (any chars), ? (single char), ** (recursive).
+ */
+const matchesGlob = (filename: string, pattern: string): boolean => {
+  // Strip leading **/ for recursive matching
+  const normalized = pattern.replace(/^\*\*\//, '')
+  const regexStr = normalized
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '__DOUBLESTAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLESTAR__/g, '.*')
+    .replace(/\?/g, '[^/]')
+  const regex = new RegExp(`^${regexStr}$`)
+  return regex.test(filename) || regex.test(filename.split('/').pop() ?? '')
+}
+
+/**
+ * Enumerate files in a directory suitable for ingestion.
+ *
+ * - Excludes hidden files (dot-prefix)
+ * - Does not follow symlinks
+ * - Respects .gitignore patterns when present
+ * - Applies glob filter if provided
+ * - Enforces maxFiles limit
+ * - Skips files over 25 MiB
+ */
+export const enumerateFiles = async (opts: EnumerateOptions): Promise<EnumerateResult> => {
+  const maxFiles = opts.maxFiles ?? 100
+  const recursive = opts.recursive ?? true
+  const files: EnumeratedFile[] = []
+  const skipped: string[] = []
+
+  // Try to load .gitignore
+  let gitignorePatterns: readonly string[] = []
+  try {
+    const gitignoreContent = await readFile(join(opts.directory, '.gitignore'), 'utf8')
+    gitignorePatterns = parseGitignore(gitignoreContent)
+  } catch {
+    // No .gitignore or unreadable — proceed without patterns
+  }
+
+  const walk = async (dir: string): Promise<void> => {
+    if (files.length >= maxFiles) return
+
+    let entries: Awaited<ReturnType<typeof readdir>>
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      skipped.push(`${dir}: ${message}`)
+      return
+    }
+
+    for (const entry of entries) {
+      if (files.length >= maxFiles) {
+        skipped.push(`max files limit (${maxFiles}) reached`)
+        return
+      }
+
+      // Skip hidden files/directories
+      if (entry.name.startsWith('.')) continue
+
+      const fullPath = join(dir, entry.name)
+      const relativePath = relative(opts.directory, fullPath)
+
+      // Check .gitignore patterns
+      if (gitignorePatterns.length > 0 && matchesGitignore(relativePath, gitignorePatterns)) {
+        continue
+      }
+
+      // Skip symlinks
+      try {
+        const fileStat = await lstat(fullPath)
+        if (fileStat.isSymbolicLink()) continue
+
+        if (fileStat.isDirectory()) {
+          if (recursive) {
+            await walk(fullPath)
+          }
+          continue
+        }
+
+        if (!fileStat.isFile()) continue
+
+        // Check file size
+        if (fileStat.size > FILE_SIZE_LIMIT) {
+          skipped.push(`${relativePath}: exceeds 25 MiB limit (${Math.round(fileStat.size / 1024 / 1024)} MiB)`)
+          continue
+        }
+
+        // Check glob filter
+        if (opts.glob !== undefined && !matchesGlob(relativePath, opts.glob)) {
+          continue
+        }
+
+        // Check if file has a known text extension (skip binary files)
+        const ext = extname(entry.name).toLowerCase()
+        if (ext !== '' && !KNOWN_EXTENSIONS.has(ext)) {
+          continue
+        }
+
+        files.push({ path: fullPath, size: fileStat.size })
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        skipped.push(`${relativePath}: ${message}`)
+      }
+    }
+  }
+
+  await walk(opts.directory)
+  return { files, skipped }
+}

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -127,3 +127,10 @@ export {
   type ExtractAfterIngestOptions,
   type ExtractAfterIngestResult,
 } from './extract-after-ingest.js'
+
+export {
+  enumerateFiles,
+  type EnumerateOptions,
+  type EnumeratedFile,
+  type EnumerateResult,
+} from './directory.js'

--- a/spec/MCP-TOOLS.md
+++ b/spec/MCP-TOOLS.md
@@ -196,6 +196,14 @@ Ingest up to 50 local files in a single call with per-file error isolation. Retu
 
 **Description**: "Ingest up to 50 local files in a single call. Returns per-file results."
 
+---
+
+## `memory_ingest_directory`
+
+Recursively ingest files from a directory with optional glob filtering and .gitignore support.
+
+**Description**: "Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering."
+
 **Input schema**
 
 ```
@@ -229,6 +237,50 @@ Each file entry is processed sequentially. A failure in file N does not prevent 
 ```
 
 **Progress**: When `progressToken` is present, emits one `notifications/progress` per file processed. Counter increments from 0 to `total - 1`. Message format: `"{completed}/{total} {currentFile}"`.
+
+---
+
+## `memory_ingest_directory`
+
+Recursively ingest files from a directory with optional glob filtering and .gitignore support.
+
+**Description**: "Ingest files from a directory. Walks recursively, respects .gitignore, and supports glob filtering."
+
+**Input schema**
+
+```
+{
+  directory: string            # absolute path to directory
+  glob?:     string            # glob pattern filter (e.g. "**/*.md")
+  brain?:    string
+  recursive?: boolean          # default true
+  maxFiles?: number            # max files to process (1-500, default 100)
+}
+```
+
+Hidden files (dot-prefix) are excluded by default. Symlinks are not followed. Files exceeding 25 MiB individually are skipped with a reason.
+
+**Output shape**
+
+```
+{
+  total:         number,
+  succeeded:     number,
+  failed:        number,
+  skipped:       number,
+  skippedReasons: string[],
+  results: Array<{
+    path:        string,
+    status:      'success' | 'error' | 'skipped',
+    documentId?: string,
+    hash?:       string,
+    bytes?:      number,
+    error?:      string,
+  }>
+}
+```
+
+**Progress**: When `progressToken` is present, emits one `notifications/progress` per file processed. Message format: `"{completed}/{total} {currentFile}"`.
 
 ---
 
@@ -613,6 +665,7 @@ Long-running tools emit MCP progress notifications using the standard `notificat
 | `memory_ingest_file` | **Reserved.** The v1.0 TS implementation does not emit `notifications/progress` frames; the tool runs synchronously end-to-end and the final response carries a `status` of `queued` or `completed`. | n/a | n/a |
 | `memory_ingest_url` | **Reserved.** Same as `memory_ingest_file`. | n/a | n/a |
 | `memory_ingest_batch` | Yes, when `progressToken` present. | Number of files processed so far (0-indexed). | `"{completed}/{total} {currentFile}"` — completed count, total count, and current file path. |
+| `memory_ingest_directory` | Yes, when `progressToken` present. | Number of files processed so far (0-indexed). | `"{completed}/{total} {currentFile}"` — completed count, total count, and current file path. |
 | `memory_consolidate` | **Reserved.** Fire-and-forget; the tool returns whatever `brains.consolidate`/`brains.compile` resolves with. | n/a | n/a |
 | `memory_reflect` | No. Synchronous close + reflect; no progress stream. | n/a | n/a |
 | All other tools | No. | n/a | n/a |


### PR DESCRIPTION
## Summary
- Add `memory_ingest_directory` MCP tool that recursively walks a directory, respects `.gitignore`, supports glob filtering, and ingests matching files
- Directory enumeration logic in both Go (`go/ingest/directory.go`) and TS (`sdks/ts/memory/src/ingest/directory.ts`) SDKs
- MCP tool handlers in both Go and TS with progress notifications per file

## Changes
- **TS SDK**: `directory.ts` with `enumerateFiles()` supporting glob, .gitignore, maxFiles, recursive, hidden/symlink exclusion
- **TS MCP**: `ingest-directory.ts` tool with zod validation (max 500 files per directory)
- **Go SDK**: `ingest/directory.go` with `EnumerateFiles` using `filepath.WalkDir`
- **Go MCP**: `ingest_directory.go` tool wired to directory enumeration
- **Tests**: 9 TS + 8 Go enumeration tests covering glob, .gitignore, hidden files, maxFiles, recursive mode, unknown extensions
- **Spec**: `spec/MCP-TOOLS.md` updated with `memory_ingest_directory` tool definition and progress table
- Updated tool count assertions in both TS and Go server tests (11 -> 12)

## Test plan
- [x] TS: enumerate markdown files in flat directory
- [x] TS: glob filter matches only *.md
- [x] TS: recursive=false returns top-level only
- [x] TS: maxFiles limit enforced with skip reason
- [x] TS: hidden files excluded
- [x] TS: unknown extensions skipped
- [x] TS: .gitignore patterns respected (node_modules, *.log)
- [x] TS: non-existent directory handled gracefully
- [x] TS: recursive walk returns nested files
- [x] Go: flat directory enumeration
- [x] Go: glob filter
- [x] Go: non-recursive mode
- [x] Go: maxFiles limit
- [x] Go: hidden files excluded
- [x] Go: .gitignore respected
- [x] Go: recursive walk
- [x] Go: unknown extensions skipped