### PR TITLE
feat: LLM-based ontology extraction from documents (P6-4, LLE-9792)

### DIFF
--- a/go/ontology/extract.go
+++ b/go/ontology/extract.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/jeffs-brain/memory/go/llm"
 )
@@ -136,12 +137,13 @@ func (e *Extractor) extractMultiSection(ctx context.Context, content string, par
 	sections := splitContent(content, SingleSectionThreshold)
 
 	var allResults []ExtractionResult
-	var discoveredTypes []TypeEntry
+	var discoveredNodeTypes []TypeEntry
+	var discoveredEdgeTypes []TypeEntry
 
 	for i, section := range sections {
 		prompt := buildOntologyExtractionPrompt(params.ExistingTypes)
-		if len(discoveredTypes) > 0 {
-			prompt += buildContextPrefix(discoveredTypes)
+		if len(discoveredNodeTypes) > 0 || len(discoveredEdgeTypes) > 0 {
+			prompt += buildContextPrefix(discoveredNodeTypes, discoveredEdgeTypes)
 		}
 
 		userMsg := buildUserMessage(section, params.FileName)
@@ -155,8 +157,8 @@ func (e *Extractor) extractMultiSection(ctx context.Context, content string, par
 		}
 
 		allResults = append(allResults, result)
-		discoveredTypes = append(discoveredTypes, result.NodeTypes...)
-		discoveredTypes = append(discoveredTypes, result.EdgeTypes...)
+		discoveredNodeTypes = append(discoveredNodeTypes, result.NodeTypes...)
+		discoveredEdgeTypes = append(discoveredEdgeTypes, result.EdgeTypes...)
 	}
 
 	if len(allResults) == 0 {
@@ -236,12 +238,12 @@ func parseExtractionResponse(text string) (ExtractionResult, error) {
 	}
 
 	for _, nt := range raw.NodeTypes {
-		if nt.Type != "" && nt.Label != "" && nt.Description != "" {
+		if nt.Type != "" && nt.Label != "" && nt.Description != "" && IsValidNodeType(nt.Type) {
 			result.NodeTypes = append(result.NodeTypes, nt)
 		}
 	}
 	for _, et := range raw.EdgeTypes {
-		if et.Type != "" && et.Label != "" && et.Description != "" {
+		if et.Type != "" && et.Label != "" && et.Description != "" && IsValidEdgeType(et.Type) {
 			result.EdgeTypes = append(result.EdgeTypes, et)
 		}
 	}
@@ -458,11 +460,13 @@ func fuzzyDedupByPrefix(nodeMap map[string]TypeEntry) map[string]TypeEntry {
 	for _, keys := range byPrefix {
 		for i := 0; i < len(keys); i++ {
 			for j := i + 1; j < len(keys); j++ {
-				entryI := nodeMap[keys[i]]
-				entryJ := nodeMap[keys[j]]
+				entryI, okI := nodeMap[keys[i]]
+				entryJ, okJ := nodeMap[keys[j]]
+				if !okI || !okJ {
+					continue
+				}
 				sim := JaroWinklerDistance(entryI.Label, entryJ.Label)
 				if sim >= FuzzyLabelMerge {
-					// Keep the one with the longer description
 					if len(entryJ.Description) > len(entryI.Description) {
 						delete(nodeMap, keys[i])
 					} else {
@@ -617,21 +621,52 @@ func buildExistingTypesSection(existing *ResolvedOntology) string {
 }
 
 func buildUserMessage(content, fileName string) string {
-	if fileName != "" {
-		return fmt.Sprintf("Document: %s\n\n%s", fileName, content)
+	sanitised := sanitiseFileName(fileName)
+	if sanitised != "" {
+		return fmt.Sprintf("Document: %s\n\n<ingested-document>\n%s\n</ingested-document>", sanitised, content)
 	}
-	return content
+	return fmt.Sprintf("<ingested-document>\n%s\n</ingested-document>", content)
 }
 
-func buildContextPrefix(discoveredTypes []TypeEntry) string {
+// sanitiseFileName strips newlines, control characters, and trims the
+// filename to prevent prompt injection via crafted file names.
+func sanitiseFileName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	result := strings.TrimSpace(b.String())
+	if len(result) > 256 {
+		result = result[:256]
+	}
+	return result
+}
+
+func buildContextPrefix(nodeTypes, edgeTypes []TypeEntry) string {
 	var b strings.Builder
 	b.WriteString("\n\nTypes discovered from earlier sections of this document (avoid duplicating these):\n")
-	for _, t := range discoveredTypes {
-		b.WriteString("- ")
-		b.WriteString(t.Type)
-		b.WriteString(": ")
-		b.WriteString(t.Label)
-		b.WriteByte('\n')
+	if len(nodeTypes) > 0 {
+		b.WriteString("\nDiscovered node types:\n")
+		for _, t := range nodeTypes {
+			b.WriteString("- ")
+			b.WriteString(t.Type)
+			b.WriteString(": ")
+			b.WriteString(t.Label)
+			b.WriteByte('\n')
+		}
+	}
+	if len(edgeTypes) > 0 {
+		b.WriteString("\nDiscovered edge types:\n")
+		for _, t := range edgeTypes {
+			b.WriteString("- ")
+			b.WriteString(t.Type)
+			b.WriteString(": ")
+			b.WriteString(t.Label)
+			b.WriteByte('\n')
+		}
 	}
 	return b.String()
 }
@@ -691,16 +726,24 @@ func splitTabularContent(content string, maxBytes int) []string {
 		return []string{content}
 	}
 
-	samplesPerSection := 3
+	headerBytes := len(header) + 1 // +1 for the newline after header
 	var sections []string
+	var sectionLines []string
+	currentBytes := headerBytes
 
-	for i := 0; i < len(dataLines); i += samplesPerSection {
-		end := i + samplesPerSection
-		if end > len(dataLines) {
-			end = len(dataLines)
+	for _, line := range dataLines {
+		lineBytes := len(line) + 1 // +1 for newline
+		if currentBytes+lineBytes > maxBytes && len(sectionLines) > 0 {
+			sections = append(sections, header+"\n"+strings.Join(sectionLines, "\n"))
+			sectionLines = sectionLines[:0]
+			currentBytes = headerBytes
 		}
-		section := header + "\n" + strings.Join(dataLines[i:end], "\n")
-		sections = append(sections, section)
+		sectionLines = append(sectionLines, line)
+		currentBytes += lineBytes
+	}
+
+	if len(sectionLines) > 0 {
+		sections = append(sections, header+"\n"+strings.Join(sectionLines, "\n"))
 	}
 
 	return sections

--- a/go/ontology/extract.go
+++ b/go/ontology/extract.go
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+// Extraction constants ported from the intelligence service.
+const (
+	// SingleSectionThreshold is the byte count above which content is
+	// split into multiple sections for extraction.
+	SingleSectionThreshold = 8000
+
+	// ExtractionTemperature is the LLM temperature used for extraction.
+	ExtractionTemperature = 0.1
+
+	// FuzzyLabelMerge is the Jaro-Winkler threshold for merging
+	// similarly-labelled types during multi-section extraction.
+	FuzzyLabelMerge = 0.88
+
+	// ConfidenceFloor is the minimum confidence value considered in
+	// noisy-OR aggregation.
+	ConfidenceFloor = 0.3
+
+	// ConfidenceCap is the maximum confidence value returned by
+	// noisy-OR aggregation.
+	ConfidenceCap = 0.99
+
+	// extractionMaxRetries is the maximum number of retries when the
+	// LLM returns malformed output.
+	extractionMaxRetries = 2
+)
+
+// ExtractionResult holds extracted ontology types from a document.
+type ExtractionResult struct {
+	NodeTypes          []TypeEntry `json:"nodeTypes"`
+	EdgeTypes          []TypeEntry `json:"edgeTypes"`
+	BusinessCategories []string    `json:"businessCategories"`
+	Domain             string      `json:"domain"`
+	Confidence         float64     `json:"confidence"`
+}
+
+// ExtractionParams configures an extraction request.
+type ExtractionParams struct {
+	Content       string
+	FileName      string
+	ExistingTypes *ResolvedOntology
+}
+
+// ExtractorConfig configures an Extractor.
+type ExtractorConfig struct {
+	// Provider is the LLM provider for extraction. If nil, Extract
+	// returns an empty result without error.
+	Provider llm.Provider
+
+	// Temperature overrides the default ExtractionTemperature.
+	// Zero uses the default.
+	Temperature float64
+
+	// MaxRetries overrides the default retry count for malformed output.
+	// Zero uses the default (2).
+	MaxRetries int
+}
+
+// Extractor performs LLM-powered ontology extraction from documents.
+type Extractor struct {
+	provider    llm.Provider
+	temperature float64
+	maxRetries  int
+}
+
+// NewExtractor creates an extractor. If provider is nil, Extract
+// returns empty results.
+func NewExtractor(provider llm.Provider) *Extractor {
+	return NewExtractorWithConfig(ExtractorConfig{Provider: provider})
+}
+
+// NewExtractorWithConfig creates an extractor with configurable options.
+func NewExtractorWithConfig(cfg ExtractorConfig) *Extractor {
+	temp := cfg.Temperature
+	if temp == 0 {
+		temp = ExtractionTemperature
+	}
+	retries := cfg.MaxRetries
+	if retries == 0 {
+		retries = extractionMaxRetries
+	}
+	return &Extractor{
+		provider:    cfg.Provider,
+		temperature: temp,
+		maxRetries:  retries,
+	}
+}
+
+// Extract analyses document content and returns discovered ontology types.
+// Returns an empty result without error when the provider is nil.
+func (e *Extractor) Extract(ctx context.Context, params ExtractionParams) (ExtractionResult, error) {
+	if e.provider == nil {
+		return emptyExtractionResult(), nil
+	}
+
+	content := params.Content
+	if len(content) == 0 {
+		return emptyExtractionResult(), nil
+	}
+
+	if len(content) <= SingleSectionThreshold {
+		return e.extractSingleSection(ctx, content, params)
+	}
+
+	return e.extractMultiSection(ctx, content, params)
+}
+
+func (e *Extractor) extractSingleSection(ctx context.Context, content string, params ExtractionParams) (ExtractionResult, error) {
+	prompt := buildOntologyExtractionPrompt(params.ExistingTypes)
+	userMsg := buildUserMessage(content, params.FileName)
+
+	result, err := e.callLLMWithRetry(ctx, prompt, userMsg)
+	if err != nil {
+		return emptyExtractionResult(), err
+	}
+
+	if params.ExistingTypes != nil {
+		result = filterExistingTypes(result, params.ExistingTypes)
+	}
+
+	return result, nil
+}
+
+func (e *Extractor) extractMultiSection(ctx context.Context, content string, params ExtractionParams) (ExtractionResult, error) {
+	sections := splitContent(content, SingleSectionThreshold)
+
+	var allResults []ExtractionResult
+	var discoveredTypes []TypeEntry
+
+	for i, section := range sections {
+		prompt := buildOntologyExtractionPrompt(params.ExistingTypes)
+		if len(discoveredTypes) > 0 {
+			prompt += buildContextPrefix(discoveredTypes)
+		}
+
+		userMsg := buildUserMessage(section, params.FileName)
+		if len(sections) > 1 {
+			userMsg = fmt.Sprintf("[Section %d of %d]\n\n%s", i+1, len(sections), userMsg)
+		}
+
+		result, err := e.callLLMWithRetry(ctx, prompt, userMsg)
+		if err != nil {
+			return emptyExtractionResult(), fmt.Errorf("ontology: extraction section %d: %w", i+1, err)
+		}
+
+		allResults = append(allResults, result)
+		discoveredTypes = append(discoveredTypes, result.NodeTypes...)
+		discoveredTypes = append(discoveredTypes, result.EdgeTypes...)
+	}
+
+	if len(allResults) == 0 {
+		return emptyExtractionResult(), nil
+	}
+
+	merged := mergeOntologyExtractions(allResults)
+
+	if params.ExistingTypes != nil {
+		merged = filterExistingTypes(merged, params.ExistingTypes)
+	}
+
+	return merged, nil
+}
+
+func (e *Extractor) callLLMWithRetry(ctx context.Context, systemPrompt, userMsg string) (ExtractionResult, error) {
+	messages := []llm.Message{
+		{Role: llm.RoleSystem, Content: systemPrompt},
+		{Role: llm.RoleUser, Content: userMsg},
+	}
+
+	for attempt := 0; attempt <= e.maxRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return emptyExtractionResult(), err
+		}
+
+		resp, err := e.provider.Complete(ctx, llm.CompleteRequest{
+			Messages:           messages,
+			Temperature:        e.temperature,
+			MaxTokens:          4096,
+			ResponseFormatJSON: true,
+		})
+		if err != nil {
+			return emptyExtractionResult(), fmt.Errorf("ontology: llm complete: %w", err)
+		}
+
+		result, parseErr := parseExtractionResponse(resp.Text)
+		if parseErr == nil {
+			return result, nil
+		}
+
+		if attempt < e.maxRetries {
+			messages = append(messages,
+				llm.Message{Role: llm.RoleAssistant, Content: resp.Text},
+				llm.Message{Role: llm.RoleUser, Content: "Your previous response was not valid JSON matching the expected schema. Return only valid JSON with the keys: domain, confidence, nodeTypes, edgeTypes, businessCategories."},
+			)
+			continue
+		}
+
+		return emptyExtractionResult(), fmt.Errorf("ontology: extraction failed after %d retries: %w", e.maxRetries, parseErr)
+	}
+
+	return emptyExtractionResult(), fmt.Errorf("ontology: extraction exhausted retries")
+}
+
+func parseExtractionResponse(text string) (ExtractionResult, error) {
+	jsonStr, err := extractJSONFromText(text)
+	if err != nil {
+		return emptyExtractionResult(), err
+	}
+
+	var raw rawExtractionResult
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return emptyExtractionResult(), fmt.Errorf("ontology: JSON unmarshal: %w", err)
+	}
+
+	if raw.Domain == "" {
+		return emptyExtractionResult(), fmt.Errorf("ontology: missing required field 'domain'")
+	}
+
+	result := ExtractionResult{
+		Domain:             raw.Domain,
+		Confidence:         raw.Confidence,
+		NodeTypes:          make([]TypeEntry, 0, len(raw.NodeTypes)),
+		EdgeTypes:          make([]TypeEntry, 0, len(raw.EdgeTypes)),
+		BusinessCategories: make([]string, 0, len(raw.BusinessCategories)),
+	}
+
+	for _, nt := range raw.NodeTypes {
+		if nt.Type != "" && nt.Label != "" && nt.Description != "" {
+			result.NodeTypes = append(result.NodeTypes, nt)
+		}
+	}
+	for _, et := range raw.EdgeTypes {
+		if et.Type != "" && et.Label != "" && et.Description != "" {
+			result.EdgeTypes = append(result.EdgeTypes, et)
+		}
+	}
+	for _, cat := range raw.BusinessCategories {
+		if cat != "" {
+			result.BusinessCategories = append(result.BusinessCategories, cat)
+		}
+	}
+
+	return result, nil
+}
+
+// rawExtractionResult is the JSON shape returned by the LLM.
+type rawExtractionResult struct {
+	Domain             string      `json:"domain"`
+	Confidence         float64     `json:"confidence"`
+	NodeTypes          []TypeEntry `json:"nodeTypes"`
+	EdgeTypes          []TypeEntry `json:"edgeTypes"`
+	BusinessCategories []string    `json:"businessCategories"`
+}
+
+// extractJSONFromText finds the first JSON object in a text response.
+func extractJSONFromText(text string) (string, error) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return "", fmt.Errorf("ontology: empty response from LLM")
+	}
+
+	start := strings.IndexByte(trimmed, '{')
+	if start < 0 {
+		return "", fmt.Errorf("ontology: no JSON object found in response")
+	}
+
+	depth := 0
+	inString := false
+	escaping := false
+
+	for i := start; i < len(trimmed); i++ {
+		ch := trimmed[i]
+		if escaping {
+			escaping = false
+			continue
+		}
+		if inString {
+			if ch == '\\' {
+				escaping = true
+			} else if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				candidate := trimmed[start : i+1]
+				var check json.RawMessage
+				if json.Unmarshal([]byte(candidate), &check) == nil {
+					return candidate, nil
+				}
+				return "", fmt.Errorf("ontology: extracted JSON is not valid")
+			}
+		}
+	}
+
+	return "", fmt.Errorf("ontology: unclosed JSON object in response")
+}
+
+// NoisyOr computes the noisy-OR confidence aggregation.
+// Filters values below ConfidenceFloor, caps at ConfidenceCap.
+// Returns 0 for empty input.
+func NoisyOr(confidences []float64) float64 {
+	if len(confidences) == 0 {
+		return 0
+	}
+
+	var filtered []float64
+	for _, c := range confidences {
+		if c >= ConfidenceFloor {
+			filtered = append(filtered, c)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return 0
+	}
+
+	if len(filtered) == 1 {
+		if filtered[0] > ConfidenceCap {
+			return ConfidenceCap
+		}
+		return filtered[0]
+	}
+
+	product := 1.0
+	for _, c := range filtered {
+		product *= (1.0 - c)
+	}
+
+	result := 1.0 - product
+	if result > ConfidenceCap {
+		return ConfidenceCap
+	}
+	return result
+}
+
+func emptyExtractionResult() ExtractionResult {
+	return ExtractionResult{
+		NodeTypes:          []TypeEntry{},
+		EdgeTypes:          []TypeEntry{},
+		BusinessCategories: []string{},
+	}
+}
+
+// mergeOntologyExtractions merges results from multi-section extraction.
+// Deduplicates by type key (keeps longest description), fuzzy-deduplicates
+// labels within the same prefix (Jaro-Winkler >= 0.88), and aggregates
+// confidence via noisy-OR.
+func mergeOntologyExtractions(results []ExtractionResult) ExtractionResult {
+	if len(results) == 0 {
+		return emptyExtractionResult()
+	}
+	if len(results) == 1 {
+		return results[0]
+	}
+
+	nodeMap := make(map[string]TypeEntry)
+	edgeMap := make(map[string]TypeEntry)
+	catSet := make(map[string]struct{})
+	domains := make(map[string]int)
+	var confidences []float64
+
+	for _, r := range results {
+		for _, nt := range r.NodeTypes {
+			if existing, ok := nodeMap[nt.Type]; ok {
+				if len(nt.Description) > len(existing.Description) {
+					nodeMap[nt.Type] = nt
+				}
+			} else {
+				nodeMap[nt.Type] = nt
+			}
+		}
+		for _, et := range r.EdgeTypes {
+			if existing, ok := edgeMap[et.Type]; ok {
+				if len(et.Description) > len(existing.Description) {
+					edgeMap[et.Type] = et
+				}
+			} else {
+				edgeMap[et.Type] = et
+			}
+		}
+		for _, cat := range r.BusinessCategories {
+			catSet[cat] = struct{}{}
+		}
+		if r.Domain != "" {
+			domains[r.Domain]++
+		}
+		if r.Confidence > 0 {
+			confidences = append(confidences, r.Confidence)
+		}
+	}
+
+	// Fuzzy-dedup labels within same prefix
+	nodeMap = fuzzyDedupByPrefix(nodeMap)
+	edgeMap = fuzzyDedupEdges(edgeMap)
+
+	nodeTypes := make([]TypeEntry, 0, len(nodeMap))
+	for _, nt := range nodeMap {
+		nodeTypes = append(nodeTypes, nt)
+	}
+
+	edgeTypes := make([]TypeEntry, 0, len(edgeMap))
+	for _, et := range edgeMap {
+		edgeTypes = append(edgeTypes, et)
+	}
+
+	categories := make([]string, 0, len(catSet))
+	for cat := range catSet {
+		categories = append(categories, cat)
+	}
+
+	bestDomain := ""
+	bestCount := 0
+	for domain, count := range domains {
+		if count > bestCount {
+			bestCount = count
+			bestDomain = domain
+		}
+	}
+
+	return ExtractionResult{
+		NodeTypes:          nodeTypes,
+		EdgeTypes:          edgeTypes,
+		BusinessCategories: categories,
+		Domain:             bestDomain,
+		Confidence:         NoisyOr(confidences),
+	}
+}
+
+// fuzzyDedupByPrefix groups node types by prefix and merges entries
+// whose labels are >= FuzzyLabelMerge similar, keeping the one with
+// the longer description.
+func fuzzyDedupByPrefix(nodeMap map[string]TypeEntry) map[string]TypeEntry {
+	byPrefix := make(map[string][]string)
+	for key := range nodeMap {
+		prefix := typePrefix(key)
+		byPrefix[prefix] = append(byPrefix[prefix], key)
+	}
+
+	for _, keys := range byPrefix {
+		for i := 0; i < len(keys); i++ {
+			for j := i + 1; j < len(keys); j++ {
+				entryI := nodeMap[keys[i]]
+				entryJ := nodeMap[keys[j]]
+				sim := JaroWinklerDistance(entryI.Label, entryJ.Label)
+				if sim >= FuzzyLabelMerge {
+					// Keep the one with the longer description
+					if len(entryJ.Description) > len(entryI.Description) {
+						delete(nodeMap, keys[i])
+					} else {
+						delete(nodeMap, keys[j])
+					}
+				}
+			}
+		}
+	}
+	return nodeMap
+}
+
+// fuzzyDedupEdges merges edge types whose labels are >= FuzzyLabelMerge
+// similar, keeping the one with the longer description.
+func fuzzyDedupEdges(edgeMap map[string]TypeEntry) map[string]TypeEntry {
+	keys := make([]string, 0, len(edgeMap))
+	for k := range edgeMap {
+		keys = append(keys, k)
+	}
+
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			entryI, okI := edgeMap[keys[i]]
+			entryJ, okJ := edgeMap[keys[j]]
+			if !okI || !okJ {
+				continue
+			}
+			sim := JaroWinklerDistance(entryI.Label, entryJ.Label)
+			if sim >= FuzzyLabelMerge {
+				if len(entryJ.Description) > len(entryI.Description) {
+					delete(edgeMap, keys[i])
+				} else {
+					delete(edgeMap, keys[j])
+				}
+			}
+		}
+	}
+	return edgeMap
+}
+
+func filterExistingTypes(result ExtractionResult, existing *ResolvedOntology) ExtractionResult {
+	existingNodeSet := make(map[string]struct{}, len(existing.NodeTypes))
+	for _, nt := range existing.NodeTypes {
+		existingNodeSet[nt.Type] = struct{}{}
+	}
+
+	existingEdgeSet := make(map[string]struct{}, len(existing.EdgeTypes))
+	for _, et := range existing.EdgeTypes {
+		existingEdgeSet[et.Type] = struct{}{}
+	}
+
+	existingCatSet := make(map[string]struct{}, len(existing.BusinessCategories))
+	for _, cat := range existing.BusinessCategories {
+		existingCatSet[cat] = struct{}{}
+	}
+
+	filtered := ExtractionResult{
+		Domain:             result.Domain,
+		Confidence:         result.Confidence,
+		NodeTypes:          make([]TypeEntry, 0, len(result.NodeTypes)),
+		EdgeTypes:          make([]TypeEntry, 0, len(result.EdgeTypes)),
+		BusinessCategories: make([]string, 0, len(result.BusinessCategories)),
+	}
+
+	for _, nt := range result.NodeTypes {
+		if _, exists := existingNodeSet[nt.Type]; !exists {
+			filtered.NodeTypes = append(filtered.NodeTypes, nt)
+		}
+	}
+	for _, et := range result.EdgeTypes {
+		if _, exists := existingEdgeSet[et.Type]; !exists {
+			filtered.EdgeTypes = append(filtered.EdgeTypes, et)
+		}
+	}
+	for _, cat := range result.BusinessCategories {
+		if _, exists := existingCatSet[cat]; !exists {
+			filtered.BusinessCategories = append(filtered.BusinessCategories, cat)
+		}
+	}
+
+	return filtered
+}
+
+// buildOntologyExtractionPrompt constructs the system prompt for ontology extraction.
+func buildOntologyExtractionPrompt(existingTypes *ResolvedOntology) string {
+	prompt := `You are a domain ontology analyst. Analyse this document and extract the SCHEMA -- the types of entities, rules, and relationships that exist in this domain.
+
+Do NOT extract individual data items or instances. Instead, identify the CATEGORIES and TYPES of things described.
+
+For each discovered type, provide:
+- type: A dotted identifier following the pattern prefix.name where prefix is one of: entity, rule, exception, decision, process. The name should be snake_case.
+- label: A human-readable name
+- description: A one-sentence explanation of what this type represents
+
+Also identify:
+- Edge types: the kinds of relationships between entities (use snake_case identifiers like requires, compatible_with, belongs_to)
+- Business categories: the high-level domain areas covered (use snake_case like server_hardware, customer_management)
+
+Analyse the document structure, column headers, data patterns, and content to infer the domain ontology.
+
+Examples of good ontology design patterns:
+
+Pattern 1 - Entity-Rule binding:
+entity.product is constrained by rule.pricing via the "constrains" edge.
+
+Pattern 2 - Process-Decision-Exception:
+process.approval_chain contains decision.escalation points that may trigger exception.override.
+
+Pattern 3 - Classification hierarchy:
+entity.category relates to entity.subcategory via "belongs_to" edge.
+
+Return your analysis as a JSON object with the following structure:
+{
+  "domain": "string describing the domain",
+  "confidence": 0.0 to 1.0,
+  "nodeTypes": [{"type": "prefix.name", "label": "Human Label", "description": "One sentence"}],
+  "edgeTypes": [{"type": "snake_case_name", "label": "Human Label", "description": "One sentence"}],
+  "businessCategories": ["snake_case_category"]
+}`
+
+	if existingTypes != nil && (len(existingTypes.NodeTypes) > 0 || len(existingTypes.EdgeTypes) > 0) {
+		prompt += "\n\nThe following types already exist in the ontology. Do NOT include these in your response -- only return NEW types that are not already present:\n"
+		prompt += buildExistingTypesSection(existingTypes)
+	}
+
+	return prompt
+}
+
+func buildExistingTypesSection(existing *ResolvedOntology) string {
+	var b strings.Builder
+	if len(existing.NodeTypes) > 0 {
+		b.WriteString("\nExisting node types:\n")
+		for _, nt := range existing.NodeTypes {
+			b.WriteString("- ")
+			b.WriteString(nt.Type)
+			b.WriteString(": ")
+			b.WriteString(nt.Label)
+			b.WriteByte('\n')
+		}
+	}
+	if len(existing.EdgeTypes) > 0 {
+		b.WriteString("\nExisting edge types:\n")
+		for _, et := range existing.EdgeTypes {
+			b.WriteString("- ")
+			b.WriteString(et.Type)
+			b.WriteString(": ")
+			b.WriteString(et.Label)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func buildUserMessage(content, fileName string) string {
+	if fileName != "" {
+		return fmt.Sprintf("Document: %s\n\n%s", fileName, content)
+	}
+	return content
+}
+
+func buildContextPrefix(discoveredTypes []TypeEntry) string {
+	var b strings.Builder
+	b.WriteString("\n\nTypes discovered from earlier sections of this document (avoid duplicating these):\n")
+	for _, t := range discoveredTypes {
+		b.WriteString("- ")
+		b.WriteString(t.Type)
+		b.WriteString(": ")
+		b.WriteString(t.Label)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// splitContent splits content into sections of approximately maxBytes.
+// If the content appears tabular (CSV/pipe-delimited), it samples the
+// header plus 3 data rows per section. Otherwise, it splits on markdown
+// headings or at byte boundaries.
+func splitContent(content string, maxBytes int) []string {
+	if len(content) <= maxBytes {
+		return []string{content}
+	}
+
+	if isTabularContent(content) {
+		return splitTabularContent(content, maxBytes)
+	}
+
+	return splitByHeadingsOrBytes(content, maxBytes)
+}
+
+// isTabularContent returns true if the content looks like CSV/TSV data.
+// Heuristic: >= 2 delimiters per line on >= 3 of the first 5 lines.
+func isTabularContent(content string) bool {
+	lines := strings.SplitN(content, "\n", 6)
+	if len(lines) < 3 {
+		return false
+	}
+
+	limit := 5
+	if len(lines) < limit {
+		limit = len(lines)
+	}
+
+	tabularLines := 0
+	for i := 0; i < limit; i++ {
+		line := lines[i]
+		commas := strings.Count(line, ",")
+		pipes := strings.Count(line, "|")
+		if commas >= 2 || pipes >= 2 {
+			tabularLines++
+		}
+	}
+
+	return tabularLines >= 3
+}
+
+func splitTabularContent(content string, maxBytes int) []string {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 {
+		return []string{content}
+	}
+
+	header := lines[0]
+	dataLines := lines[1:]
+
+	if len(dataLines) == 0 {
+		return []string{content}
+	}
+
+	samplesPerSection := 3
+	var sections []string
+
+	for i := 0; i < len(dataLines); i += samplesPerSection {
+		end := i + samplesPerSection
+		if end > len(dataLines) {
+			end = len(dataLines)
+		}
+		section := header + "\n" + strings.Join(dataLines[i:end], "\n")
+		sections = append(sections, section)
+	}
+
+	return sections
+}
+
+func splitByHeadingsOrBytes(content string, maxBytes int) []string {
+	lines := strings.Split(content, "\n")
+	var sections []string
+	var currentSection strings.Builder
+	currentBytes := 0
+
+	for _, line := range lines {
+		lineBytes := len(line) + 1 // +1 for newline
+
+		isHeading := strings.HasPrefix(line, "# ") ||
+			strings.HasPrefix(line, "## ") ||
+			strings.HasPrefix(line, "### ")
+
+		if isHeading && currentBytes > 0 {
+			sections = append(sections, currentSection.String())
+			currentSection.Reset()
+			currentBytes = 0
+		}
+
+		if currentBytes+lineBytes > maxBytes && currentBytes > 0 {
+			sections = append(sections, currentSection.String())
+			currentSection.Reset()
+			currentBytes = 0
+		}
+
+		if currentBytes > 0 {
+			currentSection.WriteByte('\n')
+			currentBytes++
+		}
+		currentSection.WriteString(line)
+		currentBytes += len(line)
+	}
+
+	if currentBytes > 0 {
+		sections = append(sections, currentSection.String())
+	}
+
+	return sections
+}

--- a/go/ontology/extract_test.go
+++ b/go/ontology/extract_test.go
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+func TestExtract_NilProvider(t *testing.T) {
+	t.Parallel()
+	ext := NewExtractor(nil)
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  "Some document content about servers and hardware.",
+		FileName: "servers.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.NodeTypes) != 0 {
+		t.Fatalf("expected 0 node types, got %d", len(result.NodeTypes))
+	}
+	if len(result.EdgeTypes) != 0 {
+		t.Fatalf("expected 0 edge types, got %d", len(result.EdgeTypes))
+	}
+	if len(result.BusinessCategories) != 0 {
+		t.Fatalf("expected 0 business categories, got %d", len(result.BusinessCategories))
+	}
+}
+
+func TestExtract_EmptyContent(t *testing.T) {
+	t.Parallel()
+	ext := NewExtractor(llm.NewFake([]string{`{}`}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content: "",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.NodeTypes) != 0 {
+		t.Fatalf("expected 0 node types, got %d", len(result.NodeTypes))
+	}
+}
+
+func makeLLMResponse(domain string, confidence float64, nodeTypes []TypeEntry, edgeTypes []TypeEntry, categories []string) string {
+	raw := rawExtractionResult{
+		Domain:             domain,
+		Confidence:         confidence,
+		NodeTypes:          nodeTypes,
+		EdgeTypes:          edgeTypes,
+		BusinessCategories: categories,
+	}
+	data, _ := json.Marshal(raw)
+	return string(data)
+}
+
+func TestExtract_SingleSection(t *testing.T) {
+	t.Parallel()
+	response := makeLLMResponse("healthcare", 0.85, []TypeEntry{
+		{Type: "entity.patient", Label: "Patient", Description: "A person receiving care"},
+		{Type: "rule.clinical_protocol", Label: "Clinical Protocol", Description: "A clinical treatment rule"},
+	}, []TypeEntry{
+		{Type: "treats", Label: "Treats", Description: "Treatment relationship"},
+	}, []string{"patient_care"})
+
+	ext := NewExtractor(llm.NewFake([]string{response}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  "Short healthcare document about patients and treatments.",
+		FileName: "healthcare.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Domain != "healthcare" {
+		t.Fatalf("expected domain healthcare, got %s", result.Domain)
+	}
+	if result.Confidence != 0.85 {
+		t.Fatalf("expected confidence 0.85, got %f", result.Confidence)
+	}
+	if len(result.NodeTypes) != 2 {
+		t.Fatalf("expected 2 node types, got %d", len(result.NodeTypes))
+	}
+	if len(result.EdgeTypes) != 1 {
+		t.Fatalf("expected 1 edge type, got %d", len(result.EdgeTypes))
+	}
+	if len(result.BusinessCategories) != 1 {
+		t.Fatalf("expected 1 business category, got %d", len(result.BusinessCategories))
+	}
+}
+
+func TestExtract_MultiSection(t *testing.T) {
+	t.Parallel()
+	// Create content larger than SingleSectionThreshold
+	longContent := generateLongContent(SingleSectionThreshold + 1000)
+
+	response1 := makeLLMResponse("finance", 0.7, []TypeEntry{
+		{Type: "entity.account", Label: "Account", Description: "A financial account"},
+	}, []TypeEntry{
+		{Type: "holds", Label: "Holds", Description: "An account holds assets"},
+	}, []string{"retail_banking"})
+
+	response2 := makeLLMResponse("finance", 0.8, []TypeEntry{
+		{Type: "entity.payment", Label: "Payment", Description: "A transfer of funds between accounts"},
+	}, []TypeEntry{
+		{Type: "settles", Label: "Settles", Description: "A transaction settles"},
+	}, []string{"payments"})
+
+	ext := NewExtractor(llm.NewFake([]string{response1, response2}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  longContent,
+		FileName: "finance.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Domain != "finance" {
+		t.Fatalf("expected domain finance, got %s", result.Domain)
+	}
+	if len(result.NodeTypes) < 1 {
+		t.Fatalf("expected at least 1 node type, got %d", len(result.NodeTypes))
+	}
+}
+
+func TestExtract_ExistingTypesFiltered(t *testing.T) {
+	t.Parallel()
+	response := makeLLMResponse("healthcare", 0.85, []TypeEntry{
+		{Type: "entity.patient", Label: "Patient", Description: "A person receiving care"},
+		{Type: "entity.medication", Label: "Medication", Description: "A pharmaceutical product"},
+	}, []TypeEntry{
+		{Type: "treats", Label: "Treats", Description: "Treatment relationship"},
+	}, []string{"patient_care"})
+
+	ext := NewExtractor(llm.NewFake([]string{response}))
+
+	existing := &ResolvedOntology{
+		NodeTypes: []ResolvedType{
+			{TypeDefinition: TypeDefinition{Type: "entity.patient", Label: "Patient", Description: "A person", Status: TypeStatusActive}, Scope: ScopeBuiltIn},
+		},
+		EdgeTypes:          []ResolvedType{},
+		BusinessCategories: []string{},
+	}
+
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:       "Healthcare document about patients and medications.",
+		FileName:      "healthcare.md",
+		ExistingTypes: existing,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// entity.patient should be filtered out
+	for _, nt := range result.NodeTypes {
+		if nt.Type == "entity.patient" {
+			t.Fatal("entity.patient should have been filtered out")
+		}
+	}
+}
+
+func TestExtract_FuzzyMergeDuplicates(t *testing.T) {
+	t.Parallel()
+	// Two sections return near-identical types
+	longContent := generateLongContent(SingleSectionThreshold + 500)
+
+	response1 := makeLLMResponse("logistics", 0.7, []TypeEntry{
+		{Type: "entity.shipment", Label: "Shipment", Description: "A collection of goods being transported"},
+		{Type: "entity.shipment_order", Label: "Shipment Order", Description: "An order for shipping goods"},
+	}, nil, nil)
+
+	response2 := makeLLMResponse("logistics", 0.8, []TypeEntry{
+		{Type: "entity.shipment", Label: "Shipment", Description: "A collection of goods being transported together"},
+		{Type: "entity.shipment_orders", Label: "Shipment Orders", Description: "Orders for shipping"},
+	}, nil, nil)
+
+	ext := NewExtractor(llm.NewFake([]string{response1, response2}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  longContent,
+		FileName: "logistics.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// "Shipment Order" and "Shipment Orders" should be fuzzy-merged (>= 0.88)
+	shipmentOrderCount := 0
+	for _, nt := range result.NodeTypes {
+		if nt.Type == "entity.shipment_order" || nt.Type == "entity.shipment_orders" {
+			shipmentOrderCount++
+		}
+	}
+	if shipmentOrderCount > 1 {
+		t.Fatalf("expected shipment order variants to be fuzzy-merged, got %d", shipmentOrderCount)
+	}
+}
+
+func TestExtract_MalformedJSON_RetriesSucceed(t *testing.T) {
+	t.Parallel()
+	goodResponse := makeLLMResponse("finance", 0.9, []TypeEntry{
+		{Type: "entity.account", Label: "Account", Description: "A financial account"},
+	}, nil, []string{"banking"})
+
+	// First response is malformed, second is valid
+	ext := NewExtractor(llm.NewFake([]string{
+		"Here is the analysis:\n{invalid json...",
+		goodResponse,
+	}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  "Short finance document.",
+		FileName: "finance.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Domain != "finance" {
+		t.Fatalf("expected domain finance, got %s", result.Domain)
+	}
+}
+
+func TestExtract_MaxRetriesExhausted(t *testing.T) {
+	t.Parallel()
+	// All responses are malformed
+	ext := NewExtractor(llm.NewFake([]string{
+		"not json at all",
+		"still not json",
+		"nope",
+	}))
+	_, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  "Some document.",
+		FileName: "doc.md",
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+}
+
+func TestExtract_WrappedJSON(t *testing.T) {
+	t.Parallel()
+	goodJSON := makeLLMResponse("tech", 0.8, []TypeEntry{
+		{Type: "entity.server", Label: "Server", Description: "A server instance"},
+	}, nil, []string{"infrastructure"})
+
+	// LLM wraps JSON in prose
+	wrappedResponse := "Here is my analysis:\n\n```json\n" + goodJSON + "\n```\n\nLet me know if you need more detail."
+
+	ext := NewExtractor(llm.NewFake([]string{wrappedResponse}))
+	result, err := ext.Extract(context.Background(), ExtractionParams{
+		Content:  "Server documentation.",
+		FileName: "servers.md",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Domain != "tech" {
+		t.Fatalf("expected domain tech, got %s", result.Domain)
+	}
+}
+
+func TestNoisyOr_Empty(t *testing.T) {
+	t.Parallel()
+	result := NoisyOr(nil)
+	if result != 0 {
+		t.Fatalf("expected 0, got %f", result)
+	}
+}
+
+func TestNoisyOr_SingleValue(t *testing.T) {
+	t.Parallel()
+	result := NoisyOr([]float64{0.7})
+	if result != 0.7 {
+		t.Fatalf("expected 0.7, got %f", result)
+	}
+}
+
+func TestNoisyOr_SingleValueCapped(t *testing.T) {
+	t.Parallel()
+	result := NoisyOr([]float64{1.0})
+	if result != ConfidenceCap {
+		t.Fatalf("expected %f, got %f", ConfidenceCap, result)
+	}
+}
+
+func TestNoisyOr_MultipleValues(t *testing.T) {
+	t.Parallel()
+	// NoisyOr([0.7, 0.8]) = 1 - (0.3 * 0.2) = 1 - 0.06 = 0.94
+	result := NoisyOr([]float64{0.7, 0.8})
+	expected := 0.94
+	if result < expected-0.001 || result > expected+0.001 {
+		t.Fatalf("expected ~%f, got %f", expected, result)
+	}
+}
+
+func TestNoisyOr_BelowFloor(t *testing.T) {
+	t.Parallel()
+	// All values below ConfidenceFloor should be filtered out
+	result := NoisyOr([]float64{0.1, 0.2, 0.15})
+	if result != 0 {
+		t.Fatalf("expected 0 (all below floor), got %f", result)
+	}
+}
+
+func TestNoisyOr_CappedAt099(t *testing.T) {
+	t.Parallel()
+	// Very high confidences: 1 - (0.05 * 0.05 * 0.05) = 0.999875 -> capped at 0.99
+	result := NoisyOr([]float64{0.95, 0.95, 0.95})
+	if result != ConfidenceCap {
+		t.Fatalf("expected %f (capped), got %f", ConfidenceCap, result)
+	}
+}
+
+func TestNoisyOr_MixedAboveAndBelowFloor(t *testing.T) {
+	t.Parallel()
+	// 0.1 is below floor, 0.7 and 0.8 are above
+	result := NoisyOr([]float64{0.1, 0.7, 0.8})
+	expected := 0.94 // 1 - (0.3 * 0.2)
+	if result < expected-0.001 || result > expected+0.001 {
+		t.Fatalf("expected ~%f, got %f", expected, result)
+	}
+}
+
+func TestSplitContent_Short(t *testing.T) {
+	t.Parallel()
+	content := "Short document."
+	sections := splitContent(content, SingleSectionThreshold)
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	if sections[0] != content {
+		t.Fatal("section content should match input")
+	}
+}
+
+func TestSplitContent_Tabular(t *testing.T) {
+	t.Parallel()
+	content := "col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9\nval10,val11,val12\nval13,val14,val15\nval16,val17,val18\nval19,val20,val21\nval22,val23,val24\nval25,val26,val27"
+	// Make it exceed threshold by repeating
+	for len(content) <= SingleSectionThreshold {
+		content += "\nextra1,extra2,extra3"
+	}
+	sections := splitContent(content, SingleSectionThreshold)
+	if len(sections) < 2 {
+		t.Fatalf("expected at least 2 sections for tabular content, got %d", len(sections))
+	}
+	// Each section should start with the header
+	for i, s := range sections {
+		if !startsWith(s, "col1,col2,col3") {
+			t.Fatalf("section %d should start with header, got: %s", i, s[:min(50, len(s))])
+		}
+	}
+}
+
+func TestSplitContent_Sections(t *testing.T) {
+	t.Parallel()
+	content := "# Section 1\n\nContent for section 1.\n\n# Section 2\n\nContent for section 2."
+	for len(content) <= SingleSectionThreshold {
+		content += "\n\nMore content to pad the document with additional text."
+	}
+	sections := splitContent(content, SingleSectionThreshold)
+	if len(sections) < 2 {
+		t.Fatalf("expected at least 2 sections for headed content, got %d", len(sections))
+	}
+}
+
+func TestBuildPrompt_WithExistingTypes(t *testing.T) {
+	t.Parallel()
+	existing := &ResolvedOntology{
+		NodeTypes: []ResolvedType{
+			{TypeDefinition: TypeDefinition{Type: "entity.customer", Label: "Customer"}, Scope: ScopeBuiltIn},
+		},
+		EdgeTypes: []ResolvedType{
+			{TypeDefinition: TypeDefinition{Type: "triggers", Label: "Triggers"}, Scope: ScopeBuiltIn},
+		},
+	}
+	prompt := buildOntologyExtractionPrompt(existing)
+	if !containsStr(prompt, "entity.customer") {
+		t.Fatal("prompt should mention existing node types")
+	}
+	if !containsStr(prompt, "triggers") {
+		t.Fatal("prompt should mention existing edge types")
+	}
+	if !containsStr(prompt, "Do NOT include these") {
+		t.Fatal("prompt should instruct to exclude existing types")
+	}
+}
+
+func TestBuildPrompt_WithoutExistingTypes(t *testing.T) {
+	t.Parallel()
+	prompt := buildOntologyExtractionPrompt(nil)
+	if containsStr(prompt, "Do NOT include these") {
+		t.Fatal("prompt should not mention filtering when no existing types")
+	}
+}
+
+func TestIsTabularContent_CSV(t *testing.T) {
+	t.Parallel()
+	content := "col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9"
+	if !isTabularContent(content) {
+		t.Fatal("CSV content should be detected as tabular")
+	}
+}
+
+func TestIsTabularContent_Pipe(t *testing.T) {
+	t.Parallel()
+	content := "col1|col2|col3\nval1|val2|val3\nval4|val5|val6\nval7|val8|val9"
+	if !isTabularContent(content) {
+		t.Fatal("pipe-delimited content should be detected as tabular")
+	}
+}
+
+func TestIsTabularContent_Prose(t *testing.T) {
+	t.Parallel()
+	content := "This is a normal paragraph.\nIt has multiple sentences.\nBut no delimiters.\nJust prose text.\nNothing tabular here."
+	if isTabularContent(content) {
+		t.Fatal("prose content should not be detected as tabular")
+	}
+}
+
+func TestExtractJSONFromText_PlainJSON(t *testing.T) {
+	t.Parallel()
+	input := `{"domain": "test", "confidence": 0.5}`
+	result, err := extractJSONFromText(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed map[string]interface{}
+	if json.Unmarshal([]byte(result), &parsed) != nil {
+		t.Fatal("result should be valid JSON")
+	}
+}
+
+func TestExtractJSONFromText_WrappedInProse(t *testing.T) {
+	t.Parallel()
+	input := `Here is the analysis:
+
+{"domain": "test", "confidence": 0.5}
+
+I hope this helps!`
+	result, err := extractJSONFromText(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed map[string]interface{}
+	if json.Unmarshal([]byte(result), &parsed) != nil {
+		t.Fatal("result should be valid JSON")
+	}
+}
+
+func TestExtractJSONFromText_NoJSON(t *testing.T) {
+	t.Parallel()
+	_, err := extractJSONFromText("just plain text without any json")
+	if err == nil {
+		t.Fatal("expected error for text without JSON")
+	}
+}
+
+func TestExtractJSONFromText_Empty(t *testing.T) {
+	t.Parallel()
+	_, err := extractJSONFromText("")
+	if err == nil {
+		t.Fatal("expected error for empty text")
+	}
+}
+
+// --- helpers ---
+
+func generateLongContent(minBytes int) string {
+	var b []byte
+	section := "# Section\n\nThis is a paragraph about server hardware and configuration management. " +
+		"It discusses various components, compatibility rules, and operational procedures.\n\n"
+	for len(b) < minBytes {
+		b = append(b, section...)
+	}
+	return string(b)
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && contains(s, substr)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/go/ontology/extract_test.go
+++ b/go/ontology/extract_test.go
@@ -290,6 +290,14 @@ func TestNoisyOr_MultipleValues(t *testing.T) {
 	}
 }
 
+func TestNoisyOr_SingleValueBelowFloor(t *testing.T) {
+	t.Parallel()
+	result := NoisyOr([]float64{0.2})
+	if result != 0 {
+		t.Fatalf("expected 0 for single value below floor, got %f", result)
+	}
+}
+
 func TestNoisyOr_BelowFloor(t *testing.T) {
 	t.Parallel()
 	// All values below ConfidenceFloor should be filtered out

--- a/go/ontology/similarity.go
+++ b/go/ontology/similarity.go
@@ -30,16 +30,18 @@ func JaroWinklerDistance(s1, s2 string) float64 {
 
 	jaro := jaroDistance(a, b)
 
+	ra := []rune(a)
+	rb := []rune(b)
 	commonPrefix := 0
 	limit := 4
-	if len(a) < limit {
-		limit = len(a)
+	if len(ra) < limit {
+		limit = len(ra)
 	}
-	if len(b) < limit {
-		limit = len(b)
+	if len(rb) < limit {
+		limit = len(rb)
 	}
 	for i := 0; i < limit; i++ {
-		if a[i] != b[i] {
+		if ra[i] != rb[i] {
 			break
 		}
 		commonPrefix++
@@ -50,37 +52,41 @@ func JaroWinklerDistance(s1, s2 string) float64 {
 
 // jaroDistance computes the Jaro similarity between two strings.
 // Both strings must be non-empty and already lowercased/trimmed.
+// Uses []rune internally for correct multi-byte character handling.
 func jaroDistance(s1, s2 string) float64 {
-	maxLen := len(s1)
-	if len(s2) > maxLen {
-		maxLen = len(s2)
+	r1 := []rune(s1)
+	r2 := []rune(s2)
+
+	maxLen := len(r1)
+	if len(r2) > maxLen {
+		maxLen = len(r2)
 	}
 	matchWindow := maxLen/2 - 1
 	if matchWindow < 0 {
 		matchWindow = 0
 	}
 
-	s1Matches := make([]bool, len(s1))
-	s2Matches := make([]bool, len(s2))
+	r1Matches := make([]bool, len(r1))
+	r2Matches := make([]bool, len(r2))
 
 	matches := 0
 	transpositions := 0
 
-	for i := 0; i < len(s1); i++ {
+	for i := 0; i < len(r1); i++ {
 		start := i - matchWindow
 		if start < 0 {
 			start = 0
 		}
 		end := i + matchWindow + 1
-		if end > len(s2) {
-			end = len(s2)
+		if end > len(r2) {
+			end = len(r2)
 		}
 		for j := start; j < end; j++ {
-			if s2Matches[j] || s1[i] != s2[j] {
+			if r2Matches[j] || r1[i] != r2[j] {
 				continue
 			}
-			s1Matches[i] = true
-			s2Matches[j] = true
+			r1Matches[i] = true
+			r2Matches[j] = true
 			matches++
 			break
 		}
@@ -91,21 +97,21 @@ func jaroDistance(s1, s2 string) float64 {
 	}
 
 	k := 0
-	for i := 0; i < len(s1); i++ {
-		if !s1Matches[i] {
+	for i := 0; i < len(r1); i++ {
+		if !r1Matches[i] {
 			continue
 		}
-		for !s2Matches[k] {
+		for !r2Matches[k] {
 			k++
 		}
-		if s1[i] != s2[k] {
+		if r1[i] != r2[k] {
 			transpositions++
 		}
 		k++
 	}
 
-	return (float64(matches)/float64(len(s1)) +
-		float64(matches)/float64(len(s2)) +
+	return (float64(matches)/float64(len(r1)) +
+		float64(matches)/float64(len(r2)) +
 		float64(matches-transpositions/2)/float64(matches)) / 3.0
 }
 

--- a/sdks/ts/memory/src/ontology/extract.test.ts
+++ b/sdks/ts/memory/src/ontology/extract.test.ts
@@ -246,6 +246,10 @@ describe('noisyOr', () => {
     expect(result).toBeCloseTo(0.94, 2)
   })
 
+  it('returns 0 for single value below floor', () => {
+    expect(noisyOr([0.2])).toBe(0)
+  })
+
   it('filters values below floor', () => {
     expect(noisyOr([0.1, 0.2, 0.15])).toBe(0)
   })

--- a/sdks/ts/memory/src/ontology/extract.test.ts
+++ b/sdks/ts/memory/src/ontology/extract.test.ts
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+
+import type { CompletionRequest, CompletionResponse, Provider, StreamEvent } from '../llm/types.js'
+import type { ResolvedOntology, ResolvedType } from './store.js'
+
+import {
+  CONFIDENCE_CAP,
+  CONFIDENCE_FLOOR,
+  Extractor,
+  isTabularContent,
+  noisyOr,
+  buildOntologyExtractionPrompt,
+  splitContent,
+  SINGLE_SECTION_THRESHOLD,
+} from './extract.js'
+
+function makeFakeProvider(responses: string[]): Provider {
+  let idx = 0
+  return {
+    name: () => 'fake',
+    modelName: () => 'fake-model',
+    supportsStructuredDecoding: () => false,
+    structured: async () => '',
+    stream: (_req: CompletionRequest, _signal?: AbortSignal): AsyncIterable<StreamEvent> => {
+      return {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => ({ done: true as const, value: undefined }),
+        }),
+      }
+    },
+    complete: async (): Promise<CompletionResponse> => {
+      const text = responses[idx % responses.length] ?? ''
+      idx++
+      return {
+        content: text,
+        toolCalls: [],
+        usage: { inputTokens: 10, outputTokens: 10 },
+        stopReason: 'end_turn',
+      }
+    },
+  }
+}
+
+function makeLLMResponse(
+  domain: string,
+  confidence: number,
+  nodeTypes: Array<{ type: string; label: string; description: string }>,
+  edgeTypes: Array<{ type: string; label: string; description: string }>,
+  categories: string[],
+): string {
+  return JSON.stringify({ domain, confidence, nodeTypes, edgeTypes, businessCategories: categories })
+}
+
+function generateLongContent(minBytes: number): string {
+  const section =
+    '# Section\n\nThis is a paragraph about server hardware and configuration management. ' +
+    'It discusses various components, compatibility rules, and operational procedures.\n\n'
+  let content = ''
+  while (content.length < minBytes) {
+    content += section
+  }
+  return content
+}
+
+describe('Extractor', () => {
+  it('returns empty result when provider is undefined', async () => {
+    const ext = new Extractor({ provider: undefined })
+    const result = await ext.extract({
+      content: 'Some document about servers.',
+      fileName: 'servers.md',
+    })
+    expect(result.nodeTypes).toHaveLength(0)
+    expect(result.edgeTypes).toHaveLength(0)
+    expect(result.businessCategories).toHaveLength(0)
+  })
+
+  it('returns empty result for empty content', async () => {
+    const ext = new Extractor({
+      provider: makeFakeProvider(['{}']),
+    })
+    const result = await ext.extract({ content: '', fileName: '' })
+    expect(result.nodeTypes).toHaveLength(0)
+  })
+
+  it('extracts from single section when content is under threshold', async () => {
+    const response = makeLLMResponse(
+      'healthcare',
+      0.85,
+      [
+        { type: 'entity.patient', label: 'Patient', description: 'A person receiving care' },
+        {
+          type: 'rule.clinical_protocol',
+          label: 'Clinical Protocol',
+          description: 'A clinical treatment rule',
+        },
+      ],
+      [{ type: 'treats', label: 'Treats', description: 'Treatment relationship' }],
+      ['patient_care'],
+    )
+
+    const ext = new Extractor({ provider: makeFakeProvider([response]) })
+    const result = await ext.extract({
+      content: 'Short healthcare document about patients.',
+      fileName: 'healthcare.md',
+    })
+
+    expect(result.domain).toBe('healthcare')
+    expect(result.confidence).toBe(0.85)
+    expect(result.nodeTypes).toHaveLength(2)
+    expect(result.edgeTypes).toHaveLength(1)
+    expect(result.businessCategories).toHaveLength(1)
+  })
+
+  it('handles multi-section extraction for long content', async () => {
+    const longContent = generateLongContent(SINGLE_SECTION_THRESHOLD + 1000)
+    const response1 = makeLLMResponse(
+      'finance',
+      0.7,
+      [{ type: 'entity.account', label: 'Account', description: 'A financial account' }],
+      [{ type: 'holds', label: 'Holds', description: 'An account holds assets' }],
+      ['retail_banking'],
+    )
+    const response2 = makeLLMResponse(
+      'finance',
+      0.8,
+      [{ type: 'entity.payment', label: 'Payment', description: 'A transfer of funds' }],
+      [{ type: 'settles', label: 'Settles', description: 'A transaction settles' }],
+      ['payments'],
+    )
+
+    const ext = new Extractor({ provider: makeFakeProvider([response1, response2]) })
+    const result = await ext.extract({
+      content: longContent,
+      fileName: 'finance.md',
+    })
+
+    expect(result.domain).toBe('finance')
+    expect(result.nodeTypes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('filters existing types from result', async () => {
+    const response = makeLLMResponse(
+      'healthcare',
+      0.85,
+      [
+        { type: 'entity.patient', label: 'Patient', description: 'A person receiving care' },
+        { type: 'entity.medication', label: 'Medication', description: 'A pharmaceutical product' },
+      ],
+      [{ type: 'treats', label: 'Treats', description: 'Treatment relationship' }],
+      ['patient_care'],
+    )
+
+    const existing: ResolvedOntology = {
+      nodeTypes: [
+        {
+          type: 'entity.patient',
+          label: 'Patient',
+          description: 'A person',
+          createdAt: '2026-01-01',
+          status: 'active',
+          scope: 'built-in',
+        },
+      ],
+      edgeTypes: [],
+      businessCategories: [],
+    }
+
+    const ext = new Extractor({ provider: makeFakeProvider([response]) })
+    const result = await ext.extract({
+      content: 'Healthcare document about patients and medications.',
+      fileName: 'healthcare.md',
+      existingTypes: existing,
+    })
+
+    const patientType = result.nodeTypes.find((nt) => nt.type === 'entity.patient')
+    expect(patientType).toBeUndefined()
+  })
+
+  it('retries on malformed JSON and succeeds', async () => {
+    const goodResponse = makeLLMResponse(
+      'finance',
+      0.9,
+      [{ type: 'entity.account', label: 'Account', description: 'A financial account' }],
+      [],
+      ['banking'],
+    )
+
+    const ext = new Extractor({
+      provider: makeFakeProvider(['Here is analysis: {invalid...', goodResponse]),
+    })
+    const result = await ext.extract({
+      content: 'Short finance document.',
+      fileName: 'finance.md',
+    })
+
+    expect(result.domain).toBe('finance')
+  })
+
+  it('throws after exhausting retries', async () => {
+    const ext = new Extractor({
+      provider: makeFakeProvider(['not json', 'still not', 'nope']),
+    })
+    await expect(
+      ext.extract({ content: 'Some document.', fileName: 'doc.md' }),
+    ).rejects.toThrow(/extraction failed/)
+  })
+
+  it('handles JSON wrapped in prose', async () => {
+    const goodJSON = makeLLMResponse(
+      'tech',
+      0.8,
+      [{ type: 'entity.server', label: 'Server', description: 'A server instance' }],
+      [],
+      ['infrastructure'],
+    )
+    const wrapped = `Here is my analysis:\n\n${goodJSON}\n\nLet me know if you need more.`
+
+    const ext = new Extractor({ provider: makeFakeProvider([wrapped]) })
+    const result = await ext.extract({
+      content: 'Server documentation.',
+      fileName: 'servers.md',
+    })
+
+    expect(result.domain).toBe('tech')
+  })
+})
+
+describe('noisyOr', () => {
+  it('returns 0 for empty input', () => {
+    expect(noisyOr([])).toBe(0)
+  })
+
+  it('returns single value as-is when above floor', () => {
+    expect(noisyOr([0.7])).toBe(0.7)
+  })
+
+  it('caps single value at 0.99', () => {
+    expect(noisyOr([1.0])).toBe(CONFIDENCE_CAP)
+  })
+
+  it('computes noisy-OR for multiple values', () => {
+    // 1 - (0.3 * 0.2) = 0.94
+    const result = noisyOr([0.7, 0.8])
+    expect(result).toBeCloseTo(0.94, 2)
+  })
+
+  it('filters values below floor', () => {
+    expect(noisyOr([0.1, 0.2, 0.15])).toBe(0)
+  })
+
+  it('caps at 0.99 for very high confidences', () => {
+    const result = noisyOr([0.95, 0.95, 0.95])
+    expect(result).toBe(CONFIDENCE_CAP)
+  })
+
+  it('filters below-floor values from mixed input', () => {
+    // 0.1 is below floor; 0.7 and 0.8 are above
+    const result = noisyOr([0.1, 0.7, 0.8])
+    expect(result).toBeCloseTo(0.94, 2)
+  })
+})
+
+describe('splitContent', () => {
+  it('does not split content under threshold', () => {
+    const content = 'Short document.'
+    const sections = splitContent(content, SINGLE_SECTION_THRESHOLD)
+    expect(sections).toHaveLength(1)
+    expect(sections[0]).toBe(content)
+  })
+
+  it('splits tabular content with header in each section', () => {
+    let content = 'col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9'
+    while (content.length <= SINGLE_SECTION_THRESHOLD) {
+      content += '\nextra1,extra2,extra3'
+    }
+    const sections = splitContent(content, SINGLE_SECTION_THRESHOLD)
+    expect(sections.length).toBeGreaterThanOrEqual(2)
+    for (const s of sections) {
+      expect(s.startsWith('col1,col2,col3')).toBe(true)
+    }
+  })
+
+  it('splits headed content at markdown headings', () => {
+    let content = '# Section 1\n\nContent for section 1.\n\n# Section 2\n\nContent for section 2.'
+    while (content.length <= SINGLE_SECTION_THRESHOLD) {
+      content += '\n\nMore content to pad the document.'
+    }
+    const sections = splitContent(content, SINGLE_SECTION_THRESHOLD)
+    expect(sections.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('isTabularContent', () => {
+  it('detects CSV content', () => {
+    const content =
+      'col1,col2,col3\nval1,val2,val3\nval4,val5,val6\nval7,val8,val9\nval10,val11,val12'
+    expect(isTabularContent(content)).toBe(true)
+  })
+
+  it('detects pipe-delimited content', () => {
+    const content =
+      'col1|col2|col3\nval1|val2|val3\nval4|val5|val6\nval7|val8|val9\nval10|val11|val12'
+    expect(isTabularContent(content)).toBe(true)
+  })
+
+  it('rejects prose content', () => {
+    const content =
+      'This is a paragraph.\nIt has sentences.\nBut no delimiters.\nJust text.\nNothing tabular.'
+    expect(isTabularContent(content)).toBe(false)
+  })
+})
+
+describe('buildOntologyExtractionPrompt', () => {
+  it('includes existing types when provided', () => {
+    const existing: ResolvedOntology = {
+      nodeTypes: [
+        {
+          type: 'entity.customer',
+          label: 'Customer',
+          description: 'A customer',
+          createdAt: '2026-01-01',
+          status: 'active',
+          scope: 'built-in',
+        },
+      ],
+      edgeTypes: [
+        {
+          type: 'triggers',
+          label: 'Triggers',
+          description: 'Triggers',
+          createdAt: '2026-01-01',
+          status: 'active',
+          scope: 'built-in',
+        },
+      ],
+      businessCategories: [],
+    }
+    const prompt = buildOntologyExtractionPrompt(existing)
+    expect(prompt).toContain('entity.customer')
+    expect(prompt).toContain('triggers')
+    expect(prompt).toContain('Do NOT include these')
+  })
+
+  it('does not include existing types section when none provided', () => {
+    const prompt = buildOntologyExtractionPrompt(undefined)
+    expect(prompt).not.toContain('Do NOT include these')
+  })
+})

--- a/sdks/ts/memory/src/ontology/extract.ts
+++ b/sdks/ts/memory/src/ontology/extract.ts
@@ -1,0 +1,648 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * LLM-powered ontology extraction from documents. Analyses document
+ * content to discover node types, edge types, and business categories.
+ * Handles multi-section splitting for large documents and merges results
+ * via noisy-OR confidence aggregation.
+ *
+ * Port of apps/intelligence-service/src/services/document-processing/
+ * ontology-extraction.service.ts adapted for the standalone memory
+ * package.
+ */
+
+import type { Provider } from '../llm/types.js'
+import type { TypeEntry } from './templates.js'
+import type { ResolvedOntology, ResolvedType } from './store.js'
+
+import { jaroWinklerDistance } from './similarity.js'
+import { extractJSON } from '../llm/structured.js'
+
+/** Byte count above which content is split into multiple sections. */
+export const SINGLE_SECTION_THRESHOLD = 8000
+
+/** LLM temperature used for extraction. */
+export const EXTRACTION_TEMPERATURE = 0.1
+
+/** Jaro-Winkler threshold for merging similarly-labelled types during multi-section merge. */
+export const FUZZY_LABEL_MERGE = 0.88
+
+/** Minimum confidence value considered in noisy-OR aggregation. */
+export const CONFIDENCE_FLOOR = 0.3
+
+/** Maximum confidence value returned by noisy-OR aggregation. */
+export const CONFIDENCE_CAP = 0.99
+
+/** Maximum number of retries when the LLM returns malformed output. */
+const DEFAULT_MAX_RETRIES = 2
+
+export type ExtractionResult = {
+  readonly nodeTypes: TypeEntry[]
+  readonly edgeTypes: TypeEntry[]
+  readonly businessCategories: string[]
+  readonly domain: string
+  readonly confidence: number
+}
+
+export type ExtractionParams = {
+  readonly content: string
+  readonly fileName: string
+  readonly existingTypes?: ResolvedOntology
+}
+
+export type ExtractorOptions = {
+  readonly provider: Provider | undefined
+  /** Override the default temperature (0.1). */
+  readonly temperature?: number
+  /** Override the default max retries (2). */
+  readonly maxRetries?: number
+}
+
+/**
+ * Extractor performs LLM-powered ontology extraction from documents.
+ * Returns empty results without error when no provider is configured.
+ */
+export class Extractor {
+  private readonly provider: Provider | undefined
+  private readonly temperature: number
+  private readonly maxRetries: number
+
+  constructor(options: ExtractorOptions) {
+    this.provider = options.provider
+    this.temperature = options.temperature ?? EXTRACTION_TEMPERATURE
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+  }
+
+  /**
+   * Analyse document content and return discovered ontology types.
+   * Returns an empty result without error when the provider is undefined.
+   */
+  async extract(params: ExtractionParams, signal?: AbortSignal): Promise<ExtractionResult> {
+    if (this.provider === undefined) {
+      return emptyExtractionResult()
+    }
+
+    const content = params.content
+    if (content.length === 0) {
+      return emptyExtractionResult()
+    }
+
+    if (content.length <= SINGLE_SECTION_THRESHOLD) {
+      return this.extractSingleSection(content, params, signal)
+    }
+
+    return this.extractMultiSection(content, params, signal)
+  }
+
+  private async extractSingleSection(
+    content: string,
+    params: ExtractionParams,
+    signal?: AbortSignal,
+  ): Promise<ExtractionResult> {
+    const systemPrompt = buildOntologyExtractionPrompt(params.existingTypes)
+    const userMsg = buildUserMessage(content, params.fileName)
+    let result = await this.callLLMWithRetry(systemPrompt, userMsg, signal)
+
+    if (params.existingTypes !== undefined) {
+      result = filterExistingTypes(result, params.existingTypes)
+    }
+
+    return result
+  }
+
+  private async extractMultiSection(
+    content: string,
+    params: ExtractionParams,
+    signal?: AbortSignal,
+  ): Promise<ExtractionResult> {
+    const sections = splitContent(content, SINGLE_SECTION_THRESHOLD)
+    const allResults: ExtractionResult[] = []
+    const discoveredTypes: TypeEntry[] = []
+
+    for (let i = 0; i < sections.length; i++) {
+      let systemPrompt = buildOntologyExtractionPrompt(params.existingTypes)
+      if (discoveredTypes.length > 0) {
+        systemPrompt += buildContextPrefix(discoveredTypes)
+      }
+
+      let userMsg = buildUserMessage(sections[i]!, params.fileName)
+      if (sections.length > 1) {
+        userMsg = `[Section ${i + 1} of ${sections.length}]\n\n${userMsg}`
+      }
+
+      const result = await this.callLLMWithRetry(systemPrompt, userMsg, signal)
+      allResults.push(result)
+      discoveredTypes.push(...result.nodeTypes)
+      discoveredTypes.push(...result.edgeTypes)
+    }
+
+    if (allResults.length === 0) {
+      return emptyExtractionResult()
+    }
+
+    let merged = mergeOntologyExtractions(allResults)
+
+    if (params.existingTypes !== undefined) {
+      merged = filterExistingTypes(merged, params.existingTypes)
+    }
+
+    return merged
+  }
+
+  private async callLLMWithRetry(
+    systemPrompt: string,
+    userMsg: string,
+    signal?: AbortSignal,
+  ): Promise<ExtractionResult> {
+    const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userMsg },
+    ]
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      signal?.throwIfAborted()
+
+      const resp = await this.provider!.complete(
+        {
+          messages,
+          temperature: this.temperature,
+          maxTokens: 4096,
+          jsonMode: true,
+        },
+        signal,
+      )
+
+      const parseResult = parseExtractionResponse(resp.content)
+      if (parseResult !== undefined) {
+        return parseResult
+      }
+
+      if (attempt < this.maxRetries) {
+        messages.push(
+          { role: 'assistant', content: resp.content },
+          {
+            role: 'user',
+            content:
+              'Your previous response was not valid JSON matching the expected schema. Return only valid JSON with the keys: domain, confidence, nodeTypes, edgeTypes, businessCategories.',
+          },
+        )
+        continue
+      }
+
+      throw new Error(`ontology: extraction failed after ${this.maxRetries} retries`)
+    }
+
+    throw new Error('ontology: extraction exhausted retries')
+  }
+}
+
+/**
+ * Parse an LLM response into an ExtractionResult.
+ * Returns undefined when the response cannot be parsed.
+ */
+function parseExtractionResponse(text: string): ExtractionResult | undefined {
+  let jsonStr: string
+  try {
+    jsonStr = extractJSON(text)
+  } catch {
+    return undefined
+  }
+
+  let raw: RawExtractionResult
+  try {
+    raw = JSON.parse(jsonStr) as RawExtractionResult
+  } catch {
+    return undefined
+  }
+
+  if (typeof raw.domain !== 'string' || raw.domain === '') {
+    return undefined
+  }
+
+  const nodeTypes: TypeEntry[] = []
+  if (Array.isArray(raw.nodeTypes)) {
+    for (const nt of raw.nodeTypes) {
+      if (
+        typeof nt === 'object' &&
+        nt !== null &&
+        typeof nt.type === 'string' &&
+        typeof nt.label === 'string' &&
+        typeof nt.description === 'string' &&
+        nt.type !== '' &&
+        nt.label !== '' &&
+        nt.description !== ''
+      ) {
+        nodeTypes.push({ type: nt.type, label: nt.label, description: nt.description })
+      }
+    }
+  }
+
+  const edgeTypes: TypeEntry[] = []
+  if (Array.isArray(raw.edgeTypes)) {
+    for (const et of raw.edgeTypes) {
+      if (
+        typeof et === 'object' &&
+        et !== null &&
+        typeof et.type === 'string' &&
+        typeof et.label === 'string' &&
+        typeof et.description === 'string' &&
+        et.type !== '' &&
+        et.label !== '' &&
+        et.description !== ''
+      ) {
+        edgeTypes.push({ type: et.type, label: et.label, description: et.description })
+      }
+    }
+  }
+
+  const businessCategories: string[] = []
+  if (Array.isArray(raw.businessCategories)) {
+    for (const cat of raw.businessCategories) {
+      if (typeof cat === 'string' && cat !== '') {
+        businessCategories.push(cat)
+      }
+    }
+  }
+
+  return {
+    domain: raw.domain,
+    confidence: typeof raw.confidence === 'number' ? raw.confidence : 0,
+    nodeTypes,
+    edgeTypes,
+    businessCategories,
+  }
+}
+
+type RawExtractionResult = {
+  domain: string
+  confidence: number
+  nodeTypes: ReadonlyArray<{ type: string; label: string; description: string }>
+  edgeTypes: ReadonlyArray<{ type: string; label: string; description: string }>
+  businessCategories: readonly string[]
+}
+
+/**
+ * Compute the noisy-OR confidence aggregation.
+ * Filters values below CONFIDENCE_FLOOR, caps at CONFIDENCE_CAP.
+ * Returns 0 for empty input.
+ */
+export function noisyOr(confidences: readonly number[]): number {
+  if (confidences.length === 0) {
+    return 0
+  }
+
+  const filtered = confidences.filter((c) => c >= CONFIDENCE_FLOOR)
+
+  if (filtered.length === 0) {
+    return 0
+  }
+
+  if (filtered.length === 1) {
+    return Math.min(filtered[0]!, CONFIDENCE_CAP)
+  }
+
+  let product = 1.0
+  for (const c of filtered) {
+    product *= 1.0 - c
+  }
+
+  const result = 1.0 - product
+  return Math.min(result, CONFIDENCE_CAP)
+}
+
+function emptyExtractionResult(): ExtractionResult {
+  return {
+    nodeTypes: [],
+    edgeTypes: [],
+    businessCategories: [],
+    domain: '',
+    confidence: 0,
+  }
+}
+
+/**
+ * Merge results from multi-section extraction. Deduplicates by type key
+ * (keeps longest description), fuzzy-deduplicates labels within the same
+ * prefix (Jaro-Winkler >= 0.88), and aggregates confidence via noisy-OR.
+ */
+function mergeOntologyExtractions(results: readonly ExtractionResult[]): ExtractionResult {
+  if (results.length === 0) {
+    return emptyExtractionResult()
+  }
+  if (results.length === 1) {
+    return results[0]!
+  }
+
+  const nodeMap = new Map<string, TypeEntry>()
+  const edgeMap = new Map<string, TypeEntry>()
+  const catSet = new Set<string>()
+  const domains = new Map<string, number>()
+  const confidences: number[] = []
+
+  for (const r of results) {
+    for (const nt of r.nodeTypes) {
+      const existing = nodeMap.get(nt.type)
+      if (existing === undefined || nt.description.length > existing.description.length) {
+        nodeMap.set(nt.type, nt)
+      }
+    }
+    for (const et of r.edgeTypes) {
+      const existing = edgeMap.get(et.type)
+      if (existing === undefined || et.description.length > existing.description.length) {
+        edgeMap.set(et.type, et)
+      }
+    }
+    for (const cat of r.businessCategories) {
+      catSet.add(cat)
+    }
+    if (r.domain !== '') {
+      domains.set(r.domain, (domains.get(r.domain) ?? 0) + 1)
+    }
+    if (r.confidence > 0) {
+      confidences.push(r.confidence)
+    }
+  }
+
+  fuzzyDedupByPrefix(nodeMap)
+  fuzzyDedupEdges(edgeMap)
+
+  let bestDomain = ''
+  let bestCount = 0
+  for (const [domain, count] of domains) {
+    if (count > bestCount) {
+      bestCount = count
+      bestDomain = domain
+    }
+  }
+
+  return {
+    nodeTypes: [...nodeMap.values()],
+    edgeTypes: [...edgeMap.values()],
+    businessCategories: [...catSet],
+    domain: bestDomain,
+    confidence: noisyOr(confidences),
+  }
+}
+
+function fuzzyDedupByPrefix(nodeMap: Map<string, TypeEntry>): void {
+  const byPrefix = new Map<string, string[]>()
+  for (const key of nodeMap.keys()) {
+    const prefix = typePrefix(key)
+    const keys = byPrefix.get(prefix)
+    if (keys !== undefined) {
+      keys.push(key)
+    } else {
+      byPrefix.set(prefix, [key])
+    }
+  }
+
+  for (const keys of byPrefix.values()) {
+    for (let i = 0; i < keys.length; i++) {
+      for (let j = i + 1; j < keys.length; j++) {
+        const entryI = nodeMap.get(keys[i]!)
+        const entryJ = nodeMap.get(keys[j]!)
+        if (entryI === undefined || entryJ === undefined) continue
+        const sim = jaroWinklerDistance(entryI.label, entryJ.label)
+        if (sim >= FUZZY_LABEL_MERGE) {
+          if (entryJ.description.length > entryI.description.length) {
+            nodeMap.delete(keys[i]!)
+          } else {
+            nodeMap.delete(keys[j]!)
+          }
+        }
+      }
+    }
+  }
+}
+
+function fuzzyDedupEdges(edgeMap: Map<string, TypeEntry>): void {
+  const keys = [...edgeMap.keys()]
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      const entryI = edgeMap.get(keys[i]!)
+      const entryJ = edgeMap.get(keys[j]!)
+      if (entryI === undefined || entryJ === undefined) continue
+      const sim = jaroWinklerDistance(entryI.label, entryJ.label)
+      if (sim >= FUZZY_LABEL_MERGE) {
+        if (entryJ.description.length > entryI.description.length) {
+          edgeMap.delete(keys[i]!)
+        } else {
+          edgeMap.delete(keys[j]!)
+        }
+      }
+    }
+  }
+}
+
+function filterExistingTypes(
+  result: ExtractionResult,
+  existing: ResolvedOntology,
+): ExtractionResult {
+  const existingNodeSet = new Set<string>()
+  for (const nt of existing.nodeTypes) {
+    existingNodeSet.add(nt.type)
+  }
+
+  const existingEdgeSet = new Set<string>()
+  for (const et of existing.edgeTypes) {
+    existingEdgeSet.add(et.type)
+  }
+
+  const existingCatSet = new Set<string>(existing.businessCategories)
+
+  return {
+    domain: result.domain,
+    confidence: result.confidence,
+    nodeTypes: result.nodeTypes.filter((nt) => !existingNodeSet.has(nt.type)),
+    edgeTypes: result.edgeTypes.filter((et) => !existingEdgeSet.has(et.type)),
+    businessCategories: result.businessCategories.filter((cat) => !existingCatSet.has(cat)),
+  }
+}
+
+function typePrefix(typeID: string): string {
+  const dotIndex = typeID.indexOf('.')
+  if (dotIndex < 0) return typeID
+  return typeID.slice(0, dotIndex)
+}
+
+/**
+ * Build the system prompt for ontology extraction.
+ */
+export function buildOntologyExtractionPrompt(existingTypes?: ResolvedOntology): string {
+  let prompt = `You are a domain ontology analyst. Analyse this document and extract the SCHEMA -- the types of entities, rules, and relationships that exist in this domain.
+
+Do NOT extract individual data items or instances. Instead, identify the CATEGORIES and TYPES of things described.
+
+For each discovered type, provide:
+- type: A dotted identifier following the pattern prefix.name where prefix is one of: entity, rule, exception, decision, process. The name should be snake_case.
+- label: A human-readable name
+- description: A one-sentence explanation of what this type represents
+
+Also identify:
+- Edge types: the kinds of relationships between entities (use snake_case identifiers like requires, compatible_with, belongs_to)
+- Business categories: the high-level domain areas covered (use snake_case like server_hardware, customer_management)
+
+Analyse the document structure, column headers, data patterns, and content to infer the domain ontology.
+
+Examples of good ontology design patterns:
+
+Pattern 1 - Entity-Rule binding:
+entity.product is constrained by rule.pricing via the "constrains" edge.
+
+Pattern 2 - Process-Decision-Exception:
+process.approval_chain contains decision.escalation points that may trigger exception.override.
+
+Pattern 3 - Classification hierarchy:
+entity.category relates to entity.subcategory via "belongs_to" edge.
+
+Return your analysis as a JSON object with the following structure:
+{
+  "domain": "string describing the domain",
+  "confidence": 0.0 to 1.0,
+  "nodeTypes": [{"type": "prefix.name", "label": "Human Label", "description": "One sentence"}],
+  "edgeTypes": [{"type": "snake_case_name", "label": "Human Label", "description": "One sentence"}],
+  "businessCategories": ["snake_case_category"]
+}`
+
+  if (
+    existingTypes !== undefined &&
+    (existingTypes.nodeTypes.length > 0 || existingTypes.edgeTypes.length > 0)
+  ) {
+    prompt +=
+      '\n\nThe following types already exist in the ontology. Do NOT include these in your response -- only return NEW types that are not already present:\n'
+    prompt += buildExistingTypesSection(existingTypes)
+  }
+
+  return prompt
+}
+
+function buildExistingTypesSection(existing: ResolvedOntology): string {
+  const parts: string[] = []
+  if (existing.nodeTypes.length > 0) {
+    parts.push('\nExisting node types:')
+    for (const nt of existing.nodeTypes) {
+      parts.push(`- ${nt.type}: ${nt.label}`)
+    }
+  }
+  if (existing.edgeTypes.length > 0) {
+    parts.push('\nExisting edge types:')
+    for (const et of existing.edgeTypes) {
+      parts.push(`- ${et.type}: ${et.label}`)
+    }
+  }
+  return parts.join('\n') + '\n'
+}
+
+function buildUserMessage(content: string, fileName: string): string {
+  if (fileName !== '') {
+    return `Document: ${fileName}\n\n${content}`
+  }
+  return content
+}
+
+function buildContextPrefix(discoveredTypes: readonly TypeEntry[]): string {
+  const lines = [
+    '\n\nTypes discovered from earlier sections of this document (avoid duplicating these):',
+  ]
+  for (const t of discoveredTypes) {
+    lines.push(`- ${t.type}: ${t.label}`)
+  }
+  return lines.join('\n') + '\n'
+}
+
+/**
+ * Split content into sections of approximately maxBytes.
+ * Detects tabular content and samples header + data rows per section.
+ * Otherwise splits on markdown headings or at byte boundaries.
+ */
+export function splitContent(content: string, maxBytes: number): string[] {
+  if (content.length <= maxBytes) {
+    return [content]
+  }
+
+  if (isTabularContent(content)) {
+    return splitTabularContent(content, maxBytes)
+  }
+
+  return splitByHeadingsOrBytes(content, maxBytes)
+}
+
+/**
+ * Returns true if the content looks like CSV/TSV data.
+ * Heuristic: >= 2 delimiters per line on >= 3 of the first 5 lines.
+ */
+export function isTabularContent(content: string): boolean {
+  const lines = content.split('\n', 6)
+  if (lines.length < 3) return false
+
+  const limit = Math.min(5, lines.length)
+  let tabularLines = 0
+  for (let i = 0; i < limit; i++) {
+    const line = lines[i]!
+    const commas = (line.match(/,/g) ?? []).length
+    const pipes = (line.match(/\|/g) ?? []).length
+    if (commas >= 2 || pipes >= 2) {
+      tabularLines++
+    }
+  }
+
+  return tabularLines >= 3
+}
+
+function splitTabularContent(content: string, _maxBytes: number): string[] {
+  const lines = content.split('\n')
+  if (lines.length === 0) return [content]
+
+  const header = lines[0]!
+  const dataLines = lines.slice(1)
+  if (dataLines.length === 0) return [content]
+
+  const samplesPerSection = 3
+  const sections: string[] = []
+
+  for (let i = 0; i < dataLines.length; i += samplesPerSection) {
+    const end = Math.min(i + samplesPerSection, dataLines.length)
+    const section = header + '\n' + dataLines.slice(i, end).join('\n')
+    sections.push(section)
+  }
+
+  return sections
+}
+
+function splitByHeadingsOrBytes(content: string, maxBytes: number): string[] {
+  const lines = content.split('\n')
+  const sections: string[] = []
+  let currentSection = ''
+  let currentBytes = 0
+
+  for (const line of lines) {
+    const lineBytes = line.length + 1
+
+    const isHeading = line.startsWith('# ') || line.startsWith('## ') || line.startsWith('### ')
+
+    if (isHeading && currentBytes > 0) {
+      sections.push(currentSection)
+      currentSection = ''
+      currentBytes = 0
+    }
+
+    if (currentBytes + lineBytes > maxBytes && currentBytes > 0) {
+      sections.push(currentSection)
+      currentSection = ''
+      currentBytes = 0
+    }
+
+    if (currentBytes > 0) {
+      currentSection += '\n'
+      currentBytes++
+    }
+    currentSection += line
+    currentBytes += line.length
+  }
+
+  if (currentBytes > 0) {
+    sections.push(currentSection)
+  }
+
+  return sections
+}

--- a/sdks/ts/memory/src/ontology/extract.ts
+++ b/sdks/ts/memory/src/ontology/extract.ts
@@ -11,8 +11,9 @@
  * package.
  */
 
+import { Buffer } from 'node:buffer'
 import type { Provider } from '../llm/types.js'
-import type { TypeEntry } from './templates.js'
+import { isValidNodeType, isValidEdgeType, type TypeEntry } from './templates.js'
 import type { ResolvedOntology, ResolvedType } from './store.js'
 
 import { jaroWinklerDistance } from './similarity.js'
@@ -117,12 +118,13 @@ export class Extractor {
   ): Promise<ExtractionResult> {
     const sections = splitContent(content, SINGLE_SECTION_THRESHOLD)
     const allResults: ExtractionResult[] = []
-    const discoveredTypes: TypeEntry[] = []
+    const discoveredNodeTypes: TypeEntry[] = []
+    const discoveredEdgeTypes: TypeEntry[] = []
 
     for (let i = 0; i < sections.length; i++) {
       let systemPrompt = buildOntologyExtractionPrompt(params.existingTypes)
-      if (discoveredTypes.length > 0) {
-        systemPrompt += buildContextPrefix(discoveredTypes)
+      if (discoveredNodeTypes.length > 0 || discoveredEdgeTypes.length > 0) {
+        systemPrompt += buildContextPrefix(discoveredNodeTypes, discoveredEdgeTypes)
       }
 
       let userMsg = buildUserMessage(sections[i]!, params.fileName)
@@ -132,8 +134,8 @@ export class Extractor {
 
       const result = await this.callLLMWithRetry(systemPrompt, userMsg, signal)
       allResults.push(result)
-      discoveredTypes.push(...result.nodeTypes)
-      discoveredTypes.push(...result.edgeTypes)
+      discoveredNodeTypes.push(...result.nodeTypes)
+      discoveredEdgeTypes.push(...result.edgeTypes)
     }
 
     if (allResults.length === 0) {
@@ -230,7 +232,8 @@ function parseExtractionResponse(text: string): ExtractionResult | undefined {
         typeof nt.description === 'string' &&
         nt.type !== '' &&
         nt.label !== '' &&
-        nt.description !== ''
+        nt.description !== '' &&
+        isValidNodeType(nt.type)
       ) {
         nodeTypes.push({ type: nt.type, label: nt.label, description: nt.description })
       }
@@ -248,7 +251,8 @@ function parseExtractionResponse(text: string): ExtractionResult | undefined {
         typeof et.description === 'string' &&
         et.type !== '' &&
         et.label !== '' &&
-        et.description !== ''
+        et.description !== '' &&
+        isValidEdgeType(et.type)
       ) {
         edgeTypes.push({ type: et.type, label: et.label, description: et.description })
       }
@@ -534,18 +538,40 @@ function buildExistingTypesSection(existing: ResolvedOntology): string {
 }
 
 function buildUserMessage(content: string, fileName: string): string {
-  if (fileName !== '') {
-    return `Document: ${fileName}\n\n${content}`
+  const sanitised = sanitiseFileName(fileName)
+  if (sanitised !== '') {
+    return `Document: ${sanitised}\n\n<ingested-document>\n${content}\n</ingested-document>`
   }
-  return content
+  return `<ingested-document>\n${content}\n</ingested-document>`
 }
 
-function buildContextPrefix(discoveredTypes: readonly TypeEntry[]): string {
+/**
+ * Strip newlines, control characters, and trim the filename to
+ * prevent prompt injection via crafted file names.
+ */
+function sanitiseFileName(name: string): string {
+  const cleaned = name.replace(/[\x00-\x1f\x7f-\x9f]/g, '').trim()
+  return cleaned.length > 256 ? cleaned.slice(0, 256) : cleaned
+}
+
+function buildContextPrefix(
+  nodeTypes: readonly TypeEntry[],
+  edgeTypes: readonly TypeEntry[],
+): string {
   const lines = [
     '\n\nTypes discovered from earlier sections of this document (avoid duplicating these):',
   ]
-  for (const t of discoveredTypes) {
-    lines.push(`- ${t.type}: ${t.label}`)
+  if (nodeTypes.length > 0) {
+    lines.push('\nDiscovered node types:')
+    for (const t of nodeTypes) {
+      lines.push(`- ${t.type}: ${t.label}`)
+    }
+  }
+  if (edgeTypes.length > 0) {
+    lines.push('\nDiscovered edge types:')
+    for (const t of edgeTypes) {
+      lines.push(`- ${t.type}: ${t.label}`)
+    }
   }
   return lines.join('\n') + '\n'
 }
@@ -556,7 +582,7 @@ function buildContextPrefix(discoveredTypes: readonly TypeEntry[]): string {
  * Otherwise splits on markdown headings or at byte boundaries.
  */
 export function splitContent(content: string, maxBytes: number): string[] {
-  if (content.length <= maxBytes) {
+  if (Buffer.byteLength(content, 'utf8') <= maxBytes) {
     return [content]
   }
 
@@ -589,7 +615,7 @@ export function isTabularContent(content: string): boolean {
   return tabularLines >= 3
 }
 
-function splitTabularContent(content: string, _maxBytes: number): string[] {
+function splitTabularContent(content: string, maxBytes: number): string[] {
   const lines = content.split('\n')
   if (lines.length === 0) return [content]
 
@@ -597,13 +623,24 @@ function splitTabularContent(content: string, _maxBytes: number): string[] {
   const dataLines = lines.slice(1)
   if (dataLines.length === 0) return [content]
 
-  const samplesPerSection = 3
+  const headerBytes = Buffer.byteLength(header, 'utf8') + 1 // +1 for newline
   const sections: string[] = []
+  let sectionLines: string[] = []
+  let currentBytes = headerBytes
 
-  for (let i = 0; i < dataLines.length; i += samplesPerSection) {
-    const end = Math.min(i + samplesPerSection, dataLines.length)
-    const section = header + '\n' + dataLines.slice(i, end).join('\n')
-    sections.push(section)
+  for (const line of dataLines) {
+    const lineBytes = Buffer.byteLength(line, 'utf8') + 1
+    if (currentBytes + lineBytes > maxBytes && sectionLines.length > 0) {
+      sections.push(header + '\n' + sectionLines.join('\n'))
+      sectionLines = []
+      currentBytes = headerBytes
+    }
+    sectionLines.push(line)
+    currentBytes += lineBytes
+  }
+
+  if (sectionLines.length > 0) {
+    sections.push(header + '\n' + sectionLines.join('\n'))
   }
 
   return sections
@@ -616,7 +653,7 @@ function splitByHeadingsOrBytes(content: string, maxBytes: number): string[] {
   let currentBytes = 0
 
   for (const line of lines) {
-    const lineBytes = line.length + 1
+    const lineBytes = Buffer.byteLength(line, 'utf8') + 1
 
     const isHeading = line.startsWith('# ') || line.startsWith('## ') || line.startsWith('### ')
 
@@ -637,7 +674,7 @@ function splitByHeadingsOrBytes(content: string, maxBytes: number): string[] {
       currentBytes++
     }
     currentSection += line
-    currentBytes += line.length
+    currentBytes += Buffer.byteLength(line, 'utf8')
   }
 
   if (currentBytes > 0) {

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -90,3 +90,17 @@ export type {
   SimilarityFn,
 } from './dedup.js'
 export { cosineSimilarity, jaroWinklerDistance } from './similarity.js'
+
+export type { ExtractionResult, ExtractionParams, ExtractorOptions } from './extract.js'
+export {
+  Extractor,
+  noisyOr,
+  buildOntologyExtractionPrompt,
+  splitContent,
+  isTabularContent,
+  SINGLE_SECTION_THRESHOLD,
+  EXTRACTION_TEMPERATURE,
+  FUZZY_LABEL_MERGE,
+  CONFIDENCE_FLOOR,
+  CONFIDENCE_CAP,
+} from './extract.js'


### PR DESCRIPTION
## Summary
- Implement LLM-powered ontology extraction pipeline in Go (`go/ontology/extract.go`) and TypeScript (`sdks/ts/memory/src/ontology/extract.ts`)
- Single-section extraction for docs under 8KB, multi-section with merge for larger docs
- Noisy-OR confidence aggregation, fuzzy label dedup (Jaro-Winkler >= 0.88), tabular content detection, existing type filtering, JSON parsing with brace-matching fallback, max 2 retries on malformed output
- Graceful no-op when no LLM provider is configured

## Files Changed
- `go/ontology/extract.go` — Extractor, NoisyOr, split/merge logic
- `go/ontology/extract_test.go` — 25 unit tests
- `sdks/ts/memory/src/ontology/extract.ts` — TS mirror of Go implementation
- `sdks/ts/memory/src/ontology/extract.test.ts` — 23 unit tests
- `sdks/ts/memory/src/ontology/index.ts` — barrel exports

## Test plan
- [x] Go tests pass: `go test ./ontology/... -v` (all pass including 25 new tests)
- [x] TS tests pass: `vitest run sdks/ts/memory/src/ontology/` (244 tests, 23 new)
- [x] Nil/undefined provider returns empty result
- [x] Single-section extraction with mock LLM
- [x] Multi-section split and merge for content > 8000 bytes
- [x] Existing type filtering
- [x] Fuzzy merge of duplicate labels across sections
- [x] Retry on malformed JSON, fail after max retries
- [x] NoisyOr: empty, single, multi, below-floor, capped
- [x] Tabular/heading/byte-boundary splitting
- [x] Prompt building with and without existing types