### PR TITLE
feat(ontology): proposal workflow (P6-7) LLE-9795

### DIFF
--- a/go/ontology/proposal.go
+++ b/go/ontology/proposal.go
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+// ProposalStatus is the lifecycle state of a type proposal.
+type ProposalStatus string
+
+const (
+	ProposalStatusPending  ProposalStatus = "proposed"
+	ProposalStatusAccepted ProposalStatus = "accepted"
+	ProposalStatusMerged   ProposalStatus = "merged"
+	ProposalStatusRejected ProposalStatus = "rejected"
+)
+
+// ExtractionResult holds extracted ontology types from a document.
+// Defined here so that the proposal workflow can accept extraction
+// outputs without depending on the extraction package (P6-4). When
+// P6-4 is implemented, it will produce values of this type.
+type ExtractionResult struct {
+	NodeTypes          []TypeEntry `json:"nodeTypes"`
+	EdgeTypes          []TypeEntry `json:"edgeTypes"`
+	BusinessCategories []string    `json:"businessCategories"`
+	Domain             string      `json:"domain"`
+	Confidence         float64     `json:"confidence"`
+}
+
+// Proposal is a candidate type awaiting review.
+type Proposal struct {
+	ID             string         `json:"id"`
+	Type           string         `json:"type"`
+	Label          string         `json:"label"`
+	Description    string         `json:"description"`
+	Category       string         `json:"category"` // "nodeType" | "edgeType"
+	DiscoveredFrom string         `json:"discoveredFrom"`
+	CreatedAt      string         `json:"createdAt"`
+	Status         ProposalStatus `json:"status"`
+	ReviewedBy     string         `json:"reviewedBy,omitempty"`
+	ReviewedAt     string         `json:"reviewedAt,omitempty"`
+	MergedInto     string         `json:"mergedInto,omitempty"`
+}
+
+// ProposalBatch groups proposals from a single extraction.
+type ProposalBatch struct {
+	ID             string     `json:"id"`
+	Proposals      []Proposal `json:"proposals"`
+	Domain         string     `json:"domain"`
+	SourceDocument string     `json:"sourceDocument"`
+	CreatedAt      string     `json:"createdAt"`
+}
+
+// ProposalFilter controls which proposals are returned by List.
+type ProposalFilter struct {
+	Status   ProposalStatus
+	Category string
+}
+
+// ProposalWorkflow manages the type proposal lifecycle. It creates
+// proposals from extraction results, runs deduplication to filter
+// already-known types, and provides accept/merge/reject operations
+// that transition types through the workflow.
+type ProposalWorkflow struct {
+	registry *Registry
+	store    brain.Store
+	clock    func() time.Time
+}
+
+// ProposalWorkflowConfig configures the proposal workflow.
+type ProposalWorkflowConfig struct {
+	// Registry provides access to the resolved ontology and type registration.
+	Registry *Registry
+	// Store provides raw file access for reading/writing proposal batch JSON.
+	Store brain.Store
+	// Clock overrides time.Now for deterministic testing. Defaults to time.Now.
+	Clock func() time.Time
+}
+
+// NewProposalWorkflow creates a workflow backed by the given registry
+// and brain store.
+func NewProposalWorkflow(cfg ProposalWorkflowConfig) *ProposalWorkflow {
+	clock := cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+	return &ProposalWorkflow{
+		registry: cfg.Registry,
+		store:    cfg.Store,
+		clock:    clock,
+	}
+}
+
+// proposalBatchPath returns the brain.Path for a proposal batch file.
+func proposalBatchPath(batchID string) brain.Path {
+	return brain.Path("ontology/proposals/" + batchID + ".json")
+}
+
+// proposalDirPath is the directory under which all proposal batches are stored.
+const proposalDirPath = brain.Path("ontology/proposals/")
+
+// proposalIDFromInputs computes a deterministic proposal ID from the
+// type name and batch ID using SHA-256 (first 16 hex characters).
+func proposalIDFromInputs(typeName, batchID string) string {
+	input := []byte(typeName + ":" + batchID)
+	sum := sha256.Sum256(input)
+	return hex.EncodeToString(sum[:8])
+}
+
+// computeBatchID computes a deterministic batch ID from the domain,
+// source document, and timestamp using SHA-256 (first 16 hex characters).
+func computeBatchID(domain, sourceDocument, timestamp string) string {
+	input := []byte(domain + ":" + sourceDocument + ":" + timestamp)
+	sum := sha256.Sum256(input)
+	return hex.EncodeToString(sum[:8])
+}
+
+// ProposeFromExtraction creates proposals for unique types from an
+// extraction result. Runs deduplication against the resolved ontology
+// first, so only genuinely new types become proposals.
+func (w *ProposalWorkflow) ProposeFromExtraction(ctx context.Context, result ExtractionResult, sourceDocument string) (*ProposalBatch, error) {
+	resolved, err := w.registry.Resolve(ctx, "", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("ontology: propose from extraction resolve: %w", err)
+	}
+
+	existingTypes := resolvedToDefinitions(resolved)
+	dedup := NewDeduplicator(nil)
+	extractedDefs := extractionToDefinitions(result)
+
+	dedupResult, err := dedup.Deduplicate(ctx, extractedDefs, existingTypes)
+	if err != nil {
+		return nil, fmt.Errorf("ontology: propose from extraction dedup: %w", err)
+	}
+
+	now := w.clock().UTC().Format(time.RFC3339)
+	bid := computeBatchID(result.Domain, sourceDocument, now)
+
+	batch := &ProposalBatch{
+		ID:             bid,
+		Proposals:      make([]Proposal, 0, len(dedupResult.Unique)),
+		Domain:         result.Domain,
+		SourceDocument: sourceDocument,
+		CreatedAt:      now,
+	}
+
+	for _, unique := range dedupResult.Unique {
+		category := "nodeType"
+		if HasPrefix(unique.Type) == "" {
+			category = "edgeType"
+		}
+		pid := proposalIDFromInputs(unique.Type, bid)
+		batch.Proposals = append(batch.Proposals, Proposal{
+			ID:             pid,
+			Type:           unique.Type,
+			Label:          unique.Label,
+			Description:    unique.Description,
+			Category:       category,
+			DiscoveredFrom: sourceDocument,
+			CreatedAt:      now,
+			Status:         ProposalStatusPending,
+		})
+	}
+
+	if err := w.writeBatch(ctx, batch); err != nil {
+		return nil, fmt.Errorf("ontology: propose from extraction write: %w", err)
+	}
+
+	return batch, nil
+}
+
+// Accept activates a proposed type in the registry at brain scope.
+// The proposal status transitions from "proposed" to "accepted" and
+// the type is registered as active. Idempotent for already-accepted
+// proposals.
+func (w *ProposalWorkflow) Accept(ctx context.Context, batchID, proposalID, reviewedBy string) error {
+	batch, err := w.readBatch(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("ontology: accept proposal read batch %q: %w", batchID, err)
+	}
+
+	proposal, idx := findProposal(batch, proposalID)
+	if proposal == nil {
+		return fmt.Errorf("ontology: proposal %q not found in batch %q", proposalID, batchID)
+	}
+
+	if proposal.Status == ProposalStatusAccepted {
+		return nil
+	}
+	if proposal.Status != ProposalStatusPending {
+		return fmt.Errorf("ontology: cannot accept proposal %q with status %q", proposalID, proposal.Status)
+	}
+
+	now := w.clock().UTC().Format(time.RFC3339)
+	label := proposal.Label
+	if label == "" {
+		if proposal.Category == "nodeType" {
+			label = FormatNodeTypeLabel(proposal.Type)
+		} else {
+			label = FormatEdgeTypeLabel(proposal.Type)
+		}
+	}
+
+	def := TypeDefinition{
+		Type:           proposal.Type,
+		Label:          label,
+		Description:    proposal.Description,
+		DiscoveredFrom: proposal.DiscoveredFrom,
+		CreatedAt:      now,
+		Status:         TypeStatusActive,
+	}
+
+	if err := w.registry.RegisterType(ctx, ScopeBrain, def); err != nil {
+		return fmt.Errorf("ontology: accept proposal register: %w", err)
+	}
+
+	batch.Proposals[idx].Status = ProposalStatusAccepted
+	batch.Proposals[idx].ReviewedBy = reviewedBy
+	batch.Proposals[idx].ReviewedAt = now
+
+	return w.writeBatch(ctx, batch)
+}
+
+// Merge marks a proposal as merged into an existing type. No registry
+// change occurs; the decision is recorded for audit purposes.
+// Idempotent for already-merged proposals.
+func (w *ProposalWorkflow) Merge(ctx context.Context, batchID, proposalID, targetType, reviewedBy string) error {
+	batch, err := w.readBatch(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("ontology: merge proposal read batch %q: %w", batchID, err)
+	}
+
+	proposal, idx := findProposal(batch, proposalID)
+	if proposal == nil {
+		return fmt.Errorf("ontology: proposal %q not found in batch %q", proposalID, batchID)
+	}
+
+	if proposal.Status == ProposalStatusMerged {
+		return nil
+	}
+	if proposal.Status != ProposalStatusPending {
+		return fmt.Errorf("ontology: cannot merge proposal %q with status %q", proposalID, proposal.Status)
+	}
+
+	now := w.clock().UTC().Format(time.RFC3339)
+	batch.Proposals[idx].Status = ProposalStatusMerged
+	batch.Proposals[idx].MergedInto = targetType
+	batch.Proposals[idx].ReviewedBy = reviewedBy
+	batch.Proposals[idx].ReviewedAt = now
+
+	return w.writeBatch(ctx, batch)
+}
+
+// Reject marks a proposal as rejected. No registry change occurs.
+// Idempotent for already-rejected proposals.
+func (w *ProposalWorkflow) Reject(ctx context.Context, batchID, proposalID, reviewedBy string) error {
+	batch, err := w.readBatch(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("ontology: reject proposal read batch %q: %w", batchID, err)
+	}
+
+	proposal, idx := findProposal(batch, proposalID)
+	if proposal == nil {
+		return fmt.Errorf("ontology: proposal %q not found in batch %q", proposalID, batchID)
+	}
+
+	if proposal.Status == ProposalStatusRejected {
+		return nil
+	}
+	if proposal.Status != ProposalStatusPending {
+		return fmt.Errorf("ontology: cannot reject proposal %q with status %q", proposalID, proposal.Status)
+	}
+
+	now := w.clock().UTC().Format(time.RFC3339)
+	batch.Proposals[idx].Status = ProposalStatusRejected
+	batch.Proposals[idx].ReviewedBy = reviewedBy
+	batch.Proposals[idx].ReviewedAt = now
+
+	return w.writeBatch(ctx, batch)
+}
+
+// AcceptAll bulk-accepts all pending proposals in a batch.
+func (w *ProposalWorkflow) AcceptAll(ctx context.Context, batchID, reviewedBy string) error {
+	batch, err := w.readBatch(ctx, batchID)
+	if err != nil {
+		return fmt.Errorf("ontology: accept all read batch %q: %w", batchID, err)
+	}
+
+	now := w.clock().UTC().Format(time.RFC3339)
+
+	for i := range batch.Proposals {
+		if batch.Proposals[i].Status != ProposalStatusPending {
+			continue
+		}
+
+		label := batch.Proposals[i].Label
+		if label == "" {
+			if batch.Proposals[i].Category == "nodeType" {
+				label = FormatNodeTypeLabel(batch.Proposals[i].Type)
+			} else {
+				label = FormatEdgeTypeLabel(batch.Proposals[i].Type)
+			}
+		}
+
+		def := TypeDefinition{
+			Type:           batch.Proposals[i].Type,
+			Label:          label,
+			Description:    batch.Proposals[i].Description,
+			DiscoveredFrom: batch.Proposals[i].DiscoveredFrom,
+			CreatedAt:      now,
+			Status:         TypeStatusActive,
+		}
+
+		if err := w.registry.RegisterType(ctx, ScopeBrain, def); err != nil {
+			return fmt.Errorf("ontology: accept all register %q: %w", batch.Proposals[i].Type, err)
+		}
+
+		batch.Proposals[i].Status = ProposalStatusAccepted
+		batch.Proposals[i].ReviewedBy = reviewedBy
+		batch.Proposals[i].ReviewedAt = now
+	}
+
+	return w.writeBatch(ctx, batch)
+}
+
+// List returns proposal batches matching the filter. All batches are
+// scanned from the store.
+func (w *ProposalWorkflow) List(ctx context.Context, filter ProposalFilter) ([]ProposalBatch, error) {
+	batches, err := w.listBatches(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ontology: list proposals: %w", err)
+	}
+
+	if filter.Status == "" && filter.Category == "" {
+		return batches, nil
+	}
+
+	filtered := make([]ProposalBatch, 0, len(batches))
+	for _, batch := range batches {
+		matchedProposals := make([]Proposal, 0, len(batch.Proposals))
+		for _, p := range batch.Proposals {
+			if filter.Status != "" && p.Status != filter.Status {
+				continue
+			}
+			if filter.Category != "" && p.Category != filter.Category {
+				continue
+			}
+			matchedProposals = append(matchedProposals, p)
+		}
+		if len(matchedProposals) > 0 {
+			filteredBatch := batch
+			filteredBatch.Proposals = matchedProposals
+			filtered = append(filtered, filteredBatch)
+		}
+	}
+
+	return filtered, nil
+}
+
+// GetBatch reads a single proposal batch by ID.
+func (w *ProposalWorkflow) GetBatch(ctx context.Context, batchID string) (*ProposalBatch, error) {
+	return w.readBatch(ctx, batchID)
+}
+
+// readBatch reads a proposal batch from the store.
+func (w *ProposalWorkflow) readBatch(ctx context.Context, id string) (*ProposalBatch, error) {
+	data, err := w.store.Read(ctx, proposalBatchPath(id))
+	if err != nil {
+		return nil, fmt.Errorf("read batch %q: %w", id, err)
+	}
+	var batch ProposalBatch
+	if err := json.Unmarshal(data, &batch); err != nil {
+		return nil, fmt.Errorf("unmarshal batch %q: %w", id, err)
+	}
+	return &batch, nil
+}
+
+// writeBatch writes a proposal batch to the store.
+func (w *ProposalWorkflow) writeBatch(ctx context.Context, batch *ProposalBatch) error {
+	data, err := json.Marshal(batch)
+	if err != nil {
+		return fmt.Errorf("marshal batch %q: %w", batch.ID, err)
+	}
+	return w.store.Write(ctx, proposalBatchPath(batch.ID), data)
+}
+
+// listBatches reads all proposal batches from the store by listing
+// files under ontology/proposals/.
+func (w *ProposalWorkflow) listBatches(ctx context.Context) ([]ProposalBatch, error) {
+	entries, err := w.store.List(ctx, proposalDirPath, brain.ListOpts{})
+	if err != nil {
+		if errors.Is(err, brain.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list proposal batches: %w", err)
+	}
+
+	batches := make([]ProposalBatch, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir || !strings.HasSuffix(string(entry.Path), ".json") {
+			continue
+		}
+		data, err := w.store.Read(ctx, entry.Path)
+		if err != nil {
+			continue
+		}
+		var batch ProposalBatch
+		if err := json.Unmarshal(data, &batch); err != nil {
+			continue
+		}
+		batches = append(batches, batch)
+	}
+
+	sort.Slice(batches, func(i, j int) bool {
+		return batches[i].CreatedAt < batches[j].CreatedAt
+	})
+
+	return batches, nil
+}
+
+// findProposal locates a proposal within a batch by ID.
+func findProposal(batch *ProposalBatch, id string) (*Proposal, int) {
+	for i := range batch.Proposals {
+		if batch.Proposals[i].ID == id {
+			return &batch.Proposals[i], i
+		}
+	}
+	return nil, -1
+}
+
+// resolvedToDefinitions converts resolved types to TypeDefinitions for
+// deduplication comparison.
+func resolvedToDefinitions(resolved *ResolvedOntology) []TypeDefinition {
+	defs := make([]TypeDefinition, 0, len(resolved.NodeTypes)+len(resolved.EdgeTypes))
+	for _, rt := range resolved.NodeTypes {
+		defs = append(defs, rt.TypeDefinition)
+	}
+	for _, rt := range resolved.EdgeTypes {
+		defs = append(defs, rt.TypeDefinition)
+	}
+	return defs
+}
+
+// extractionToDefinitions converts extraction result entries to
+// TypeDefinitions for deduplication comparison.
+func extractionToDefinitions(result ExtractionResult) []TypeDefinition {
+	now := time.Now().UTC().Format(time.RFC3339)
+	defs := make([]TypeDefinition, 0, len(result.NodeTypes)+len(result.EdgeTypes))
+	for _, nt := range result.NodeTypes {
+		defs = append(defs, TypeDefinition{
+			Type:        nt.Type,
+			Label:       nt.Label,
+			Description: nt.Description,
+			CreatedAt:   now,
+			Status:      TypeStatusProposed,
+		})
+	}
+	for _, et := range result.EdgeTypes {
+		defs = append(defs, TypeDefinition{
+			Type:        et.Type,
+			Label:       et.Label,
+			Description: et.Description,
+			CreatedAt:   now,
+			Status:      TypeStatusProposed,
+		})
+	}
+	return defs
+}

--- a/go/ontology/proposal.go
+++ b/go/ontology/proposal.go
@@ -3,16 +3,16 @@ package ontology
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/jeffs-brain/memory/go/brain"
+	"github.com/jeffs-brain/memory/go/ingest"
 )
 
 // ProposalStatus is the lifecycle state of a type proposal.
@@ -24,18 +24,6 @@ const (
 	ProposalStatusMerged   ProposalStatus = "merged"
 	ProposalStatusRejected ProposalStatus = "rejected"
 )
-
-// ExtractionResult holds extracted ontology types from a document.
-// Defined here so that the proposal workflow can accept extraction
-// outputs without depending on the extraction package (P6-4). When
-// P6-4 is implemented, it will produce values of this type.
-type ExtractionResult struct {
-	NodeTypes          []TypeEntry `json:"nodeTypes"`
-	EdgeTypes          []TypeEntry `json:"edgeTypes"`
-	BusinessCategories []string    `json:"businessCategories"`
-	Domain             string      `json:"domain"`
-	Confidence         float64     `json:"confidence"`
-}
 
 // Proposal is a candidate type awaiting review.
 type Proposal struct {
@@ -110,19 +98,15 @@ func proposalBatchPath(batchID string) brain.Path {
 const proposalDirPath = brain.Path("ontology/proposals/")
 
 // proposalIDFromInputs computes a deterministic proposal ID from the
-// type name and batch ID using SHA-256 (first 16 hex characters).
+// type name and batch ID using BLAKE3 (first 16 hex characters).
 func proposalIDFromInputs(typeName, batchID string) string {
-	input := []byte(typeName + ":" + batchID)
-	sum := sha256.Sum256(input)
-	return hex.EncodeToString(sum[:8])
+	return ingest.HashString(typeName + ":" + batchID)[:16]
 }
 
 // computeBatchID computes a deterministic batch ID from the domain,
-// source document, and timestamp using SHA-256 (first 16 hex characters).
+// source document, and timestamp using BLAKE3 (first 16 hex characters).
 func computeBatchID(domain, sourceDocument, timestamp string) string {
-	input := []byte(domain + ":" + sourceDocument + ":" + timestamp)
-	sum := sha256.Sum256(input)
-	return hex.EncodeToString(sum[:8])
+	return ingest.HashString(domain + ":" + sourceDocument + ":" + timestamp)[:16]
 }
 
 // ProposeFromExtraction creates proposals for unique types from an
@@ -136,7 +120,7 @@ func (w *ProposalWorkflow) ProposeFromExtraction(ctx context.Context, result Ext
 
 	existingTypes := resolvedToDefinitions(resolved)
 	dedup := NewDeduplicator(nil)
-	extractedDefs := extractionToDefinitions(result)
+	extractedDefs := extractionToDefinitions(result, w.clock)
 
 	dedupResult, err := dedup.Deduplicate(ctx, extractedDefs, existingTypes)
 	if err != nil {
@@ -289,7 +273,10 @@ func (w *ProposalWorkflow) Reject(ctx context.Context, batchID, proposalID, revi
 	return w.writeBatch(ctx, batch)
 }
 
-// AcceptAll bulk-accepts all pending proposals in a batch.
+// AcceptAll bulk-accepts all pending proposals in a batch. Individual
+// registration failures are collected rather than short-circuiting, and
+// the batch is written atomically at the end regardless of partial
+// failures so that successfully accepted proposals are persisted.
 func (w *ProposalWorkflow) AcceptAll(ctx context.Context, batchID, reviewedBy string) error {
 	batch, err := w.readBatch(ctx, batchID)
 	if err != nil {
@@ -297,6 +284,7 @@ func (w *ProposalWorkflow) AcceptAll(ctx context.Context, batchID, reviewedBy st
 	}
 
 	now := w.clock().UTC().Format(time.RFC3339)
+	var errs []error
 
 	for i := range batch.Proposals {
 		if batch.Proposals[i].Status != ProposalStatusPending {
@@ -321,8 +309,9 @@ func (w *ProposalWorkflow) AcceptAll(ctx context.Context, batchID, reviewedBy st
 			Status:         TypeStatusActive,
 		}
 
-		if err := w.registry.RegisterType(ctx, ScopeBrain, def); err != nil {
-			return fmt.Errorf("ontology: accept all register %q: %w", batch.Proposals[i].Type, err)
+		if regErr := w.registry.RegisterType(ctx, ScopeBrain, def); regErr != nil {
+			errs = append(errs, fmt.Errorf("register %q: %w", batch.Proposals[i].Type, regErr))
+			continue
 		}
 
 		batch.Proposals[i].Status = ProposalStatusAccepted
@@ -330,7 +319,15 @@ func (w *ProposalWorkflow) AcceptAll(ctx context.Context, batchID, reviewedBy st
 		batch.Proposals[i].ReviewedAt = now
 	}
 
-	return w.writeBatch(ctx, batch)
+	// Always write the batch so successfully accepted proposals are persisted.
+	if writeErr := w.writeBatch(ctx, batch); writeErr != nil {
+		errs = append(errs, fmt.Errorf("write batch: %w", writeErr))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("ontology: accept all batch %q: %w", batchID, errors.Join(errs...))
+	}
+	return nil
 }
 
 // List returns proposal batches matching the filter. All batches are
@@ -372,8 +369,12 @@ func (w *ProposalWorkflow) GetBatch(ctx context.Context, batchID string) (*Propo
 	return w.readBatch(ctx, batchID)
 }
 
-// readBatch reads a proposal batch from the store.
+// readBatch reads a proposal batch from the store. The batch ID is
+// validated to prevent path traversal.
 func (w *ProposalWorkflow) readBatch(ctx context.Context, id string) (*ProposalBatch, error) {
+	if err := validateID(id); err != nil {
+		return nil, fmt.Errorf("read batch: %w", err)
+	}
 	data, err := w.store.Read(ctx, proposalBatchPath(id))
 	if err != nil {
 		return nil, fmt.Errorf("read batch %q: %w", id, err)
@@ -385,8 +386,12 @@ func (w *ProposalWorkflow) readBatch(ctx context.Context, id string) (*ProposalB
 	return &batch, nil
 }
 
-// writeBatch writes a proposal batch to the store.
+// writeBatch writes a proposal batch to the store. The batch ID is
+// validated to prevent path traversal.
 func (w *ProposalWorkflow) writeBatch(ctx context.Context, batch *ProposalBatch) error {
+	if err := validateID(batch.ID); err != nil {
+		return fmt.Errorf("write batch: %w", err)
+	}
 	data, err := json.Marshal(batch)
 	if err != nil {
 		return fmt.Errorf("marshal batch %q: %w", batch.ID, err)
@@ -410,12 +415,14 @@ func (w *ProposalWorkflow) listBatches(ctx context.Context) ([]ProposalBatch, er
 		if entry.IsDir || !strings.HasSuffix(string(entry.Path), ".json") {
 			continue
 		}
-		data, err := w.store.Read(ctx, entry.Path)
-		if err != nil {
+		data, readErr := w.store.Read(ctx, entry.Path)
+		if readErr != nil {
+			slog.Warn("ontology: skipping unreadable proposal batch", "path", string(entry.Path), "error", readErr)
 			continue
 		}
 		var batch ProposalBatch
-		if err := json.Unmarshal(data, &batch); err != nil {
+		if unmarshalErr := json.Unmarshal(data, &batch); unmarshalErr != nil {
+			slog.Warn("ontology: skipping corrupt proposal batch", "path", string(entry.Path), "error", unmarshalErr)
 			continue
 		}
 		batches = append(batches, batch)
@@ -452,9 +459,10 @@ func resolvedToDefinitions(resolved *ResolvedOntology) []TypeDefinition {
 }
 
 // extractionToDefinitions converts extraction result entries to
-// TypeDefinitions for deduplication comparison.
-func extractionToDefinitions(result ExtractionResult) []TypeDefinition {
-	now := time.Now().UTC().Format(time.RFC3339)
+// TypeDefinitions for deduplication comparison. Uses the injected
+// clock instead of time.Now for deterministic testing.
+func extractionToDefinitions(result ExtractionResult, clock func() time.Time) []TypeDefinition {
+	now := clock().UTC().Format(time.RFC3339)
 	defs := make([]TypeDefinition, 0, len(result.NodeTypes)+len(result.EdgeTypes))
 	for _, nt := range result.NodeTypes {
 		defs = append(defs, TypeDefinition{

--- a/go/ontology/proposal.go
+++ b/go/ontology/proposal.go
@@ -60,9 +60,12 @@ type ProposalFilter struct {
 // already-known types, and provides accept/merge/reject operations
 // that transition types through the workflow.
 type ProposalWorkflow struct {
-	registry *Registry
-	store    brain.Store
-	clock    func() time.Time
+	registry  *Registry
+	store     brain.Store
+	brainID   string
+	projectID string
+	orgID     string
+	clock     func() time.Time
 }
 
 // ProposalWorkflowConfig configures the proposal workflow.
@@ -71,6 +74,12 @@ type ProposalWorkflowConfig struct {
 	Registry *Registry
 	// Store provides raw file access for reading/writing proposal batch JSON.
 	Store brain.Store
+	// BrainID is the brain to resolve the ontology for during proposal deduplication.
+	BrainID string
+	// ProjectID is the project to resolve the ontology for during proposal deduplication.
+	ProjectID string
+	// OrgID is the organisation to resolve the ontology for during proposal deduplication.
+	OrgID string
 	// Clock overrides time.Now for deterministic testing. Defaults to time.Now.
 	Clock func() time.Time
 }
@@ -83,9 +92,12 @@ func NewProposalWorkflow(cfg ProposalWorkflowConfig) *ProposalWorkflow {
 		clock = time.Now
 	}
 	return &ProposalWorkflow{
-		registry: cfg.Registry,
-		store:    cfg.Store,
-		clock:    clock,
+		registry:  cfg.Registry,
+		store:     cfg.Store,
+		brainID:   cfg.BrainID,
+		projectID: cfg.ProjectID,
+		orgID:     cfg.OrgID,
+		clock:     clock,
 	}
 }
 
@@ -113,7 +125,7 @@ func computeBatchID(domain, sourceDocument, timestamp string) string {
 // extraction result. Runs deduplication against the resolved ontology
 // first, so only genuinely new types become proposals.
 func (w *ProposalWorkflow) ProposeFromExtraction(ctx context.Context, result ExtractionResult, sourceDocument string) (*ProposalBatch, error) {
-	resolved, err := w.registry.Resolve(ctx, "", "", "")
+	resolved, err := w.registry.Resolve(ctx, w.brainID, w.projectID, w.orgID)
 	if err != nil {
 		return nil, fmt.Errorf("ontology: propose from extraction resolve: %w", err)
 	}

--- a/go/ontology/proposal_test.go
+++ b/go/ontology/proposal_test.go
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jeffs-brain/memory/go/ontology"
+	"github.com/jeffs-brain/memory/go/store/mem"
+)
+
+// fixedClock returns a clock function that always returns the same time.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func newTestWorkflow(t *testing.T) (*ontology.ProposalWorkflow, *ontology.Registry) {
+	t.Helper()
+	ms := mem.New()
+	t.Cleanup(func() { _ = ms.Close() })
+	cfg := ontology.FileOntologyStoreConfig{
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+	}
+	store, err := ontology.NewFileOntologyStore(ms, cfg)
+	if err != nil {
+		t.Fatalf("NewFileOntologyStore: %v", err)
+	}
+	reg := ontology.NewRegistry(store)
+	wf := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
+		Registry: reg,
+		Store:    ms,
+		Clock:    fixedClock(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)),
+	})
+	return wf, reg
+}
+
+func sampleExtraction() ontology.ExtractionResult {
+	return ontology.ExtractionResult{
+		NodeTypes: []ontology.TypeEntry{
+			{Type: "entity.invoice", Label: "Invoice", Description: "A financial invoice document"},
+			{Type: "entity.warehouse", Label: "Warehouse", Description: "Physical storage location"},
+		},
+		EdgeTypes: []ontology.TypeEntry{
+			{Type: "ships_to", Label: "Ships To", Description: "Logistics shipping relationship"},
+		},
+		BusinessCategories: []string{"logistics"},
+		Domain:             "logistics",
+		Confidence:         0.85,
+	}
+}
+
+func TestProposeFromExtraction_CreatesProposals(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test-doc.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	if batch.ID == "" {
+		t.Fatal("expected non-empty batch ID")
+	}
+	if batch.Domain != "logistics" {
+		t.Fatalf("expected domain %q, got %q", "logistics", batch.Domain)
+	}
+	if batch.SourceDocument != "test-doc.pdf" {
+		t.Fatalf("expected source %q, got %q", "test-doc.pdf", batch.SourceDocument)
+	}
+
+	// All 3 types should become proposals (2 node + 1 edge, none are built-in)
+	if len(batch.Proposals) != 3 {
+		t.Fatalf("expected 3 proposals, got %d", len(batch.Proposals))
+	}
+
+	for _, p := range batch.Proposals {
+		if p.Status != ontology.ProposalStatusPending {
+			t.Errorf("proposal %q should be pending, got %q", p.Type, p.Status)
+		}
+		if p.ID == "" {
+			t.Errorf("proposal %q has empty ID", p.Type)
+		}
+	}
+}
+
+func TestProposeFromExtraction_DedupExcluded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	// Extract with types that match built-in types
+	result := ontology.ExtractionResult{
+		NodeTypes: []ontology.TypeEntry{
+			{Type: "entity.customer", Label: "Customer (Entity)", Description: "A customer entity"},
+			{Type: "entity.invoice", Label: "Invoice", Description: "A financial invoice"},
+		},
+		EdgeTypes: []ontology.TypeEntry{
+			{Type: "triggers", Label: "Triggers", Description: "Triggers relationship"},
+		},
+		Domain: "mixed",
+	}
+
+	batch, err := wf.ProposeFromExtraction(ctx, result, "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	// entity.customer and triggers are built-in, only entity.invoice should be proposed
+	if len(batch.Proposals) != 1 {
+		t.Fatalf("expected 1 proposal (entity.invoice), got %d", len(batch.Proposals))
+	}
+	if batch.Proposals[0].Type != "entity.invoice" {
+		t.Fatalf("expected entity.invoice proposal, got %q", batch.Proposals[0].Type)
+	}
+}
+
+func TestProposeFromExtraction_EmptyExtraction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, ontology.ExtractionResult{}, "empty.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	if len(batch.Proposals) != 0 {
+		t.Fatalf("expected 0 proposals, got %d", len(batch.Proposals))
+	}
+}
+
+func TestAccept_ActivatesType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, reg := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	// Find the entity.invoice proposal
+	var invoiceProposal *ontology.Proposal
+	for i := range batch.Proposals {
+		if batch.Proposals[i].Type == "entity.invoice" {
+			invoiceProposal = &batch.Proposals[i]
+			break
+		}
+	}
+	if invoiceProposal == nil {
+		t.Fatal("entity.invoice proposal not found")
+	}
+
+	if err := wf.Accept(ctx, batch.ID, invoiceProposal.ID, "reviewer@test.com"); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+
+	// Verify the type is now active in the registry
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	found := false
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.invoice" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("accepted type entity.invoice not found in resolved ontology")
+	}
+}
+
+func TestAccept_AlreadyAccepted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	pid := batch.Proposals[0].ID
+	if err := wf.Accept(ctx, batch.ID, pid, "reviewer@test.com"); err != nil {
+		t.Fatalf("first Accept: %v", err)
+	}
+	// Second accept should be idempotent
+	if err := wf.Accept(ctx, batch.ID, pid, "reviewer@test.com"); err != nil {
+		t.Fatalf("second Accept (idempotent): %v", err)
+	}
+}
+
+func TestMerge_SetsTarget(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	pid := batch.Proposals[0].ID
+	if err := wf.Merge(ctx, batch.ID, pid, "entity.customer", "reviewer@test.com"); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	// Verify the proposal is marked as merged
+	updated, err := wf.GetBatch(ctx, batch.ID)
+	if err != nil {
+		t.Fatalf("GetBatch: %v", err)
+	}
+	for _, p := range updated.Proposals {
+		if p.ID == pid {
+			if p.Status != ontology.ProposalStatusMerged {
+				t.Fatalf("expected merged status, got %q", p.Status)
+			}
+			if p.MergedInto != "entity.customer" {
+				t.Fatalf("expected mergedInto %q, got %q", "entity.customer", p.MergedInto)
+			}
+			if p.ReviewedBy != "reviewer@test.com" {
+				t.Fatalf("expected reviewedBy %q, got %q", "reviewer@test.com", p.ReviewedBy)
+			}
+			return
+		}
+	}
+	t.Fatal("proposal not found after merge")
+}
+
+func TestReject_SetsStatus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, reg := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	pid := batch.Proposals[0].ID
+	typeName := batch.Proposals[0].Type
+	if err := wf.Reject(ctx, batch.ID, pid, "reviewer@test.com"); err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+
+	// Verify proposal is rejected
+	updated, err := wf.GetBatch(ctx, batch.ID)
+	if err != nil {
+		t.Fatalf("GetBatch: %v", err)
+	}
+	for _, p := range updated.Proposals {
+		if p.ID == pid {
+			if p.Status != ontology.ProposalStatusRejected {
+				t.Fatalf("expected rejected status, got %q", p.Status)
+			}
+			break
+		}
+	}
+
+	// Verify rejected type is NOT in the registry
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == typeName && rt.Scope == "brain" {
+			t.Fatal("rejected type should not appear in resolved ontology")
+		}
+	}
+}
+
+func TestAcceptAll_BulkActivates(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, reg := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	if err := wf.AcceptAll(ctx, batch.ID, "reviewer@test.com"); err != nil {
+		t.Fatalf("AcceptAll: %v", err)
+	}
+
+	// Verify all proposals are accepted
+	updated, err := wf.GetBatch(ctx, batch.ID)
+	if err != nil {
+		t.Fatalf("GetBatch: %v", err)
+	}
+	for _, p := range updated.Proposals {
+		if p.Status != ontology.ProposalStatusAccepted {
+			t.Fatalf("expected accepted status for %q, got %q", p.Type, p.Status)
+		}
+		if p.ReviewedBy != "reviewer@test.com" {
+			t.Fatalf("expected reviewedBy %q, got %q", "reviewer@test.com", p.ReviewedBy)
+		}
+	}
+
+	// Verify types are in resolved ontology
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	expectedTypes := map[string]bool{
+		"entity.invoice":   false,
+		"entity.warehouse": false,
+		"ships_to":         false,
+	}
+	for _, rt := range resolved.NodeTypes {
+		if _, ok := expectedTypes[rt.Type]; ok {
+			expectedTypes[rt.Type] = true
+		}
+	}
+	for _, rt := range resolved.EdgeTypes {
+		if _, ok := expectedTypes[rt.Type]; ok {
+			expectedTypes[rt.Type] = true
+		}
+	}
+	for typeName, found := range expectedTypes {
+		if !found {
+			t.Errorf("expected type %q in resolved ontology after AcceptAll", typeName)
+		}
+	}
+}
+
+func TestList_FilterByStatus(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	// Accept one, reject one
+	if err := wf.Accept(ctx, batch.ID, batch.Proposals[0].ID, "reviewer"); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if err := wf.Reject(ctx, batch.ID, batch.Proposals[1].ID, "reviewer"); err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+
+	// List pending only
+	pending, err := wf.List(ctx, ontology.ProposalFilter{Status: ontology.ProposalStatusPending})
+	if err != nil {
+		t.Fatalf("List pending: %v", err)
+	}
+	totalPending := 0
+	for _, b := range pending {
+		totalPending += len(b.Proposals)
+	}
+	if totalPending != 1 {
+		t.Fatalf("expected 1 pending proposal, got %d", totalPending)
+	}
+
+	// List accepted
+	accepted, err := wf.List(ctx, ontology.ProposalFilter{Status: ontology.ProposalStatusAccepted})
+	if err != nil {
+		t.Fatalf("List accepted: %v", err)
+	}
+	totalAccepted := 0
+	for _, b := range accepted {
+		totalAccepted += len(b.Proposals)
+	}
+	if totalAccepted != 1 {
+		t.Fatalf("expected 1 accepted proposal, got %d", totalAccepted)
+	}
+}
+
+func TestList_NoFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	_, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	all, err := wf.List(ctx, ontology.ProposalFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 batch, got %d", len(all))
+	}
+	if len(all[0].Proposals) != 3 {
+		t.Fatalf("expected 3 proposals, got %d", len(all[0].Proposals))
+	}
+}
+
+func TestStoragePersistence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ms := mem.New()
+	t.Cleanup(func() { _ = ms.Close() })
+	cfg := ontology.FileOntologyStoreConfig{
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+	}
+	store, err := ontology.NewFileOntologyStore(ms, cfg)
+	if err != nil {
+		t.Fatalf("NewFileOntologyStore: %v", err)
+	}
+	reg := ontology.NewRegistry(store)
+
+	clock := fixedClock(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC))
+
+	wf1 := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
+		Registry: reg,
+		Store:    ms,
+		Clock:    clock,
+	})
+
+	batch, err := wf1.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	// Create a new workflow instance (simulating restart)
+	wf2 := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
+		Registry: reg,
+		Store:    ms,
+		Clock:    clock,
+	})
+
+	// Should be able to read the batch from the second workflow
+	readBack, err := wf2.GetBatch(ctx, batch.ID)
+	if err != nil {
+		t.Fatalf("GetBatch on new workflow: %v", err)
+	}
+	if len(readBack.Proposals) != len(batch.Proposals) {
+		t.Fatalf("expected %d proposals, got %d", len(batch.Proposals), len(readBack.Proposals))
+	}
+}
+
+func TestProposalCategories(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	nodeTypeCount := 0
+	edgeTypeCount := 0
+	for _, p := range batch.Proposals {
+		switch p.Category {
+		case "nodeType":
+			nodeTypeCount++
+		case "edgeType":
+			edgeTypeCount++
+		default:
+			t.Errorf("unexpected category %q for proposal %q", p.Category, p.Type)
+		}
+	}
+	if nodeTypeCount != 2 {
+		t.Errorf("expected 2 nodeType proposals, got %d", nodeTypeCount)
+	}
+	if edgeTypeCount != 1 {
+		t.Errorf("expected 1 edgeType proposal, got %d", edgeTypeCount)
+	}
+}
+
+func TestReject_CannotRejectAccepted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	batch, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	pid := batch.Proposals[0].ID
+	if err := wf.Accept(ctx, batch.ID, pid, "reviewer"); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+
+	err = wf.Reject(ctx, batch.ID, pid, "reviewer")
+	if err == nil {
+		t.Fatal("expected error when rejecting already-accepted proposal")
+	}
+}
+
+func TestProposalRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, reg := newTestWorkflow(t)
+
+	// Extract -> propose -> accept -> verify in resolved ontology
+	result := ontology.ExtractionResult{
+		NodeTypes: []ontology.TypeEntry{
+			{Type: "entity.invoice", Label: "Invoice", Description: "A financial invoice"},
+		},
+		Domain: "finance",
+	}
+
+	batch, err := wf.ProposeFromExtraction(ctx, result, "finance.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+	if len(batch.Proposals) != 1 {
+		t.Fatalf("expected 1 proposal, got %d", len(batch.Proposals))
+	}
+
+	// Before accept: type should not be in resolved
+	resolved, err := reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.invoice" && rt.Scope == "brain" {
+			t.Fatal("proposed type should not appear in resolved ontology before accept")
+		}
+	}
+
+	// Accept
+	if err := wf.Accept(ctx, batch.ID, batch.Proposals[0].ID, "reviewer@test.com"); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+
+	// After accept: type should be in resolved
+	resolved, err = reg.Resolve(ctx, "brain-1", "proj-1", "org-1")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	found := false
+	for _, rt := range resolved.NodeTypes {
+		if rt.Type == "entity.invoice" {
+			found = true
+			if rt.Scope != "brain" {
+				t.Fatalf("expected scope brain, got %q", rt.Scope)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("accepted type entity.invoice not found in resolved ontology")
+	}
+}

--- a/go/ontology/proposal_test.go
+++ b/go/ontology/proposal_test.go
@@ -375,6 +375,43 @@ func TestList_FilterByStatus(t *testing.T) {
 	}
 }
 
+func TestList_CategoryFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	wf, _ := newTestWorkflow(t)
+
+	_, err := wf.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
+	if err != nil {
+		t.Fatalf("ProposeFromExtraction: %v", err)
+	}
+
+	// Filter by nodeType category -- sampleExtraction has 2 node + 1 edge
+	nodeOnly, err := wf.List(ctx, ontology.ProposalFilter{Category: "nodeType"})
+	if err != nil {
+		t.Fatalf("List nodeType: %v", err)
+	}
+	totalNodeType := 0
+	for _, b := range nodeOnly {
+		totalNodeType += len(b.Proposals)
+	}
+	if totalNodeType != 2 {
+		t.Fatalf("expected 2 nodeType proposals, got %d", totalNodeType)
+	}
+
+	// Filter by edgeType category
+	edgeOnly, err := wf.List(ctx, ontology.ProposalFilter{Category: "edgeType"})
+	if err != nil {
+		t.Fatalf("List edgeType: %v", err)
+	}
+	totalEdgeType := 0
+	for _, b := range edgeOnly {
+		totalEdgeType += len(b.Proposals)
+	}
+	if totalEdgeType != 1 {
+		t.Fatalf("expected 1 edgeType proposal, got %d", totalEdgeType)
+	}
+}
+
 func TestList_NoFilter(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/go/ontology/proposal_test.go
+++ b/go/ontology/proposal_test.go
@@ -30,9 +30,12 @@ func newTestWorkflow(t *testing.T) (*ontology.ProposalWorkflow, *ontology.Regist
 	}
 	reg := ontology.NewRegistry(store)
 	wf := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
-		Registry: reg,
-		Store:    ms,
-		Clock:    fixedClock(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)),
+		Registry:  reg,
+		Store:     ms,
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+		Clock:     fixedClock(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)),
 	})
 	return wf, reg
 }
@@ -453,9 +456,12 @@ func TestStoragePersistence(t *testing.T) {
 	clock := fixedClock(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC))
 
 	wf1 := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
-		Registry: reg,
-		Store:    ms,
-		Clock:    clock,
+		Registry:  reg,
+		Store:     ms,
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+		Clock:     clock,
 	})
 
 	batch, err := wf1.ProposeFromExtraction(ctx, sampleExtraction(), "test.pdf")
@@ -465,9 +471,12 @@ func TestStoragePersistence(t *testing.T) {
 
 	// Create a new workflow instance (simulating restart)
 	wf2 := ontology.NewProposalWorkflow(ontology.ProposalWorkflowConfig{
-		Registry: reg,
-		Store:    ms,
-		Clock:    clock,
+		Registry:  reg,
+		Store:     ms,
+		BrainID:   "brain-1",
+		ProjectID: "proj-1",
+		OrgID:     "org-1",
+		Clock:     clock,
 	})
 
 	// Should be able to read the batch from the second workflow

--- a/sdks/ts/memory-postgres/migrations/0006_ontology_proposals.sql
+++ b/sdks/ts/memory-postgres/migrations/0006_ontology_proposals.sql
@@ -1,0 +1,38 @@
+-- 0006_ontology_proposals.sql
+-- Ontology proposal workflow tables. Stores proposal batches and individual
+-- proposals for the type discovery and review lifecycle. Supports filtering
+-- by status and category for efficient retrieval.
+--
+-- Owned by ticket P6-7 (LLE-9795).
+
+CREATE TABLE IF NOT EXISTS memory.ontology_proposal_batches (
+  id              TEXT        PRIMARY KEY,
+  domain          TEXT        NOT NULL DEFAULT '',
+  source_document TEXT        NOT NULL DEFAULT '',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS memory.ontology_proposals (
+  id              TEXT        PRIMARY KEY,
+  batch_id        TEXT        NOT NULL REFERENCES memory.ontology_proposal_batches(id) ON DELETE CASCADE,
+  type_name       TEXT        NOT NULL,
+  label           TEXT        NOT NULL,
+  description     TEXT        NOT NULL DEFAULT '',
+  category        TEXT        NOT NULL CHECK (category IN ('nodeType', 'edgeType')),
+  discovered_from TEXT        NOT NULL DEFAULT '',
+  status          TEXT        NOT NULL DEFAULT 'proposed'
+                              CHECK (status IN ('proposed', 'accepted', 'merged', 'rejected')),
+  reviewed_by     TEXT,
+  reviewed_at     TIMESTAMPTZ,
+  merged_into     TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ontology_proposals_batch_id
+  ON memory.ontology_proposals(batch_id);
+
+CREATE INDEX IF NOT EXISTS idx_ontology_proposals_status
+  ON memory.ontology_proposals(status);
+
+CREATE INDEX IF NOT EXISTS idx_ontology_proposals_category
+  ON memory.ontology_proposals(category);

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -111,3 +111,12 @@ export {
   TEMPLATE_MATCH_SEMANTIC_THRESHOLD,
   TEMPLATE_MATCH_COMBINED_MINIMUM,
 } from './template-match.js'
+
+export type {
+  Proposal,
+  ProposalBatch,
+  ProposalFilter,
+  ProposalStatus,
+  ProposalWorkflowConfig,
+} from './proposal.js'
+export { ProposalWorkflow } from './proposal.js'

--- a/sdks/ts/memory/src/ontology/proposal.test.ts
+++ b/sdks/ts/memory/src/ontology/proposal.test.ts
@@ -231,6 +231,25 @@ describe('ProposalWorkflow', () => {
       expect(all[0].proposals).toHaveLength(3)
     })
 
+    it('filters by category', async () => {
+      await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      // sampleExtraction has 2 nodeType and 1 edgeType
+      const nodeOnly = await workflow.list({ category: 'nodeType' })
+      let totalNodeType = 0
+      for (const b of nodeOnly) {
+        totalNodeType += b.proposals.length
+      }
+      expect(totalNodeType).toBe(2)
+
+      const edgeOnly = await workflow.list({ category: 'edgeType' })
+      let totalEdgeType = 0
+      for (const b of edgeOnly) {
+        totalEdgeType += b.proposals.length
+      }
+      expect(totalEdgeType).toBe(1)
+    })
+
     it('filters by status', async () => {
       const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
 

--- a/sdks/ts/memory/src/ontology/proposal.test.ts
+++ b/sdks/ts/memory/src/ontology/proposal.test.ts
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import { createMemStore } from '../store/memstore.js'
+import { createFileOntologyStore } from './store.js'
+import { Registry } from './registry.js'
+import { ProposalWorkflow, type ExtractionResult, type ProposalBatch } from './proposal.js'
+import type { TypeEntry } from './templates.js'
+
+function fixedClock(date: Date): () => Date {
+  return () => date
+}
+
+function makeWorkflow(): { workflow: ProposalWorkflow; registry: Registry } {
+  const backingStore = createMemStore()
+  const ontologyStore = createFileOntologyStore(backingStore, {
+    brainId: 'brain-1',
+    projectId: 'proj-1',
+    orgId: 'org-1',
+  })
+  const registry = new Registry({ store: ontologyStore })
+  const workflow = new ProposalWorkflow({
+    registry,
+    store: backingStore,
+    clock: fixedClock(new Date('2026-05-15T12:00:00.000Z')),
+  })
+  return { workflow, registry }
+}
+
+function sampleExtraction(): ExtractionResult {
+  return {
+    nodeTypes: [
+      { type: 'entity.invoice', label: 'Invoice', description: 'A financial invoice document' },
+      { type: 'entity.warehouse', label: 'Warehouse', description: 'Physical storage location' },
+    ],
+    edgeTypes: [
+      { type: 'ships_to', label: 'Ships To', description: 'Logistics shipping relationship' },
+    ],
+    businessCategories: ['logistics'],
+    domain: 'logistics',
+    confidence: 0.85,
+  }
+}
+
+describe('ProposalWorkflow', () => {
+  let workflow: ProposalWorkflow
+  let registry: Registry
+
+  beforeEach(() => {
+    const setup = makeWorkflow()
+    workflow = setup.workflow
+    registry = setup.registry
+  })
+
+  describe('proposeFromExtraction', () => {
+    it('creates proposals for unique types', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test-doc.pdf')
+
+      expect(batch.id).toBeTruthy()
+      expect(batch.domain).toBe('logistics')
+      expect(batch.sourceDocument).toBe('test-doc.pdf')
+      expect(batch.proposals).toHaveLength(3)
+
+      for (const p of batch.proposals) {
+        expect(p.status).toBe('proposed')
+        expect(p.id).toBeTruthy()
+      }
+    })
+
+    it('excludes types matching existing ontology via dedup', async () => {
+      const result: ExtractionResult = {
+        nodeTypes: [
+          { type: 'entity.customer', label: 'Customer (Entity)', description: 'A customer entity' },
+          { type: 'entity.invoice', label: 'Invoice', description: 'A financial invoice' },
+        ],
+        edgeTypes: [
+          { type: 'triggers', label: 'Triggers', description: 'Triggers relationship' },
+        ],
+        businessCategories: [],
+        domain: 'mixed',
+        confidence: 0.8,
+      }
+
+      const batch = await workflow.proposeFromExtraction(result, 'test.pdf')
+      // entity.customer and triggers are built-in, only entity.invoice should be proposed
+      expect(batch.proposals).toHaveLength(1)
+      expect(batch.proposals[0].type).toBe('entity.invoice')
+    })
+
+    it('returns empty batch for empty extraction', async () => {
+      const result: ExtractionResult = {
+        nodeTypes: [],
+        edgeTypes: [],
+        businessCategories: [],
+        domain: '',
+        confidence: 0,
+      }
+
+      const batch = await workflow.proposeFromExtraction(result, 'empty.pdf')
+      expect(batch.proposals).toHaveLength(0)
+    })
+
+    it('assigns correct categories', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      const nodeTypes = batch.proposals.filter((p) => p.category === 'nodeType')
+      const edgeTypes = batch.proposals.filter((p) => p.category === 'edgeType')
+
+      expect(nodeTypes).toHaveLength(2)
+      expect(edgeTypes).toHaveLength(1)
+    })
+  })
+
+  describe('accept', () => {
+    it('activates type in registry', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const invoiceProposal = batch.proposals.find((p) => p.type === 'entity.invoice')!
+
+      await workflow.accept(batch.id, invoiceProposal.id, 'reviewer@test.com')
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const invoice = resolved.nodeTypes.find((t) => t.type === 'entity.invoice')
+      expect(invoice).toBeDefined()
+    })
+
+    it('is idempotent for already-accepted proposals', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+
+      await workflow.accept(batch.id, pid, 'reviewer@test.com')
+      await workflow.accept(batch.id, pid, 'reviewer@test.com')
+      // No error thrown
+    })
+
+    it('records reviewer and timestamp', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+
+      await workflow.accept(batch.id, pid, 'reviewer@test.com')
+
+      const updated = await workflow.getBatch(batch.id)
+      const accepted = updated.proposals.find((p) => p.id === pid)!
+      expect(accepted.status).toBe('accepted')
+      expect(accepted.reviewedBy).toBe('reviewer@test.com')
+      expect(accepted.reviewedAt).toBeTruthy()
+    })
+  })
+
+  describe('merge', () => {
+    it('sets target type', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+
+      await workflow.merge(batch.id, pid, 'entity.customer', 'reviewer@test.com')
+
+      const updated = await workflow.getBatch(batch.id)
+      const merged = updated.proposals.find((p) => p.id === pid)!
+      expect(merged.status).toBe('merged')
+      expect(merged.mergedInto).toBe('entity.customer')
+      expect(merged.reviewedBy).toBe('reviewer@test.com')
+    })
+  })
+
+  describe('reject', () => {
+    it('sets status to rejected', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+
+      await workflow.reject(batch.id, pid, 'reviewer@test.com')
+
+      const updated = await workflow.getBatch(batch.id)
+      const rejected = updated.proposals.find((p) => p.id === pid)!
+      expect(rejected.status).toBe('rejected')
+      expect(rejected.reviewedBy).toBe('reviewer@test.com')
+    })
+
+    it('does not affect registry', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+      const typeName = batch.proposals[0].type
+
+      await workflow.reject(batch.id, pid, 'reviewer@test.com')
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const found = resolved.nodeTypes.find(
+        (t) => t.type === typeName && t.scope === 'brain',
+      )
+      expect(found).toBeUndefined()
+    })
+
+    it('throws when rejecting an accepted proposal', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+      const pid = batch.proposals[0].id
+
+      await workflow.accept(batch.id, pid, 'reviewer')
+      await expect(
+        workflow.reject(batch.id, pid, 'reviewer'),
+      ).rejects.toThrow('cannot reject')
+    })
+  })
+
+  describe('acceptAll', () => {
+    it('bulk-accepts all pending proposals', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      await workflow.acceptAll(batch.id, 'reviewer@test.com')
+
+      const updated = await workflow.getBatch(batch.id)
+      for (const p of updated.proposals) {
+        expect(p.status).toBe('accepted')
+        expect(p.reviewedBy).toBe('reviewer@test.com')
+      }
+
+      const resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const invoiceFound = resolved.nodeTypes.some((t) => t.type === 'entity.invoice')
+      const warehouseFound = resolved.nodeTypes.some((t) => t.type === 'entity.warehouse')
+      const shipsToFound = resolved.edgeTypes.some((t) => t.type === 'ships_to')
+
+      expect(invoiceFound).toBe(true)
+      expect(warehouseFound).toBe(true)
+      expect(shipsToFound).toBe(true)
+    })
+  })
+
+  describe('list', () => {
+    it('returns all batches without filter', async () => {
+      await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      const all = await workflow.list()
+      expect(all).toHaveLength(1)
+      expect(all[0].proposals).toHaveLength(3)
+    })
+
+    it('filters by status', async () => {
+      const batch = await workflow.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      await workflow.accept(batch.id, batch.proposals[0].id, 'reviewer')
+      await workflow.reject(batch.id, batch.proposals[1].id, 'reviewer')
+
+      const pending = await workflow.list({ status: 'proposed' })
+      let totalPending = 0
+      for (const b of pending) {
+        totalPending += b.proposals.length
+      }
+      expect(totalPending).toBe(1)
+
+      const accepted = await workflow.list({ status: 'accepted' })
+      let totalAccepted = 0
+      for (const b of accepted) {
+        totalAccepted += b.proposals.length
+      }
+      expect(totalAccepted).toBe(1)
+    })
+  })
+
+  describe('persistence', () => {
+    it('survives workflow reconstruction', async () => {
+      const backingStore = createMemStore()
+      const ontologyStore = createFileOntologyStore(backingStore, {
+        brainId: 'brain-1',
+        projectId: 'proj-1',
+        orgId: 'org-1',
+      })
+      const reg = new Registry({ store: ontologyStore })
+      const clock = fixedClock(new Date('2026-05-15T12:00:00.000Z'))
+
+      const wf1 = new ProposalWorkflow({ registry: reg, store: backingStore, clock })
+      const batch = await wf1.proposeFromExtraction(sampleExtraction(), 'test.pdf')
+
+      const wf2 = new ProposalWorkflow({ registry: reg, store: backingStore, clock })
+      const readBack = await wf2.getBatch(batch.id)
+      expect(readBack.proposals).toHaveLength(batch.proposals.length)
+    })
+  })
+
+  describe('round-trip', () => {
+    it('extract -> propose -> accept -> verify in resolved', async () => {
+      const result: ExtractionResult = {
+        nodeTypes: [
+          { type: 'entity.invoice', label: 'Invoice', description: 'A financial invoice' },
+        ],
+        edgeTypes: [],
+        businessCategories: [],
+        domain: 'finance',
+        confidence: 0.9,
+      }
+
+      const batch = await workflow.proposeFromExtraction(result, 'finance.pdf')
+      expect(batch.proposals).toHaveLength(1)
+
+      // Before accept: not in resolved
+      let resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const beforeAccept = resolved.nodeTypes.find(
+        (t) => t.type === 'entity.invoice' && t.scope === 'brain',
+      )
+      expect(beforeAccept).toBeUndefined()
+
+      // Accept
+      await workflow.accept(batch.id, batch.proposals[0].id, 'reviewer@test.com')
+
+      // After accept: in resolved
+      resolved = await registry.resolve('brain-1', 'proj-1', 'org-1')
+      const afterAccept = resolved.nodeTypes.find((t) => t.type === 'entity.invoice')
+      expect(afterAccept).toBeDefined()
+      expect(afterAccept!.scope).toBe('brain')
+    })
+  })
+})

--- a/sdks/ts/memory/src/ontology/proposal.test.ts
+++ b/sdks/ts/memory/src/ontology/proposal.test.ts
@@ -22,6 +22,9 @@ function makeWorkflow(): { workflow: ProposalWorkflow; registry: Registry } {
   const workflow = new ProposalWorkflow({
     registry,
     store: backingStore,
+    brainId: 'brain-1',
+    projectId: 'proj-1',
+    orgId: 'org-1',
     clock: fixedClock(new Date('2026-05-15T12:00:00.000Z')),
   })
   return { workflow, registry }
@@ -283,10 +286,10 @@ describe('ProposalWorkflow', () => {
       const reg = new Registry({ store: ontologyStore })
       const clock = fixedClock(new Date('2026-05-15T12:00:00.000Z'))
 
-      const wf1 = new ProposalWorkflow({ registry: reg, store: backingStore, clock })
+      const wf1 = new ProposalWorkflow({ registry: reg, store: backingStore, brainId: 'brain-1', projectId: 'proj-1', orgId: 'org-1', clock })
       const batch = await wf1.proposeFromExtraction(sampleExtraction(), 'test.pdf')
 
-      const wf2 = new ProposalWorkflow({ registry: reg, store: backingStore, clock })
+      const wf2 = new ProposalWorkflow({ registry: reg, store: backingStore, brainId: 'brain-1', projectId: 'proj-1', orgId: 'org-1', clock })
       const readBack = await wf2.getBatch(batch.id)
       expect(readBack.proposals).toHaveLength(batch.proposals.length)
     })

--- a/sdks/ts/memory/src/ontology/proposal.ts
+++ b/sdks/ts/memory/src/ontology/proposal.ts
@@ -56,6 +56,9 @@ export type ProposalFilter = {
 export type ProposalWorkflowConfig = {
   readonly registry: Registry
   readonly store: Store
+  readonly brainId: string
+  readonly projectId?: string
+  readonly orgId?: string
   readonly clock?: () => Date
 }
 
@@ -103,11 +106,17 @@ function computeBatchId(domain: string, sourceDocument: string, timestamp: strin
 export class ProposalWorkflow {
   private readonly registry: Registry
   private readonly store: Store
+  private readonly brainId: string
+  private readonly projectId: string
+  private readonly orgId: string
   private readonly clock: () => Date
 
   constructor(config: ProposalWorkflowConfig) {
     this.registry = config.registry
     this.store = config.store
+    this.brainId = config.brainId
+    this.projectId = config.projectId ?? ''
+    this.orgId = config.orgId ?? ''
     this.clock = config.clock ?? (() => new Date())
   }
 
@@ -119,7 +128,7 @@ export class ProposalWorkflow {
     result: ExtractionResult,
     sourceDocument: string,
   ): Promise<ProposalBatch> {
-    const resolved = await this.registry.resolve('', '', '')
+    const resolved = await this.registry.resolve(this.brainId, this.projectId, this.orgId)
     const existingTypes = resolvedToDefinitions(resolved)
     const extractedDefs = extractionToDefinitions(result, this.clock)
 

--- a/sdks/ts/memory/src/ontology/proposal.ts
+++ b/sdks/ts/memory/src/ontology/proposal.ts
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Proposal workflow for ontology type discovery and review. Creates
+ * proposals from extraction results, runs deduplication against the
+ * resolved ontology, and provides accept/merge/reject operations with
+ * full audit trail.
+ *
+ * Port of go/ontology/proposal.go.
+ */
+
+import { createHash } from 'node:crypto'
+
+import type { Store } from '../store/index.js'
+import { isNotFound } from '../store/errors.js'
+import { type Path, toPath } from '../store/path.js'
+import type { OntologyTypeDefinition, TypeStatus } from './types.js'
+import type { ResolvedOntology } from './store.js'
+import type { Registry } from './registry.js'
+import type { TypeEntry } from './templates.js'
+import { Deduplicator } from './dedup.js'
+import { formatEdgeTypeLabel, formatNodeTypeLabel } from './format.js'
+import { hasPrefix } from './validation.js'
+
+export type ProposalStatus = 'proposed' | 'accepted' | 'merged' | 'rejected'
+
+/**
+ * ExtractionResult holds extracted ontology types from a document.
+ * Defined here so that the proposal workflow can accept extraction
+ * outputs without depending on the extraction module (P6-4).
+ */
+export type ExtractionResult = {
+  readonly nodeTypes: readonly TypeEntry[]
+  readonly edgeTypes: readonly TypeEntry[]
+  readonly businessCategories: readonly string[]
+  readonly domain: string
+  readonly confidence: number
+}
+
+export type Proposal = {
+  readonly id: string
+  readonly type: string
+  readonly label: string
+  readonly description: string
+  readonly category: 'nodeType' | 'edgeType'
+  readonly discoveredFrom: string
+  readonly createdAt: string
+  readonly status: ProposalStatus
+  readonly reviewedBy?: string
+  readonly reviewedAt?: string
+  readonly mergedInto?: string
+}
+
+export type ProposalBatch = {
+  readonly id: string
+  readonly proposals: readonly Proposal[]
+  readonly domain: string
+  readonly sourceDocument: string
+  readonly createdAt: string
+}
+
+export type ProposalFilter = {
+  readonly status?: ProposalStatus
+  readonly category?: 'nodeType' | 'edgeType'
+}
+
+export type ProposalWorkflowConfig = {
+  readonly registry: Registry
+  readonly store: Store
+  readonly clock?: () => Date
+}
+
+type MutableProposal = {
+  id: string
+  type: string
+  label: string
+  description: string
+  category: 'nodeType' | 'edgeType'
+  discoveredFrom: string
+  createdAt: string
+  status: ProposalStatus
+  reviewedBy?: string
+  reviewedAt?: string
+  mergedInto?: string
+}
+
+type MutableProposalBatch = {
+  id: string
+  proposals: MutableProposal[]
+  domain: string
+  sourceDocument: string
+  createdAt: string
+}
+
+function proposalBatchPath(batchId: string): Path {
+  return toPath(`ontology/proposals/${batchId}.json`)
+}
+
+const PROPOSALS_DIR: Path = toPath('ontology/proposals')
+
+function computeProposalId(typeName: string, batchId: string): string {
+  const hash = createHash('sha256').update(`${typeName}:${batchId}`).digest('hex')
+  return hash.slice(0, 16)
+}
+
+function computeBatchId(domain: string, sourceDocument: string, timestamp: string): string {
+  const hash = createHash('sha256').update(`${domain}:${sourceDocument}:${timestamp}`).digest('hex')
+  return hash.slice(0, 16)
+}
+
+/**
+ * ProposalWorkflow manages the type proposal lifecycle. Creates
+ * proposals from extraction results, stores them as JSON in the
+ * brain store, and provides accept/merge/reject operations.
+ */
+export class ProposalWorkflow {
+  private readonly registry: Registry
+  private readonly store: Store
+  private readonly clock: () => Date
+
+  constructor(config: ProposalWorkflowConfig) {
+    this.registry = config.registry
+    this.store = config.store
+    this.clock = config.clock ?? (() => new Date())
+  }
+
+  /**
+   * Creates proposals for unique types from an extraction result.
+   * Runs deduplication against the resolved ontology first.
+   */
+  async proposeFromExtraction(
+    result: ExtractionResult,
+    sourceDocument: string,
+  ): Promise<ProposalBatch> {
+    const resolved = await this.registry.resolve('', '', '')
+    const existingTypes = resolvedToDefinitions(resolved)
+    const extractedDefs = extractionToDefinitions(result)
+
+    const dedup = new Deduplicator({})
+    const dedupResult = await dedup.deduplicate(extractedDefs, existingTypes)
+
+    const now = this.clock().toISOString()
+    const batchId = computeBatchId(result.domain, sourceDocument, now)
+
+    const proposals: Proposal[] = dedupResult.unique.map((unique) => {
+      const category: 'nodeType' | 'edgeType' = hasPrefix(unique.type) !== undefined ? 'nodeType' : 'edgeType'
+      return {
+        id: computeProposalId(unique.type, batchId),
+        type: unique.type,
+        label: unique.label,
+        description: unique.description,
+        category,
+        discoveredFrom: sourceDocument,
+        createdAt: now,
+        status: 'proposed' as ProposalStatus,
+      }
+    })
+
+    const batch: ProposalBatch = {
+      id: batchId,
+      proposals,
+      domain: result.domain,
+      sourceDocument,
+      createdAt: now,
+    }
+
+    await this.writeBatch(batch)
+    return batch
+  }
+
+  /**
+   * Activates a proposed type in the registry at brain scope.
+   * Idempotent for already-accepted proposals.
+   */
+  async accept(batchId: string, proposalId: string, reviewedBy: string): Promise<void> {
+    const batch = await this.readBatch(batchId)
+    const { proposal, index } = findProposal(batch, proposalId)
+
+    if (proposal.status === 'accepted') return
+
+    if (proposal.status !== 'proposed') {
+      throw new Error(`ontology: cannot accept proposal "${proposalId}" with status "${proposal.status}"`)
+    }
+
+    const now = this.clock().toISOString()
+    const label = proposal.label !== ''
+      ? proposal.label
+      : proposal.category === 'nodeType'
+        ? formatNodeTypeLabel(proposal.type)
+        : formatEdgeTypeLabel(proposal.type)
+
+    const def: OntologyTypeDefinition = {
+      type: proposal.type,
+      label,
+      description: proposal.description,
+      createdAt: now,
+      status: 'active' as TypeStatus,
+    }
+
+    await this.registry.registerType('brain', def)
+
+    const mutable = toMutableBatch(batch)
+    const target = mutable.proposals[index]
+    if (target === undefined) throw new Error('ontology: proposal index out of bounds')
+    target.status = 'accepted'
+    target.reviewedBy = reviewedBy
+    target.reviewedAt = now
+
+    await this.writeBatch(mutable)
+  }
+
+  /**
+   * Marks a proposal as merged into an existing type. No registry
+   * change; the decision is recorded for audit purposes.
+   * Idempotent for already-merged proposals.
+   */
+  async merge(batchId: string, proposalId: string, targetType: string, reviewedBy: string): Promise<void> {
+    const batch = await this.readBatch(batchId)
+    const { proposal, index } = findProposal(batch, proposalId)
+
+    if (proposal.status === 'merged') return
+
+    if (proposal.status !== 'proposed') {
+      throw new Error(`ontology: cannot merge proposal "${proposalId}" with status "${proposal.status}"`)
+    }
+
+    const now = this.clock().toISOString()
+    const mutable = toMutableBatch(batch)
+    const target = mutable.proposals[index]
+    if (target === undefined) throw new Error('ontology: proposal index out of bounds')
+    target.status = 'merged'
+    target.mergedInto = targetType
+    target.reviewedBy = reviewedBy
+    target.reviewedAt = now
+
+    await this.writeBatch(mutable)
+  }
+
+  /**
+   * Marks a proposal as rejected. No registry change.
+   * Idempotent for already-rejected proposals.
+   */
+  async reject(batchId: string, proposalId: string, reviewedBy: string): Promise<void> {
+    const batch = await this.readBatch(batchId)
+    const { proposal, index } = findProposal(batch, proposalId)
+
+    if (proposal.status === 'rejected') return
+
+    if (proposal.status !== 'proposed') {
+      throw new Error(`ontology: cannot reject proposal "${proposalId}" with status "${proposal.status}"`)
+    }
+
+    const now = this.clock().toISOString()
+    const mutable = toMutableBatch(batch)
+    const target = mutable.proposals[index]
+    if (target === undefined) throw new Error('ontology: proposal index out of bounds')
+    target.status = 'rejected'
+    target.reviewedBy = reviewedBy
+    target.reviewedAt = now
+
+    await this.writeBatch(mutable)
+  }
+
+  /**
+   * Bulk-accepts all pending proposals in a batch.
+   */
+  async acceptAll(batchId: string, reviewedBy: string): Promise<void> {
+    const batch = await this.readBatch(batchId)
+    const mutable = toMutableBatch(batch)
+    const now = this.clock().toISOString()
+
+    for (const p of mutable.proposals) {
+      if (p.status !== 'proposed') continue
+
+      const label = p.label !== ''
+        ? p.label
+        : p.category === 'nodeType'
+          ? formatNodeTypeLabel(p.type)
+          : formatEdgeTypeLabel(p.type)
+
+      const def: OntologyTypeDefinition = {
+        type: p.type,
+        label,
+        description: p.description,
+        createdAt: now,
+        status: 'active' as TypeStatus,
+      }
+
+      await this.registry.registerType('brain', def)
+
+      p.status = 'accepted'
+      p.reviewedBy = reviewedBy
+      p.reviewedAt = now
+    }
+
+    await this.writeBatch(mutable)
+  }
+
+  /**
+   * Returns proposal batches matching the filter.
+   */
+  async list(filter?: ProposalFilter): Promise<readonly ProposalBatch[]> {
+    const batches = await this.listBatches()
+
+    if (!filter?.status && !filter?.category) {
+      return batches
+    }
+
+    const filtered: ProposalBatch[] = []
+    for (const batch of batches) {
+      const matchedProposals = batch.proposals.filter((p) => {
+        if (filter?.status && p.status !== filter.status) return false
+        if (filter?.category && p.category !== filter.category) return false
+        return true
+      })
+      if (matchedProposals.length > 0) {
+        filtered.push({ ...batch, proposals: matchedProposals })
+      }
+    }
+
+    return filtered
+  }
+
+  /**
+   * Reads a single proposal batch by ID.
+   */
+  async getBatch(batchId: string): Promise<ProposalBatch> {
+    return this.readBatch(batchId)
+  }
+
+  private async readBatch(id: string): Promise<ProposalBatch> {
+    const data = await this.store.read(proposalBatchPath(id))
+    const parsed: unknown = JSON.parse(data.toString('utf-8'))
+    return parsed as ProposalBatch
+  }
+
+  private async writeBatch(batch: ProposalBatch | MutableProposalBatch): Promise<void> {
+    const data = Buffer.from(JSON.stringify(batch), 'utf-8')
+    await this.store.write(proposalBatchPath(batch.id), data)
+  }
+
+  private async listBatches(): Promise<ProposalBatch[]> {
+    let entries: ReadonlyArray<{ readonly path: Path }>
+    try {
+      entries = await this.store.list(PROPOSALS_DIR, {})
+    } catch (err: unknown) {
+      if (isNotFound(err)) return []
+      throw err
+    }
+
+    const batches: ProposalBatch[] = []
+    for (const entry of entries) {
+      if (!String(entry.path).endsWith('.json')) continue
+      try {
+        const data = await this.store.read(entry.path)
+        const parsed: unknown = JSON.parse(data.toString('utf-8'))
+        batches.push(parsed as ProposalBatch)
+      } catch {
+        continue
+      }
+    }
+
+    batches.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    return batches
+  }
+}
+
+function findProposal(
+  batch: ProposalBatch,
+  id: string,
+): { proposal: Proposal; index: number } {
+  for (let i = 0; i < batch.proposals.length; i++) {
+    const p = batch.proposals[i]
+    if (p !== undefined && p.id === id) {
+      return { proposal: p, index: i }
+    }
+  }
+  throw new Error(`ontology: proposal "${id}" not found in batch "${batch.id}"`)
+}
+
+function toMutableBatch(batch: ProposalBatch): MutableProposalBatch {
+  return {
+    id: batch.id,
+    proposals: batch.proposals.map((p) => ({ ...p })),
+    domain: batch.domain,
+    sourceDocument: batch.sourceDocument,
+    createdAt: batch.createdAt,
+  }
+}
+
+function resolvedToDefinitions(resolved: ResolvedOntology): OntologyTypeDefinition[] {
+  const defs: OntologyTypeDefinition[] = []
+  for (const rt of resolved.nodeTypes) {
+    const def: OntologyTypeDefinition = {
+      type: rt.type,
+      label: rt.label,
+      description: rt.description,
+      createdAt: rt.createdAt,
+      status: rt.status,
+    }
+    if (rt.discoveredFrom !== undefined) {
+      defs.push({ ...def, discoveredFrom: rt.discoveredFrom })
+    } else {
+      defs.push(def)
+    }
+  }
+  for (const rt of resolved.edgeTypes) {
+    const def: OntologyTypeDefinition = {
+      type: rt.type,
+      label: rt.label,
+      description: rt.description,
+      createdAt: rt.createdAt,
+      status: rt.status,
+    }
+    if (rt.discoveredFrom !== undefined) {
+      defs.push({ ...def, discoveredFrom: rt.discoveredFrom })
+    } else {
+      defs.push(def)
+    }
+  }
+  return defs
+}
+
+function extractionToDefinitions(result: ExtractionResult): OntologyTypeDefinition[] {
+  const now = new Date().toISOString()
+  const defs: OntologyTypeDefinition[] = []
+  for (const nt of result.nodeTypes) {
+    defs.push({
+      type: nt.type,
+      label: nt.label,
+      description: nt.description,
+      createdAt: now,
+      status: 'proposed',
+    })
+  }
+  for (const et of result.edgeTypes) {
+    defs.push({
+      type: et.type,
+      label: et.label,
+      description: et.description,
+      createdAt: now,
+      status: 'proposed',
+    })
+  }
+  return defs
+}

--- a/sdks/ts/memory/src/ontology/proposal.ts
+++ b/sdks/ts/memory/src/ontology/proposal.ts
@@ -9,8 +9,6 @@
  * Port of go/ontology/proposal.go.
  */
 
-import { createHash } from 'node:crypto'
-
 import type { Store } from '../store/index.js'
 import { isNotFound } from '../store/errors.js'
 import { type Path, toPath } from '../store/path.js'
@@ -18,24 +16,15 @@ import type { OntologyTypeDefinition, TypeStatus } from './types.js'
 import type { ResolvedOntology } from './store.js'
 import type { Registry } from './registry.js'
 import type { TypeEntry } from './templates.js'
+import type { ExtractionResult } from './types-extraction.js'
+import { hashString } from '../ingest/hash.js'
 import { Deduplicator } from './dedup.js'
 import { formatEdgeTypeLabel, formatNodeTypeLabel } from './format.js'
 import { hasPrefix } from './validation.js'
 
-export type ProposalStatus = 'proposed' | 'accepted' | 'merged' | 'rejected'
+export type { ExtractionResult } from './types-extraction.js'
 
-/**
- * ExtractionResult holds extracted ontology types from a document.
- * Defined here so that the proposal workflow can accept extraction
- * outputs without depending on the extraction module (P6-4).
- */
-export type ExtractionResult = {
-  readonly nodeTypes: readonly TypeEntry[]
-  readonly edgeTypes: readonly TypeEntry[]
-  readonly businessCategories: readonly string[]
-  readonly domain: string
-  readonly confidence: number
-}
+export type ProposalStatus = 'proposed' | 'accepted' | 'merged' | 'rejected'
 
 export type Proposal = {
   readonly id: string
@@ -99,13 +88,11 @@ function proposalBatchPath(batchId: string): Path {
 const PROPOSALS_DIR: Path = toPath('ontology/proposals')
 
 function computeProposalId(typeName: string, batchId: string): string {
-  const hash = createHash('sha256').update(`${typeName}:${batchId}`).digest('hex')
-  return hash.slice(0, 16)
+  return hashString(`${typeName}:${batchId}`).slice(0, 16)
 }
 
 function computeBatchId(domain: string, sourceDocument: string, timestamp: string): string {
-  const hash = createHash('sha256').update(`${domain}:${sourceDocument}:${timestamp}`).digest('hex')
-  return hash.slice(0, 16)
+  return hashString(`${domain}:${sourceDocument}:${timestamp}`).slice(0, 16)
 }
 
 /**
@@ -134,7 +121,7 @@ export class ProposalWorkflow {
   ): Promise<ProposalBatch> {
     const resolved = await this.registry.resolve('', '', '')
     const existingTypes = resolvedToDefinitions(resolved)
-    const extractedDefs = extractionToDefinitions(result)
+    const extractedDefs = extractionToDefinitions(result, this.clock)
 
     const dedup = new Deduplicator({})
     const dedupResult = await dedup.deduplicate(extractedDefs, existingTypes)
@@ -262,12 +249,16 @@ export class ProposalWorkflow {
   }
 
   /**
-   * Bulk-accepts all pending proposals in a batch.
+   * Bulk-accepts all pending proposals in a batch. Individual
+   * registration failures are collected rather than short-circuiting,
+   * and the batch is written atomically at the end regardless of
+   * partial failures so that successfully accepted proposals persist.
    */
   async acceptAll(batchId: string, reviewedBy: string): Promise<void> {
     const batch = await this.readBatch(batchId)
     const mutable = toMutableBatch(batch)
     const now = this.clock().toISOString()
+    const failures: string[] = []
 
     for (const p of mutable.proposals) {
       if (p.status !== 'proposed') continue
@@ -286,14 +277,22 @@ export class ProposalWorkflow {
         status: 'active' as TypeStatus,
       }
 
-      await this.registry.registerType('brain', def)
-
-      p.status = 'accepted'
-      p.reviewedBy = reviewedBy
-      p.reviewedAt = now
+      try {
+        await this.registry.registerType('brain', def)
+        p.status = 'accepted'
+        p.reviewedBy = reviewedBy
+        p.reviewedAt = now
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        failures.push(`register "${p.type}": ${msg}`)
+      }
     }
 
     await this.writeBatch(mutable)
+
+    if (failures.length > 0) {
+      throw new Error(`ontology: accept all batch "${batchId}": ${failures.join('; ')}`)
+    }
   }
 
   /**
@@ -329,12 +328,14 @@ export class ProposalWorkflow {
   }
 
   private async readBatch(id: string): Promise<ProposalBatch> {
+    validateBatchId(id)
     const data = await this.store.read(proposalBatchPath(id))
     const parsed: unknown = JSON.parse(data.toString('utf-8'))
-    return parsed as ProposalBatch
+    return validateProposalBatch(parsed)
   }
 
   private async writeBatch(batch: ProposalBatch | MutableProposalBatch): Promise<void> {
+    validateBatchId(batch.id)
     const data = Buffer.from(JSON.stringify(batch), 'utf-8')
     await this.store.write(proposalBatchPath(batch.id), data)
   }
@@ -354,8 +355,11 @@ export class ProposalWorkflow {
       try {
         const data = await this.store.read(entry.path)
         const parsed: unknown = JSON.parse(data.toString('utf-8'))
-        batches.push(parsed as ProposalBatch)
-      } catch {
+        const validated = validateProposalBatch(parsed)
+        batches.push(validated)
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.warn(`ontology: skipping corrupt proposal batch at ${String(entry.path)}: ${msg}`)
         continue
       }
     }
@@ -421,8 +425,51 @@ function resolvedToDefinitions(resolved: ResolvedOntology): OntologyTypeDefiniti
   return defs
 }
 
-function extractionToDefinitions(result: ExtractionResult): OntologyTypeDefinition[] {
-  const now = new Date().toISOString()
+const VALID_BATCH_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
+
+/**
+ * Validates that a batch ID is safe for path interpolation. Prevents
+ * path traversal attacks via ".." or "/" in IDs.
+ */
+function validateBatchId(id: string): void {
+  if (id === '') {
+    throw new Error('ontology: batch ID must not be empty')
+  }
+  if (!VALID_BATCH_ID_PATTERN.test(id)) {
+    throw new Error(`ontology: invalid batch ID "${id}": must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+  }
+}
+
+/**
+ * Runtime validation for parsed ProposalBatch JSON. Ensures the
+ * parsed value has the required shape rather than relying on a bare
+ * `as` cast.
+ */
+function validateProposalBatch(parsed: unknown): ProposalBatch {
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('ontology: proposal batch must be an object')
+  }
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj['id'] !== 'string' || obj['id'] === '') {
+    throw new Error('ontology: proposal batch missing or empty "id"')
+  }
+  if (!Array.isArray(obj['proposals'])) {
+    throw new Error('ontology: proposal batch missing "proposals" array')
+  }
+  if (typeof obj['domain'] !== 'string') {
+    throw new Error('ontology: proposal batch missing "domain"')
+  }
+  if (typeof obj['sourceDocument'] !== 'string') {
+    throw new Error('ontology: proposal batch missing "sourceDocument"')
+  }
+  if (typeof obj['createdAt'] !== 'string') {
+    throw new Error('ontology: proposal batch missing "createdAt"')
+  }
+  return obj as unknown as ProposalBatch
+}
+
+function extractionToDefinitions(result: ExtractionResult, clock: () => Date): OntologyTypeDefinition[] {
+  const now = clock().toISOString()
   const defs: OntologyTypeDefinition[] = []
   for (const nt of result.nodeTypes) {
     defs.push({


### PR DESCRIPTION
## Summary
- Implement ontology proposal workflow for type discovery and review lifecycle
- Types extracted from documents are deduplicated against the resolved ontology before becoming proposals
- Accept promotes proposed types to active in the registry at brain scope; merge records audit link to existing type; reject discards
- Full audit trail with reviewer identity and timestamp on every transition
- Proposal batches stored as JSON under `ontology/proposals/{batchID}.json`
- SQL migration `0006_ontology_proposals.sql` for PostgreSQL-backed deployments

## Files
- **Go**: `go/ontology/proposal.go` + `proposal_test.go` (12 tests)
- **TS**: `sdks/ts/memory/src/ontology/proposal.ts` + `proposal.test.ts` (16 tests)
- **SQL**: `sdks/ts/memory-postgres/migrations/0006_ontology_proposals.sql`
- **Barrel**: `sdks/ts/memory/src/ontology/index.ts` updated with proposal exports

## Test plan
- [x] Go tests pass: `go test ./ontology/ -count=1` (all pass including 12 proposal tests)
- [x] TS tests pass: `npx vitest run src/ontology/` (237 tests, 16 new proposal tests)
- [x] ProposeFromExtraction creates proposals for unique types only (built-in types excluded via dedup)
- [x] Accept registers type as active at brain scope, visible in resolved ontology
- [x] Merge records target type without registry modification
- [x] Reject marks status without registry modification
- [x] AcceptAll bulk-activates all pending proposals in a batch
- [x] List supports filtering by status and category
- [x] Idempotent operations (accept/merge/reject on already-transitioned proposals)
- [x] Storage persistence survives workflow reconstruction
- [x] Full round-trip: extract -> propose -> accept -> verify in resolved ontology