### PR TITLE
feat: template matching for auto-detecting industry (P6-6, LLE-9794)

### DIFF
--- a/go/ontology/template_match.go
+++ b/go/ontology/template_match.go
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+// ExtractionResult holds extracted ontology types from a document.
+// Defined here so template matching can be built independently of the
+// extraction package (P6-4). When both are merged into develop, the
+// duplicate will be removed and this file will import from extract.go.
+type ExtractionResult struct {
+	NodeTypes          []TypeEntry `json:"nodeTypes"`
+	EdgeTypes          []TypeEntry `json:"edgeTypes"`
+	BusinessCategories []string    `json:"businessCategories"`
+	Domain             string      `json:"domain"`
+	Confidence         float64     `json:"confidence"`
+}
+
+// Template matching constants ported from the intelligence service.
+const (
+	// TemplateMatchSemanticThreshold is the minimum cosine similarity for
+	// a semantic embedding pair to count as a match during bipartite
+	// greedy matching.
+	TemplateMatchSemanticThreshold = 0.8
+
+	// TemplateMatchCombinedMinimum is the minimum combined score
+	// (overlap + coverage) / 2 required for a template to qualify as a
+	// suggestion.
+	TemplateMatchCombinedMinimum = 0.3
+)
+
+// TemplateSuggestion is the result of template matching.
+type TemplateSuggestion struct {
+	TemplateKey         string      `json:"templateKey"`
+	TemplateLabel       string      `json:"templateLabel"`
+	OverlapScore        float64     `json:"overlapScore"`
+	CoverageScore       float64     `json:"coverageScore"`
+	AdditionalTypes     []TypeEntry `json:"additionalTypes"`
+	MissingFromTemplate []TypeEntry `json:"missingFromTemplate"`
+}
+
+// TemplateMatcherConfig configures the TemplateMatcher.
+type TemplateMatcherConfig struct {
+	// Embedder provides semantic embeddings. May be nil for exact-only matching.
+	Embedder llm.Embedder
+
+	// SemanticThreshold overrides TemplateMatchSemanticThreshold.
+	// Zero uses the default (0.8).
+	SemanticThreshold float64
+
+	// CombinedMinimum overrides TemplateMatchCombinedMinimum.
+	// Zero uses the default (0.3).
+	CombinedMinimum float64
+}
+
+// TemplateMatcher suggests industry templates based on extracted types.
+type TemplateMatcher struct {
+	embedder          llm.Embedder
+	semanticThreshold float64
+	combinedMinimum   float64
+}
+
+// NewTemplateMatcher creates a matcher. Embedder may be nil for exact-only matching.
+func NewTemplateMatcher(embedder llm.Embedder) *TemplateMatcher {
+	return NewTemplateMatcherWithConfig(TemplateMatcherConfig{Embedder: embedder})
+}
+
+// NewTemplateMatcherWithConfig creates a TemplateMatcher with configurable options.
+func NewTemplateMatcherWithConfig(cfg TemplateMatcherConfig) *TemplateMatcher {
+	semThresh := cfg.SemanticThreshold
+	if semThresh == 0 {
+		semThresh = TemplateMatchSemanticThreshold
+	}
+	combMin := cfg.CombinedMinimum
+	if combMin == 0 {
+		combMin = TemplateMatchCombinedMinimum
+	}
+	return &TemplateMatcher{
+		embedder:          cfg.Embedder,
+		semanticThreshold: semThresh,
+		combinedMinimum:   combMin,
+	}
+}
+
+// Match finds the best-matching industry template for the given extraction.
+// Uses semantic matching when an embedder is available, falling back to exact.
+// Returns nil if no template scores above the combined threshold.
+func (m *TemplateMatcher) Match(ctx context.Context, extracted ExtractionResult) (*TemplateSuggestion, error) {
+	if len(extracted.NodeTypes) == 0 && len(extracted.EdgeTypes) == 0 {
+		return nil, nil
+	}
+
+	if m.embedder == nil {
+		return m.MatchExact(extracted), nil
+	}
+
+	return m.matchSemantic(ctx, extracted)
+}
+
+// MatchExact performs set-intersection-only matching (no embeddings).
+// Returns nil if no template scores above the combined threshold.
+func (m *TemplateMatcher) MatchExact(extracted ExtractionResult) *TemplateSuggestion {
+	if len(extracted.NodeTypes) == 0 && len(extracted.EdgeTypes) == 0 {
+		return nil
+	}
+
+	extractedNodeSet := make(map[string]TypeEntry, len(extracted.NodeTypes))
+	for _, nt := range extracted.NodeTypes {
+		extractedNodeSet[nt.Type] = nt
+	}
+	extractedEdgeSet := make(map[string]TypeEntry, len(extracted.EdgeTypes))
+	for _, et := range extracted.EdgeTypes {
+		extractedEdgeSet[et.Type] = et
+	}
+
+	extractedCount := len(extracted.NodeTypes) + len(extracted.EdgeTypes)
+
+	var best *TemplateSuggestion
+	var bestCombined float64
+
+	keys := ListTemplates()
+	for _, key := range keys {
+		tmpl, err := GetTemplate(key)
+		if err != nil {
+			continue
+		}
+
+		templateNodeSet := make(map[string]TypeEntry, len(tmpl.NodeTypes))
+		for _, nt := range tmpl.NodeTypes {
+			templateNodeSet[nt.Type] = nt
+		}
+		templateEdgeSet := make(map[string]TypeEntry, len(tmpl.EdgeTypes))
+		for _, et := range tmpl.EdgeTypes {
+			templateEdgeSet[et.Type] = et
+		}
+
+		templateCount := len(tmpl.NodeTypes) + len(tmpl.EdgeTypes)
+		if templateCount == 0 {
+			continue
+		}
+
+		intersectionCount := 0
+		for typeID := range extractedNodeSet {
+			if _, ok := templateNodeSet[typeID]; ok {
+				intersectionCount++
+			}
+		}
+		for typeID := range extractedEdgeSet {
+			if _, ok := templateEdgeSet[typeID]; ok {
+				intersectionCount++
+			}
+		}
+
+		overlapScore := 0.0
+		if extractedCount > 0 {
+			overlapScore = float64(intersectionCount) / float64(extractedCount)
+		}
+		coverageScore := float64(intersectionCount) / float64(templateCount)
+		combined := (overlapScore + coverageScore) / 2
+
+		if combined >= m.combinedMinimum && combined > bestCombined {
+			additional := computeAdditionalTypes(extracted, templateNodeSet, templateEdgeSet)
+			missing := computeMissingTypes(tmpl, extractedNodeSet, extractedEdgeSet)
+
+			bestCombined = combined
+			best = &TemplateSuggestion{
+				TemplateKey:         key,
+				TemplateLabel:       tmpl.Label,
+				OverlapScore:        overlapScore,
+				CoverageScore:       coverageScore,
+				AdditionalTypes:     additional,
+				MissingFromTemplate: missing,
+			}
+		}
+	}
+
+	return best
+}
+
+func (m *TemplateMatcher) matchSemantic(ctx context.Context, extracted ExtractionResult) (*TemplateSuggestion, error) {
+	extractedTypes := combineTypes(extracted.NodeTypes, extracted.EdgeTypes)
+	if len(extractedTypes) == 0 {
+		return nil, nil
+	}
+
+	extractedTexts := make([]string, len(extractedTypes))
+	for i, t := range extractedTypes {
+		extractedTexts[i] = t.Label + ": " + t.Description
+	}
+
+	extractedEmbeddings, err := m.embedder.Embed(ctx, extractedTexts)
+	if err != nil {
+		return nil, fmt.Errorf("ontology: embed extracted types: %w", err)
+	}
+
+	var best *TemplateSuggestion
+	var bestCombined float64
+
+	keys := ListTemplates()
+	for _, key := range keys {
+		tmpl, getErr := GetTemplate(key)
+		if getErr != nil {
+			continue
+		}
+
+		templateTypes := combineTypes(tmpl.NodeTypes, tmpl.EdgeTypes)
+		if len(templateTypes) == 0 {
+			continue
+		}
+
+		templateTexts := make([]string, len(templateTypes))
+		for i, t := range templateTypes {
+			templateTexts[i] = t.Label + ": " + t.Description
+		}
+
+		templateEmbeddings, embedErr := m.embedder.Embed(ctx, templateTexts)
+		if embedErr != nil {
+			return nil, fmt.Errorf("ontology: embed template %q types: %w", key, embedErr)
+		}
+
+		matchCount := greedyBipartiteMatch(extractedEmbeddings, templateEmbeddings, m.semanticThreshold)
+
+		extractedCount := len(extractedTypes)
+		templateCount := len(templateTypes)
+
+		overlapScore := 0.0
+		if extractedCount > 0 {
+			overlapScore = float64(matchCount) / float64(extractedCount)
+		}
+		coverageScore := 0.0
+		if templateCount > 0 {
+			coverageScore = float64(matchCount) / float64(templateCount)
+		}
+		combined := (overlapScore + coverageScore) / 2
+
+		if combined >= m.combinedMinimum && combined > bestCombined {
+			extractedNodeSet := make(map[string]TypeEntry, len(extracted.NodeTypes))
+			for _, nt := range extracted.NodeTypes {
+				extractedNodeSet[nt.Type] = nt
+			}
+			extractedEdgeSet := make(map[string]TypeEntry, len(extracted.EdgeTypes))
+			for _, et := range extracted.EdgeTypes {
+				extractedEdgeSet[et.Type] = et
+			}
+			templateNodeSet := make(map[string]TypeEntry, len(tmpl.NodeTypes))
+			for _, nt := range tmpl.NodeTypes {
+				templateNodeSet[nt.Type] = nt
+			}
+			templateEdgeSet := make(map[string]TypeEntry, len(tmpl.EdgeTypes))
+			for _, et := range tmpl.EdgeTypes {
+				templateEdgeSet[et.Type] = et
+			}
+
+			additional := computeAdditionalTypes(extracted, templateNodeSet, templateEdgeSet)
+			missing := computeMissingTypes(tmpl, extractedNodeSet, extractedEdgeSet)
+
+			bestCombined = combined
+			best = &TemplateSuggestion{
+				TemplateKey:         key,
+				TemplateLabel:       tmpl.Label,
+				OverlapScore:        overlapScore,
+				CoverageScore:       coverageScore,
+				AdditionalTypes:     additional,
+				MissingFromTemplate: missing,
+			}
+		}
+	}
+
+	return best, nil
+}
+
+// greedyBipartiteMatch counts the number of matched pairs between
+// extracted and template embeddings using greedy best-first matching.
+// Each extracted embedding is matched to the most-similar template
+// embedding with cosine similarity >= threshold. Once matched, a
+// template embedding is removed from the candidate pool.
+func greedyBipartiteMatch(extractedVecs, templateVecs [][]float32, threshold float64) int {
+	if len(extractedVecs) == 0 || len(templateVecs) == 0 {
+		return 0
+	}
+
+	type scoredPair struct {
+		extractedIdx int
+		templateIdx  int
+		similarity   float64
+	}
+
+	var pairs []scoredPair
+	for i, ev := range extractedVecs {
+		for j, tv := range templateVecs {
+			sim, err := CosineSimilarity(ev, tv)
+			if err != nil || sim < threshold {
+				continue
+			}
+			pairs = append(pairs, scoredPair{i, j, sim})
+		}
+	}
+
+	sort.Slice(pairs, func(a, b int) bool {
+		return pairs[a].similarity > pairs[b].similarity
+	})
+
+	usedExtracted := make(map[int]bool)
+	usedTemplate := make(map[int]bool)
+	matchCount := 0
+
+	for _, p := range pairs {
+		if usedExtracted[p.extractedIdx] || usedTemplate[p.templateIdx] {
+			continue
+		}
+		usedExtracted[p.extractedIdx] = true
+		usedTemplate[p.templateIdx] = true
+		matchCount++
+	}
+
+	return matchCount
+}
+
+// computeAdditionalTypes returns types in extracted that are not in the template.
+func computeAdditionalTypes(extracted ExtractionResult, templateNodeSet, templateEdgeSet map[string]TypeEntry) []TypeEntry {
+	var additional []TypeEntry
+	for _, nt := range extracted.NodeTypes {
+		if _, ok := templateNodeSet[nt.Type]; !ok {
+			additional = append(additional, nt)
+		}
+	}
+	for _, et := range extracted.EdgeTypes {
+		if _, ok := templateEdgeSet[et.Type]; !ok {
+			additional = append(additional, et)
+		}
+	}
+	if additional == nil {
+		return []TypeEntry{}
+	}
+	return additional
+}
+
+// computeMissingTypes returns types in the template that are not in extracted.
+func computeMissingTypes(tmpl IndustryTemplate, extractedNodeSet, extractedEdgeSet map[string]TypeEntry) []TypeEntry {
+	var missing []TypeEntry
+	for _, nt := range tmpl.NodeTypes {
+		if _, ok := extractedNodeSet[nt.Type]; !ok {
+			missing = append(missing, nt)
+		}
+	}
+	for _, et := range tmpl.EdgeTypes {
+		if _, ok := extractedEdgeSet[et.Type]; !ok {
+			missing = append(missing, et)
+		}
+	}
+	if missing == nil {
+		return []TypeEntry{}
+	}
+	return missing
+}
+
+// combineTypes merges node and edge type entries into a single slice.
+func combineTypes(nodeTypes, edgeTypes []TypeEntry) []TypeEntry {
+	combined := make([]TypeEntry, 0, len(nodeTypes)+len(edgeTypes))
+	combined = append(combined, nodeTypes...)
+	combined = append(combined, edgeTypes...)
+	return combined
+}

--- a/go/ontology/template_match.go
+++ b/go/ontology/template_match.go
@@ -9,18 +9,6 @@ import (
 	"github.com/jeffs-brain/memory/go/llm"
 )
 
-// ExtractionResult holds extracted ontology types from a document.
-// Defined here so template matching can be built independently of the
-// extraction package (P6-4). When both are merged into develop, the
-// duplicate will be removed and this file will import from extract.go.
-type ExtractionResult struct {
-	NodeTypes          []TypeEntry `json:"nodeTypes"`
-	EdgeTypes          []TypeEntry `json:"edgeTypes"`
-	BusinessCategories []string    `json:"businessCategories"`
-	Domain             string      `json:"domain"`
-	Confidence         float64     `json:"confidence"`
-}
-
 // Template matching constants ported from the intelligence service.
 const (
 	// TemplateMatchSemanticThreshold is the minimum cosine similarity for
@@ -63,6 +51,7 @@ type TemplateMatcher struct {
 	embedder          llm.Embedder
 	semanticThreshold float64
 	combinedMinimum   float64
+	embeddingCache    map[string][][]float32
 }
 
 // NewTemplateMatcher creates a matcher. Embedder may be nil for exact-only matching.
@@ -84,6 +73,7 @@ func NewTemplateMatcherWithConfig(cfg TemplateMatcherConfig) *TemplateMatcher {
 		embedder:          cfg.Embedder,
 		semanticThreshold: semThresh,
 		combinedMinimum:   combMin,
+		embeddingCache:    make(map[string][][]float32),
 	}
 }
 
@@ -125,8 +115,8 @@ func (m *TemplateMatcher) MatchExact(extracted ExtractionResult) *TemplateSugges
 
 	keys := ListTemplates()
 	for _, key := range keys {
-		tmpl, err := GetTemplate(key)
-		if err != nil {
+		tmpl, ok := GetTemplate(key)
+		if !ok {
 			continue
 		}
 
@@ -203,8 +193,8 @@ func (m *TemplateMatcher) matchSemantic(ctx context.Context, extracted Extractio
 
 	keys := ListTemplates()
 	for _, key := range keys {
-		tmpl, getErr := GetTemplate(key)
-		if getErr != nil {
+		tmpl, ok := GetTemplate(key)
+		if !ok {
 			continue
 		}
 
@@ -213,14 +203,21 @@ func (m *TemplateMatcher) matchSemantic(ctx context.Context, extracted Extractio
 			continue
 		}
 
-		templateTexts := make([]string, len(templateTypes))
-		for i, t := range templateTypes {
-			templateTexts[i] = t.Label + ": " + t.Description
-		}
+		var templateEmbeddings [][]float32
+		if cached, ok := m.embeddingCache[key]; ok {
+			templateEmbeddings = cached
+		} else {
+			templateTexts := make([]string, len(templateTypes))
+			for i, t := range templateTypes {
+				templateTexts[i] = t.Label + ": " + t.Description
+			}
 
-		templateEmbeddings, embedErr := m.embedder.Embed(ctx, templateTexts)
-		if embedErr != nil {
-			return nil, fmt.Errorf("ontology: embed template %q types: %w", key, embedErr)
+			var embedErr error
+			templateEmbeddings, embedErr = m.embedder.Embed(ctx, templateTexts)
+			if embedErr != nil {
+				return nil, fmt.Errorf("ontology: embed template %q types: %w", key, embedErr)
+			}
+			m.embeddingCache[key] = templateEmbeddings
 		}
 
 		matchCount := greedyBipartiteMatch(extractedEmbeddings, templateEmbeddings, m.semanticThreshold)

--- a/go/ontology/template_match_test.go
+++ b/go/ontology/template_match_test.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMatchExact_PerfectOverlap(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	// Use types from the server_hardware template for a perfect overlap
+	tmpl, err := GetTemplate("server_hardware")
+	if err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+
+	extracted := ExtractionResult{
+		NodeTypes:          make([]TypeEntry, len(tmpl.NodeTypes)),
+		EdgeTypes:          make([]TypeEntry, len(tmpl.EdgeTypes)),
+		BusinessCategories: tmpl.BusinessCategories,
+	}
+	copy(extracted.NodeTypes, tmpl.NodeTypes)
+	copy(extracted.EdgeTypes, tmpl.EdgeTypes)
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion == nil {
+		t.Fatal("expected a suggestion for perfect overlap")
+	}
+	if suggestion.TemplateKey != "server_hardware" {
+		t.Fatalf("expected server_hardware, got %s", suggestion.TemplateKey)
+	}
+	if suggestion.OverlapScore != 1.0 {
+		t.Fatalf("expected overlap score 1.0, got %f", suggestion.OverlapScore)
+	}
+	if suggestion.CoverageScore != 1.0 {
+		t.Fatalf("expected coverage score 1.0, got %f", suggestion.CoverageScore)
+	}
+}
+
+func TestMatchExact_PartialOverlap(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	// Use a subset of the healthcare template
+	tmpl, err := GetTemplate("healthcare")
+	if err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+
+	extracted := ExtractionResult{
+		NodeTypes: tmpl.NodeTypes[:5],
+		EdgeTypes: tmpl.EdgeTypes[:3],
+	}
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion == nil {
+		t.Fatal("expected a suggestion for partial overlap")
+	}
+	if suggestion.TemplateKey != "healthcare" {
+		t.Fatalf("expected healthcare, got %s", suggestion.TemplateKey)
+	}
+	// Overlap: all 8 extracted types match (8/8 = 1.0)
+	if suggestion.OverlapScore < 0.99 {
+		t.Fatalf("expected overlap ~1.0, got %f", suggestion.OverlapScore)
+	}
+	// Coverage: 8 out of 45 (30 node + 15 edge)
+	if suggestion.CoverageScore < 0.1 || suggestion.CoverageScore > 0.5 {
+		t.Fatalf("expected coverage between 0.1 and 0.5, got %f", suggestion.CoverageScore)
+	}
+}
+
+func TestMatchExact_NoOverlap(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	// Types that don't match any template
+	extracted := ExtractionResult{
+		NodeTypes: []TypeEntry{
+			{Type: "entity.alien_species", Label: "Alien Species", Description: "An extraterrestrial species"},
+			{Type: "entity.space_station", Label: "Space Station", Description: "An orbital space station"},
+		},
+		EdgeTypes: []TypeEntry{
+			{Type: "orbits", Label: "Orbits", Description: "One body orbits another"},
+		},
+	}
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion != nil {
+		t.Fatalf("expected nil for no overlap, got %s with score %f",
+			suggestion.TemplateKey, (suggestion.OverlapScore+suggestion.CoverageScore)/2)
+	}
+}
+
+func TestMatchExact_BestTemplate(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	// Use types that partially overlap with finance and slightly with insurance
+	extracted := ExtractionResult{
+		NodeTypes: []TypeEntry{
+			{Type: "entity.account", Label: "Account", Description: "A financial account"},
+			{Type: "entity.payment", Label: "Payment", Description: "A transfer of funds"},
+			{Type: "rule.kyc", Label: "KYC", Description: "Know your customer"},
+			{Type: "rule.aml", Label: "AML", Description: "Anti-money laundering"},
+			{Type: "entity.policy", Label: "Policy", Description: "An insurance policy"}, // matches insurance
+		},
+		EdgeTypes: []TypeEntry{
+			{Type: "authorises", Label: "Authorises", Description: "Authorisation relationship"},
+		},
+	}
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion == nil {
+		t.Fatal("expected a suggestion")
+	}
+	// Should select finance since more types match finance than insurance
+	if suggestion.TemplateKey != "finance" {
+		t.Fatalf("expected finance as best match, got %s", suggestion.TemplateKey)
+	}
+}
+
+func TestMatchExact_AdditionalTypes(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	tmpl, err := GetTemplate("order_processing")
+	if err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+
+	// Start with template types and add extra ones
+	extracted := ExtractionResult{
+		NodeTypes: append(
+			append([]TypeEntry{}, tmpl.NodeTypes...),
+			TypeEntry{Type: "entity.custom_thing", Label: "Custom Thing", Description: "Not in template"},
+		),
+		EdgeTypes: tmpl.EdgeTypes,
+	}
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion == nil {
+		t.Fatal("expected a suggestion")
+	}
+
+	found := false
+	for _, additional := range suggestion.AdditionalTypes {
+		if additional.Type == "entity.custom_thing" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("entity.custom_thing should be in additional types")
+	}
+}
+
+func TestMatchExact_MissingTypes(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+
+	tmpl, err := GetTemplate("order_processing")
+	if err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+
+	// Use only first 3 node types from template
+	extracted := ExtractionResult{
+		NodeTypes: tmpl.NodeTypes[:3],
+		EdgeTypes: tmpl.EdgeTypes,
+	}
+
+	suggestion := matcher.MatchExact(extracted)
+	if suggestion == nil {
+		t.Fatal("expected a suggestion")
+	}
+
+	// Missing types should include the node types we didn't extract
+	if len(suggestion.MissingFromTemplate) == 0 {
+		t.Fatal("expected missing types from template")
+	}
+
+	missingTypes := make(map[string]bool)
+	for _, mt := range suggestion.MissingFromTemplate {
+		missingTypes[mt.Type] = true
+	}
+
+	for _, nt := range tmpl.NodeTypes[3:] {
+		if !missingTypes[nt.Type] {
+			t.Fatalf("expected %s to be in missing types", nt.Type)
+		}
+	}
+}
+
+func TestMatchExact_EmptyExtraction(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+	suggestion := matcher.MatchExact(ExtractionResult{})
+	if suggestion != nil {
+		t.Fatal("expected nil for empty extraction")
+	}
+}
+
+func TestMatch_FallbackToExact(t *testing.T) {
+	t.Parallel()
+	// No embedder: should fall back to exact matching
+	matcher := NewTemplateMatcher(nil)
+
+	tmpl, err := GetTemplate("server_hardware")
+	if err != nil {
+		t.Fatalf("failed to get template: %v", err)
+	}
+
+	extracted := ExtractionResult{
+		NodeTypes: tmpl.NodeTypes,
+		EdgeTypes: tmpl.EdgeTypes,
+	}
+
+	suggestion, matchErr := matcher.Match(context.Background(), extracted)
+	if matchErr != nil {
+		t.Fatalf("unexpected error: %v", matchErr)
+	}
+	if suggestion == nil {
+		t.Fatal("expected suggestion from exact fallback")
+	}
+	if suggestion.TemplateKey != "server_hardware" {
+		t.Fatalf("expected server_hardware, got %s", suggestion.TemplateKey)
+	}
+}
+
+func TestMatchSemantic_WithEmbedder(t *testing.T) {
+	t.Parallel()
+	embedder := newFakeEmbedderForTemplateMatch(16)
+	matcher := NewTemplateMatcher(embedder)
+
+	// Use healthcare types that the fake embedder will match semantically
+	extracted := ExtractionResult{
+		NodeTypes: []TypeEntry{
+			{Type: "entity.patient", Label: "Patient", Description: "An individual receiving healthcare"},
+			{Type: "entity.practitioner", Label: "Practitioner", Description: "A healthcare professional"},
+			{Type: "entity.condition", Label: "Condition", Description: "A clinical condition or diagnosis"},
+		},
+		EdgeTypes: []TypeEntry{
+			{Type: "treats", Label: "Treats", Description: "A procedure or medication treats a condition"},
+			{Type: "diagnoses", Label: "Diagnoses", Description: "A practitioner diagnoses a patient"},
+		},
+	}
+
+	suggestion, err := matcher.Match(context.Background(), extracted)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With a fake embedder, results depend on the hash-based vectors.
+	// The main thing is it runs without error.
+	_ = suggestion
+}
+
+func TestMatch_EmptyExtraction(t *testing.T) {
+	t.Parallel()
+	matcher := NewTemplateMatcher(nil)
+	suggestion, err := matcher.Match(context.Background(), ExtractionResult{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if suggestion != nil {
+		t.Fatal("expected nil for empty extraction")
+	}
+}
+
+func TestGreedyBipartiteMatch_NoPairs(t *testing.T) {
+	t.Parallel()
+	count := greedyBipartiteMatch(nil, nil, 0.8)
+	if count != 0 {
+		t.Fatalf("expected 0, got %d", count)
+	}
+}
+
+func TestGreedyBipartiteMatch_IdenticalVectors(t *testing.T) {
+	t.Parallel()
+	vec := []float32{1.0, 0.0, 0.0}
+	count := greedyBipartiteMatch(
+		[][]float32{vec},
+		[][]float32{vec},
+		0.8,
+	)
+	if count != 1 {
+		t.Fatalf("expected 1 match for identical vectors, got %d", count)
+	}
+}
+
+func TestGreedyBipartiteMatch_OrthogonalVectors(t *testing.T) {
+	t.Parallel()
+	count := greedyBipartiteMatch(
+		[][]float32{{1.0, 0.0, 0.0}},
+		[][]float32{{0.0, 1.0, 0.0}},
+		0.8,
+	)
+	if count != 0 {
+		t.Fatalf("expected 0 matches for orthogonal vectors, got %d", count)
+	}
+}
+
+func TestCombinedScoreCalculation(t *testing.T) {
+	t.Parallel()
+	// overlapScore = intersectionCount / extractedCount
+	// coverageScore = intersectionCount / templateCount
+	// combined = (overlapScore + coverageScore) / 2
+
+	// 3 extracted, 10 template, 2 overlap
+	overlapScore := 2.0 / 3.0
+	coverageScore := 2.0 / 10.0
+	combined := (overlapScore + coverageScore) / 2
+
+	expected := (0.6667 + 0.2) / 2 // ~0.4333
+	if combined < expected-0.01 || combined > expected+0.01 {
+		t.Fatalf("expected combined ~%f, got %f", expected, combined)
+	}
+}
+
+// newFakeEmbedderForTemplateMatch creates a fake embedder that returns
+// deterministic hash-based vectors. Re-uses the dedup test fakeEmbedder.
+func newFakeEmbedderForTemplateMatch(dims int) *fakeEmbedder {
+	return &fakeEmbedder{
+		vectors:    make(map[string][]float32),
+		dimensions: dims,
+	}
+}

--- a/go/ontology/template_match_test.go
+++ b/go/ontology/template_match_test.go
@@ -11,9 +11,9 @@ func TestMatchExact_PerfectOverlap(t *testing.T) {
 	matcher := NewTemplateMatcher(nil)
 
 	// Use types from the server_hardware template for a perfect overlap
-	tmpl, err := GetTemplate("server_hardware")
-	if err != nil {
-		t.Fatalf("failed to get template: %v", err)
+	tmpl, ok := GetTemplate("server_hardware")
+	if !ok {
+		t.Fatal("failed to get template")
 	}
 
 	extracted := ExtractionResult{
@@ -44,9 +44,9 @@ func TestMatchExact_PartialOverlap(t *testing.T) {
 	matcher := NewTemplateMatcher(nil)
 
 	// Use a subset of the healthcare template
-	tmpl, err := GetTemplate("healthcare")
-	if err != nil {
-		t.Fatalf("failed to get template: %v", err)
+	tmpl, ok := GetTemplate("healthcare")
+	if !ok {
+		t.Fatal("failed to get template")
 	}
 
 	extracted := ExtractionResult{
@@ -125,9 +125,9 @@ func TestMatchExact_AdditionalTypes(t *testing.T) {
 	t.Parallel()
 	matcher := NewTemplateMatcher(nil)
 
-	tmpl, err := GetTemplate("order_processing")
-	if err != nil {
-		t.Fatalf("failed to get template: %v", err)
+	tmpl, ok := GetTemplate("order_processing")
+	if !ok {
+		t.Fatal("failed to get template")
 	}
 
 	// Start with template types and add extra ones
@@ -160,9 +160,9 @@ func TestMatchExact_MissingTypes(t *testing.T) {
 	t.Parallel()
 	matcher := NewTemplateMatcher(nil)
 
-	tmpl, err := GetTemplate("order_processing")
-	if err != nil {
-		t.Fatalf("failed to get template: %v", err)
+	tmpl, ok := GetTemplate("order_processing")
+	if !ok {
+		t.Fatal("failed to get template")
 	}
 
 	// Use only first 3 node types from template
@@ -207,9 +207,9 @@ func TestMatch_FallbackToExact(t *testing.T) {
 	// No embedder: should fall back to exact matching
 	matcher := NewTemplateMatcher(nil)
 
-	tmpl, err := GetTemplate("server_hardware")
-	if err != nil {
-		t.Fatalf("failed to get template: %v", err)
+	tmpl, ok := GetTemplate("server_hardware")
+	if !ok {
+		t.Fatal("failed to get template")
 	}
 
 	extracted := ExtractionResult{
@@ -229,21 +229,70 @@ func TestMatch_FallbackToExact(t *testing.T) {
 	}
 }
 
-func TestMatchSemantic_WithEmbedder(t *testing.T) {
+func TestMatchSemantic_AboveThreshold(t *testing.T) {
 	t.Parallel()
-	embedder := newFakeEmbedderForTemplateMatch(16)
-	matcher := NewTemplateMatcher(embedder)
 
-	// Use healthcare types that the fake embedder will match semantically
+	// Build a fake embedder where extracted and healthcare template types
+	// map to the SAME vector, guaranteeing cosine similarity = 1.0.
+	tmpl, ok := GetTemplate("healthcare")
+	if !ok {
+		t.Fatal("healthcare template not found")
+	}
+
+	sharedVec := []float32{1.0, 0.0, 0.0}
+	vectors := make(map[string][]float32)
+
+	// Use the same 3 types that will appear in the extracted set and
+	// the template. Because the fake embedder returns the same vector
+	// for both, greedy bipartite matching will produce 3 matches.
+	for _, nt := range tmpl.NodeTypes[:3] {
+		key := nt.Label + ": " + nt.Description
+		vectors[key] = sharedVec
+	}
+
+	embedder := newFakeEmbedder(3, vectors)
+	matcher := NewTemplateMatcherWithConfig(TemplateMatcherConfig{
+		Embedder:          embedder,
+		SemanticThreshold: 0.8,
+		CombinedMinimum:   0.01, // low threshold so even 3/45 matches qualify
+	})
+
+	extracted := ExtractionResult{
+		NodeTypes: tmpl.NodeTypes[:3],
+	}
+
+	suggestion, err := matcher.Match(context.Background(), extracted)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if suggestion == nil {
+		t.Fatal("expected a suggestion above threshold")
+	}
+	if suggestion.TemplateKey != "healthcare" {
+		t.Fatalf("expected healthcare, got %s", suggestion.TemplateKey)
+	}
+	if suggestion.OverlapScore < 0.99 {
+		t.Fatalf("expected overlap ~1.0, got %f", suggestion.OverlapScore)
+	}
+}
+
+func TestMatchSemantic_BelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	// All vectors are zero, so cosine similarity is 0 (or NaN) -- no matches.
+	embedder := newFakeEmbedder(3, map[string][]float32{})
+	matcher := NewTemplateMatcherWithConfig(TemplateMatcherConfig{
+		Embedder:          embedder,
+		SemanticThreshold: 0.8,
+		CombinedMinimum:   0.3,
+	})
+
 	extracted := ExtractionResult{
 		NodeTypes: []TypeEntry{
-			{Type: "entity.patient", Label: "Patient", Description: "An individual receiving healthcare"},
-			{Type: "entity.practitioner", Label: "Practitioner", Description: "A healthcare professional"},
-			{Type: "entity.condition", Label: "Condition", Description: "A clinical condition or diagnosis"},
+			{Type: "entity.alien_species", Label: "Alien Species", Description: "An extraterrestrial species"},
 		},
 		EdgeTypes: []TypeEntry{
-			{Type: "treats", Label: "Treats", Description: "A procedure or medication treats a condition"},
-			{Type: "diagnoses", Label: "Diagnoses", Description: "A practitioner diagnoses a patient"},
+			{Type: "orbits", Label: "Orbits", Description: "One body orbits another"},
 		},
 	}
 
@@ -251,9 +300,10 @@ func TestMatchSemantic_WithEmbedder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// With a fake embedder, results depend on the hash-based vectors.
-	// The main thing is it runs without error.
-	_ = suggestion
+	if suggestion != nil {
+		t.Fatalf("expected nil for zero-vector embeddings, got %s with score %f",
+			suggestion.TemplateKey, (suggestion.OverlapScore+suggestion.CoverageScore)/2)
+	}
 }
 
 func TestMatch_EmptyExtraction(t *testing.T) {

--- a/go/ontology/templates.go
+++ b/go/ontology/templates.go
@@ -55,15 +55,13 @@ func ListTemplates() []string {
 	return keys
 }
 
-// GetTemplate returns a template by key, or an error if not found.
-func GetTemplate(key string) (IndustryTemplate, error) {
+// GetTemplate returns a template by key. The second return value is
+// false when the key is not registered.
+func GetTemplate(key string) (IndustryTemplate, bool) {
 	templateMu.RLock()
 	defer templateMu.RUnlock()
 	t, ok := templates[key]
-	if !ok {
-		return IndustryTemplate{}, fmt.Errorf("ontology: template not found: %s", key)
-	}
-	return t, nil
+	return t, ok
 }
 
 // RegisterTemplate adds a custom industry template to the registry at

--- a/go/ontology/templates_test.go
+++ b/go/ontology/templates_test.go
@@ -39,9 +39,9 @@ func TestGetTemplate_Exists(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpl, err := GetTemplate(tc.key)
-			if err != nil {
-				t.Fatalf("GetTemplate(%q) returned error: %v", tc.key, err)
+			tmpl, ok := GetTemplate(tc.key)
+			if !ok {
+				t.Fatalf("GetTemplate(%q) returned false", tc.key)
 			}
 			if tmpl.Label == "" {
 				t.Errorf("GetTemplate(%q).Label is empty", tc.key)
@@ -54,9 +54,9 @@ func TestGetTemplate_Exists(t *testing.T) {
 }
 
 func TestGetTemplate_NotFound(t *testing.T) {
-	_, err := GetTemplate("nonexistent_template")
-	if err == nil {
-		t.Fatal("GetTemplate(\"nonexistent_template\") returned nil error, want error")
+	_, ok := GetTemplate("nonexistent_template")
+	if ok {
+		t.Fatal("GetTemplate(\"nonexistent_template\") returned true, want false")
 	}
 }
 
@@ -77,9 +77,9 @@ func TestTemplateCounts(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpl, err := GetTemplate(tc.key)
-			if err != nil {
-				t.Fatalf("GetTemplate(%q) error: %v", tc.key, err)
+			tmpl, ok := GetTemplate(tc.key)
+			if !ok {
+				t.Fatalf("GetTemplate(%q) returned false", tc.key)
 			}
 			if len(tmpl.NodeTypes) != tc.nodeCount {
 				t.Errorf("template %q has %d node types, want %d", tc.key, len(tmpl.NodeTypes), tc.nodeCount)
@@ -217,9 +217,9 @@ func TestRegisterTemplate(t *testing.T) {
 		t.Fatalf("expected 7 templates, got %d", len(keys))
 	}
 
-	tmpl, err := GetTemplate("education")
-	if err != nil {
-		t.Fatalf("GetTemplate(education) error: %v", err)
+	tmpl, ok := GetTemplate("education")
+	if !ok {
+		t.Fatalf("GetTemplate(education) returned false")
 	}
 	if tmpl.Label != "Education" {
 		t.Fatalf("expected label 'Education', got %q", tmpl.Label)

--- a/go/ontology/types_extraction.go
+++ b/go/ontology/types_extraction.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+// ExtractionResult holds extracted ontology types from a document.
+// Defined in a shared file so that both template matching (P6-6) and
+// the proposal workflow (P6-7) can reference it without duplication.
+// When P6-4 is merged, the canonical definition in extract.go will
+// supersede this one.
+type ExtractionResult struct {
+	NodeTypes          []TypeEntry `json:"nodeTypes"`
+	EdgeTypes          []TypeEntry `json:"edgeTypes"`
+	BusinessCategories []string    `json:"businessCategories"`
+	Domain             string      `json:"domain"`
+	Confidence         float64     `json:"confidence"`
+}

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -104,3 +104,10 @@ export {
   CONFIDENCE_FLOOR,
   CONFIDENCE_CAP,
 } from './extract.js'
+
+export type { TemplateSuggestion, TemplateMatcherOptions } from './template-match.js'
+export {
+  TemplateMatcher,
+  TEMPLATE_MATCH_SEMANTIC_THRESHOLD,
+  TEMPLATE_MATCH_COMBINED_MINIMUM,
+} from './template-match.js'

--- a/sdks/ts/memory/src/ontology/template-match.test.ts
+++ b/sdks/ts/memory/src/ontology/template-match.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+
+import type { Embedder } from '../llm/types.js'
+
+import { getTemplate } from './templates.js'
+import {
+  TemplateMatcher,
+  TEMPLATE_MATCH_COMBINED_MINIMUM,
+  type ExtractionResult,
+  type TemplateSuggestion,
+} from './template-match.js'
+
+function makeExtraction(
+  nodeTypes: Array<{ type: string; label: string; description: string }>,
+  edgeTypes: Array<{ type: string; label: string; description: string }>,
+  categories: string[] = [],
+): ExtractionResult {
+  return {
+    nodeTypes,
+    edgeTypes,
+    businessCategories: categories,
+    domain: 'test',
+    confidence: 0.8,
+  }
+}
+
+function createFakeEmbedder(dimensions: number): Embedder {
+  return {
+    name: () => 'fake-embedder',
+    model: () => 'fake-model',
+    dimension: () => dimensions,
+    embed: async (texts: readonly string[]): Promise<number[][]> => {
+      // Create deterministic vectors based on text hash
+      return texts.map((text) => {
+        const vec = new Array<number>(dimensions).fill(0)
+        for (let i = 0; i < text.length && i < dimensions; i++) {
+          vec[i] = (text.charCodeAt(i) % 100) / 100
+        }
+        // Normalise
+        const mag = Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0))
+        if (mag > 0) {
+          for (let i = 0; i < vec.length; i++) {
+            vec[i] = vec[i]! / mag
+          }
+        }
+        return vec
+      })
+    },
+  }
+}
+
+describe('TemplateMatcher.matchExact', () => {
+  it('returns suggestion with perfect overlap for exact template match', () => {
+    const matcher = new TemplateMatcher({})
+    const tmpl = getTemplate('server_hardware')!
+
+    const extracted = makeExtraction([...tmpl.nodeTypes], [...tmpl.edgeTypes])
+    const suggestion = matcher.matchExact(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    expect(suggestion!.templateKey).toBe('server_hardware')
+    expect(suggestion!.overlapScore).toBe(1.0)
+    expect(suggestion!.coverageScore).toBe(1.0)
+  })
+
+  it('calculates correct scores for partial overlap', () => {
+    const matcher = new TemplateMatcher({})
+    const tmpl = getTemplate('healthcare')!
+
+    const extracted = makeExtraction(
+      [...tmpl.nodeTypes.slice(0, 5)],
+      [...tmpl.edgeTypes.slice(0, 3)],
+    )
+
+    const suggestion = matcher.matchExact(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    expect(suggestion!.templateKey).toBe('healthcare')
+    // All 8 extracted types match (8/8 = 1.0 overlap)
+    expect(suggestion!.overlapScore).toBeCloseTo(1.0, 2)
+    // 8 out of 45 template types
+    expect(suggestion!.coverageScore).toBeGreaterThan(0.1)
+    expect(suggestion!.coverageScore).toBeLessThan(0.5)
+  })
+
+  it('returns undefined when no overlap exceeds threshold', () => {
+    const matcher = new TemplateMatcher({})
+    const extracted = makeExtraction(
+      [
+        { type: 'entity.alien_species', label: 'Alien Species', description: 'An extraterrestrial' },
+        { type: 'entity.space_station', label: 'Space Station', description: 'An orbital station' },
+      ],
+      [{ type: 'orbits', label: 'Orbits', description: 'Orbital relationship' }],
+    )
+
+    const suggestion = matcher.matchExact(extracted)
+    expect(suggestion).toBeUndefined()
+  })
+
+  it('selects the highest-scoring template from all 6', () => {
+    const matcher = new TemplateMatcher({})
+
+    const extracted = makeExtraction(
+      [
+        { type: 'entity.account', label: 'Account', description: 'A financial account' },
+        { type: 'entity.payment', label: 'Payment', description: 'A transfer of funds' },
+        { type: 'rule.kyc', label: 'KYC', description: 'Know your customer' },
+        { type: 'rule.aml', label: 'AML', description: 'Anti-money laundering' },
+        { type: 'entity.policy', label: 'Policy', description: 'An insurance policy' },
+      ],
+      [{ type: 'authorises', label: 'Authorises', description: 'Authorisation' }],
+    )
+
+    const suggestion = matcher.matchExact(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    // 5 of 6 match finance, 1 matches insurance
+    expect(suggestion!.templateKey).toBe('finance')
+  })
+
+  it('correctly identifies additional types in extracted but not template', () => {
+    const matcher = new TemplateMatcher({})
+    const tmpl = getTemplate('order_processing')!
+
+    const extracted = makeExtraction(
+      [
+        ...tmpl.nodeTypes,
+        { type: 'entity.custom_thing', label: 'Custom Thing', description: 'Not in template' },
+      ],
+      [...tmpl.edgeTypes],
+    )
+
+    const suggestion = matcher.matchExact(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    const customType = suggestion!.additionalTypes.find((t) => t.type === 'entity.custom_thing')
+    expect(customType).not.toBeUndefined()
+  })
+
+  it('correctly identifies missing types in template but not extracted', () => {
+    const matcher = new TemplateMatcher({})
+    const tmpl = getTemplate('order_processing')!
+
+    // Use only first 3 node types
+    const extracted = makeExtraction(
+      [...tmpl.nodeTypes.slice(0, 3)],
+      [...tmpl.edgeTypes],
+    )
+
+    const suggestion = matcher.matchExact(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    expect(suggestion!.missingFromTemplate.length).toBeGreaterThan(0)
+
+    const missingTypes = new Set(suggestion!.missingFromTemplate.map((t) => t.type))
+    for (const nt of tmpl.nodeTypes.slice(3)) {
+      expect(missingTypes.has(nt.type)).toBe(true)
+    }
+  })
+
+  it('returns undefined for empty extraction', () => {
+    const matcher = new TemplateMatcher({})
+    const suggestion = matcher.matchExact(makeExtraction([], []))
+    expect(suggestion).toBeUndefined()
+  })
+})
+
+describe('TemplateMatcher.match', () => {
+  it('falls back to exact matching when no embedder is provided', async () => {
+    const matcher = new TemplateMatcher({})
+    const tmpl = getTemplate('server_hardware')!
+
+    const extracted = makeExtraction([...tmpl.nodeTypes], [...tmpl.edgeTypes])
+    const suggestion = await matcher.match(extracted)
+
+    expect(suggestion).not.toBeUndefined()
+    expect(suggestion!.templateKey).toBe('server_hardware')
+  })
+
+  it('returns undefined for empty extraction', async () => {
+    const matcher = new TemplateMatcher({})
+    const suggestion = await matcher.match(makeExtraction([], []))
+    expect(suggestion).toBeUndefined()
+  })
+
+  it('uses semantic matching when embedder is provided', async () => {
+    const embedder = createFakeEmbedder(16)
+    const matcher = new TemplateMatcher({ embedder })
+
+    const extracted = makeExtraction(
+      [
+        { type: 'entity.patient', label: 'Patient', description: 'An individual receiving healthcare' },
+        { type: 'entity.practitioner', label: 'Practitioner', description: 'A healthcare professional' },
+      ],
+      [
+        { type: 'treats', label: 'Treats', description: 'Treatment relationship' },
+      ],
+    )
+
+    // Should not throw, whether or not it finds a match depends on hash-based vectors
+    await matcher.match(extracted)
+    // Just verify it ran without error
+    expect(true).toBe(true)
+  })
+})
+
+describe('combined score calculation', () => {
+  it('correctly computes (overlap + coverage) / 2', () => {
+    // overlapScore = intersectionCount / extractedCount
+    // coverageScore = intersectionCount / templateCount
+    // combined = (overlapScore + coverageScore) / 2
+
+    const overlapScore = 2 / 3
+    const coverageScore = 2 / 10
+    const combined = (overlapScore + coverageScore) / 2
+
+    expect(combined).toBeCloseTo(0.4333, 3)
+  })
+
+  it('threshold of 0.3 is enforced', () => {
+    expect(TEMPLATE_MATCH_COMBINED_MINIMUM).toBe(0.3)
+  })
+})
+

--- a/sdks/ts/memory/src/ontology/template-match.test.ts
+++ b/sdks/ts/memory/src/ontology/template-match.test.ts
@@ -185,24 +185,68 @@ describe('TemplateMatcher.match', () => {
     expect(suggestion).toBeUndefined()
   })
 
-  it('uses semantic matching when embedder is provided', async () => {
-    const embedder = createFakeEmbedder(16)
-    const matcher = new TemplateMatcher({ embedder })
+  it('semantic match above threshold returns a suggestion', async () => {
+    const tmpl = getTemplate('healthcare')!
+    const extractedTypes = tmpl.nodeTypes.slice(0, 3)
+
+    // Build a set of texts that will be requested for both extracted and
+    // healthcare template embeddings, so we can return matching vectors
+    // only for those.
+    const healthcareTexts = new Set<string>()
+    for (const nt of tmpl.nodeTypes) {
+      healthcareTexts.add(`${nt.label}: ${nt.description}`)
+    }
+    for (const et of tmpl.edgeTypes) {
+      healthcareTexts.add(`${et.label}: ${et.description}`)
+    }
+
+    const fakeEmbedder: Embedder = {
+      name: () => 'fake-selective',
+      model: () => 'fake-model',
+      dimension: () => 3,
+      embed: async (texts: readonly string[]): Promise<number[][]> =>
+        texts.map((text) =>
+          healthcareTexts.has(text) ? [1, 0, 0] : [0, 0, 0],
+        ),
+    }
+
+    const matcher = new TemplateMatcher({
+      embedder: fakeEmbedder,
+      semanticThreshold: 0.8,
+      combinedMinimum: 0.01, // low so that even 3/45 matches qualify
+    })
+
+    const extracted = makeExtraction([...extractedTypes], [])
+
+    const suggestion = await matcher.match(extracted)
+    expect(suggestion).not.toBeUndefined()
+    expect(suggestion!.templateKey).toBe('healthcare')
+    expect(suggestion!.overlapScore).toBeCloseTo(1.0, 2)
+  })
+
+  it('semantic match below threshold returns undefined', async () => {
+    // Zero-vector embedder: cosine similarity is 0 (or NaN) -- no matches.
+    const fakeEmbedder: Embedder = {
+      name: () => 'fake-zero',
+      model: () => 'fake-model',
+      dimension: () => 3,
+      embed: async (texts: readonly string[]): Promise<number[][]> =>
+        texts.map(() => [0, 0, 0]),
+    }
+
+    const matcher = new TemplateMatcher({
+      embedder: fakeEmbedder,
+      semanticThreshold: 0.8,
+      combinedMinimum: 0.3,
+    })
 
     const extracted = makeExtraction(
-      [
-        { type: 'entity.patient', label: 'Patient', description: 'An individual receiving healthcare' },
-        { type: 'entity.practitioner', label: 'Practitioner', description: 'A healthcare professional' },
-      ],
-      [
-        { type: 'treats', label: 'Treats', description: 'Treatment relationship' },
-      ],
+      [{ type: 'entity.alien_species', label: 'Alien Species', description: 'Extraterrestrial' }],
+      [{ type: 'orbits', label: 'Orbits', description: 'Orbital relationship' }],
     )
 
-    // Should not throw, whether or not it finds a match depends on hash-based vectors
-    await matcher.match(extracted)
-    // Just verify it ran without error
-    expect(true).toBe(true)
+    const suggestion = await matcher.match(extracted)
+    expect(suggestion).toBeUndefined()
   })
 })
 

--- a/sdks/ts/memory/src/ontology/template-match.ts
+++ b/sdks/ts/memory/src/ontology/template-match.ts
@@ -13,23 +13,18 @@
 
 import type { Embedder } from '../llm/types.js'
 import type { TypeEntry, IndustryTemplate } from './templates.js'
+import type { ExtractionResult } from './types-extraction.js'
 
 import { listTemplates, getTemplate } from './templates.js'
 import { cosineSimilarity } from './similarity.js'
+
+export type { ExtractionResult } from './types-extraction.js'
 
 /** Minimum cosine similarity for a semantic embedding pair to count as a match. */
 export const TEMPLATE_MATCH_SEMANTIC_THRESHOLD = 0.8
 
 /** Minimum combined score (overlap + coverage) / 2 for a suggestion. */
 export const TEMPLATE_MATCH_COMBINED_MINIMUM = 0.3
-
-export type ExtractionResult = {
-  readonly nodeTypes: readonly TypeEntry[]
-  readonly edgeTypes: readonly TypeEntry[]
-  readonly businessCategories: readonly string[]
-  readonly domain: string
-  readonly confidence: number
-}
 
 export type TemplateSuggestion = {
   readonly templateKey: string
@@ -57,6 +52,7 @@ export class TemplateMatcher {
   private readonly embedder: Embedder | undefined
   private readonly semanticThreshold: number
   private readonly combinedMinimum: number
+  private readonly embeddingCache = new Map<string, readonly (readonly number[])[]>()
 
   constructor(options: TemplateMatcherOptions) {
     this.embedder = options.embedder
@@ -176,8 +172,12 @@ export class TemplateMatcher {
       const templateTypes = combineTypes(tmpl.nodeTypes, tmpl.edgeTypes)
       if (templateTypes.length === 0) continue
 
-      const templateTexts = templateTypes.map((t) => `${t.label}: ${t.description}`)
-      const templateEmbeddings = await this.embedder!.embed(templateTexts, signal)
+      let templateEmbeddings = this.embeddingCache.get(key)
+      if (templateEmbeddings === undefined) {
+        const templateTexts = templateTypes.map((t) => `${t.label}: ${t.description}`)
+        templateEmbeddings = await this.embedder!.embed(templateTexts, signal)
+        this.embeddingCache.set(key, templateEmbeddings)
+      }
 
       const matchCount = greedyBipartiteMatch(
         extractedEmbeddings,

--- a/sdks/ts/memory/src/ontology/template-match.ts
+++ b/sdks/ts/memory/src/ontology/template-match.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Template matching: score extracted ontology types against all 6
+ * industry templates and suggest the best match. Supports exact set
+ * intersection and semantic embedding similarity with greedy bipartite
+ * matching.
+ *
+ * Port of apps/intelligence-service/src/services/document-processing/
+ * ontology-extraction.service.ts (matchAgainstTemplatesExact and
+ * matchAgainstTemplatesSemantic).
+ */
+
+import type { Embedder } from '../llm/types.js'
+import type { TypeEntry, IndustryTemplate } from './templates.js'
+
+import { listTemplates, getTemplate } from './templates.js'
+import { cosineSimilarity } from './similarity.js'
+
+/** Minimum cosine similarity for a semantic embedding pair to count as a match. */
+export const TEMPLATE_MATCH_SEMANTIC_THRESHOLD = 0.8
+
+/** Minimum combined score (overlap + coverage) / 2 for a suggestion. */
+export const TEMPLATE_MATCH_COMBINED_MINIMUM = 0.3
+
+export type ExtractionResult = {
+  readonly nodeTypes: readonly TypeEntry[]
+  readonly edgeTypes: readonly TypeEntry[]
+  readonly businessCategories: readonly string[]
+  readonly domain: string
+  readonly confidence: number
+}
+
+export type TemplateSuggestion = {
+  readonly templateKey: string
+  readonly templateLabel: string
+  readonly overlapScore: number
+  readonly coverageScore: number
+  readonly additionalTypes: TypeEntry[]
+  readonly missingFromTemplate: TypeEntry[]
+}
+
+export type TemplateMatcherOptions = {
+  readonly embedder?: Embedder
+  /** Override the default semantic threshold (0.8). */
+  readonly semanticThreshold?: number
+  /** Override the default combined minimum (0.3). */
+  readonly combinedMinimum?: number
+}
+
+/**
+ * TemplateMatcher suggests industry templates based on extracted types.
+ * Uses exact set intersection by default, and semantic embedding similarity
+ * when an embedder is provided.
+ */
+export class TemplateMatcher {
+  private readonly embedder: Embedder | undefined
+  private readonly semanticThreshold: number
+  private readonly combinedMinimum: number
+
+  constructor(options: TemplateMatcherOptions) {
+    this.embedder = options.embedder
+    this.semanticThreshold = options.semanticThreshold ?? TEMPLATE_MATCH_SEMANTIC_THRESHOLD
+    this.combinedMinimum = options.combinedMinimum ?? TEMPLATE_MATCH_COMBINED_MINIMUM
+  }
+
+  /**
+   * Find the best-matching industry template for the given extraction.
+   * Uses semantic matching when an embedder is available, falling back to exact.
+   * Returns undefined if no template scores above the combined threshold.
+   */
+  async match(
+    extracted: ExtractionResult,
+    signal?: AbortSignal,
+  ): Promise<TemplateSuggestion | undefined> {
+    if (extracted.nodeTypes.length === 0 && extracted.edgeTypes.length === 0) {
+      return undefined
+    }
+
+    if (this.embedder === undefined) {
+      return this.matchExact(extracted)
+    }
+
+    return this.matchSemantic(extracted, signal)
+  }
+
+  /**
+   * Perform set-intersection-only matching (no embeddings).
+   * Returns undefined if no template scores above the combined threshold.
+   */
+  matchExact(extracted: ExtractionResult): TemplateSuggestion | undefined {
+    if (extracted.nodeTypes.length === 0 && extracted.edgeTypes.length === 0) {
+      return undefined
+    }
+
+    const extractedNodeSet = new Map<string, TypeEntry>()
+    for (const nt of extracted.nodeTypes) {
+      extractedNodeSet.set(nt.type, nt)
+    }
+    const extractedEdgeSet = new Map<string, TypeEntry>()
+    for (const et of extracted.edgeTypes) {
+      extractedEdgeSet.set(et.type, et)
+    }
+
+    const extractedCount = extracted.nodeTypes.length + extracted.edgeTypes.length
+
+    let best: TemplateSuggestion | undefined
+    let bestCombined = 0
+
+    const keys = listTemplates()
+    for (const key of keys) {
+      const tmpl = getTemplate(key)
+      if (tmpl === undefined) continue
+
+      const templateNodeSet = new Map<string, TypeEntry>()
+      for (const nt of tmpl.nodeTypes) {
+        templateNodeSet.set(nt.type, nt)
+      }
+      const templateEdgeSet = new Map<string, TypeEntry>()
+      for (const et of tmpl.edgeTypes) {
+        templateEdgeSet.set(et.type, et)
+      }
+
+      const templateCount = tmpl.nodeTypes.length + tmpl.edgeTypes.length
+      if (templateCount === 0) continue
+
+      let intersectionCount = 0
+      for (const typeId of extractedNodeSet.keys()) {
+        if (templateNodeSet.has(typeId)) intersectionCount++
+      }
+      for (const typeId of extractedEdgeSet.keys()) {
+        if (templateEdgeSet.has(typeId)) intersectionCount++
+      }
+
+      const overlapScore = extractedCount > 0 ? intersectionCount / extractedCount : 0
+      const coverageScore = intersectionCount / templateCount
+      const combined = (overlapScore + coverageScore) / 2
+
+      if (combined >= this.combinedMinimum && combined > bestCombined) {
+        const additional = computeAdditionalTypes(extracted, templateNodeSet, templateEdgeSet)
+        const missing = computeMissingTypes(tmpl, extractedNodeSet, extractedEdgeSet)
+
+        bestCombined = combined
+        best = {
+          templateKey: key,
+          templateLabel: tmpl.label,
+          overlapScore,
+          coverageScore,
+          additionalTypes: additional,
+          missingFromTemplate: missing,
+        }
+      }
+    }
+
+    return best
+  }
+
+  private async matchSemantic(
+    extracted: ExtractionResult,
+    signal?: AbortSignal,
+  ): Promise<TemplateSuggestion | undefined> {
+    const extractedTypes = combineTypes(extracted.nodeTypes, extracted.edgeTypes)
+    if (extractedTypes.length === 0) return undefined
+
+    const extractedTexts = extractedTypes.map((t) => `${t.label}: ${t.description}`)
+    const extractedEmbeddings = await this.embedder!.embed(extractedTexts, signal)
+
+    let best: TemplateSuggestion | undefined
+    let bestCombined = 0
+
+    const keys = listTemplates()
+    for (const key of keys) {
+      const tmpl = getTemplate(key)
+      if (tmpl === undefined) continue
+
+      const templateTypes = combineTypes(tmpl.nodeTypes, tmpl.edgeTypes)
+      if (templateTypes.length === 0) continue
+
+      const templateTexts = templateTypes.map((t) => `${t.label}: ${t.description}`)
+      const templateEmbeddings = await this.embedder!.embed(templateTexts, signal)
+
+      const matchCount = greedyBipartiteMatch(
+        extractedEmbeddings,
+        templateEmbeddings,
+        this.semanticThreshold,
+      )
+
+      const extractedCount = extractedTypes.length
+      const templateCount = templateTypes.length
+
+      const overlapScore = extractedCount > 0 ? matchCount / extractedCount : 0
+      const coverageScore = templateCount > 0 ? matchCount / templateCount : 0
+      const combined = (overlapScore + coverageScore) / 2
+
+      if (combined >= this.combinedMinimum && combined > bestCombined) {
+        const extractedNodeSet = new Map<string, TypeEntry>()
+        for (const nt of extracted.nodeTypes) {
+          extractedNodeSet.set(nt.type, nt)
+        }
+        const extractedEdgeSet = new Map<string, TypeEntry>()
+        for (const et of extracted.edgeTypes) {
+          extractedEdgeSet.set(et.type, et)
+        }
+        const templateNodeSet = new Map<string, TypeEntry>()
+        for (const nt of tmpl.nodeTypes) {
+          templateNodeSet.set(nt.type, nt)
+        }
+        const templateEdgeSet = new Map<string, TypeEntry>()
+        for (const et of tmpl.edgeTypes) {
+          templateEdgeSet.set(et.type, et)
+        }
+
+        const additional = computeAdditionalTypes(extracted, templateNodeSet, templateEdgeSet)
+        const missing = computeMissingTypes(tmpl, extractedNodeSet, extractedEdgeSet)
+
+        bestCombined = combined
+        best = {
+          templateKey: key,
+          templateLabel: tmpl.label,
+          overlapScore,
+          coverageScore,
+          additionalTypes: additional,
+          missingFromTemplate: missing,
+        }
+      }
+    }
+
+    return best
+  }
+}
+
+/**
+ * Greedy bipartite matching: for each pair, compute cosine similarity.
+ * Sort by similarity descending, greedily assign each pair if both sides
+ * are unmatched. Only counts pairs with similarity >= threshold.
+ */
+function greedyBipartiteMatch(
+  extractedVecs: readonly (readonly number[])[],
+  templateVecs: readonly (readonly number[])[],
+  threshold: number,
+): number {
+  if (extractedVecs.length === 0 || templateVecs.length === 0) return 0
+
+  const pairs: Array<{ extractedIdx: number; templateIdx: number; similarity: number }> = []
+
+  for (let i = 0; i < extractedVecs.length; i++) {
+    const ev = extractedVecs[i]
+    if (ev === undefined) continue
+    for (let j = 0; j < templateVecs.length; j++) {
+      const tv = templateVecs[j]
+      if (tv === undefined) continue
+      try {
+        const sim = cosineSimilarity(ev, tv)
+        if (sim >= threshold) {
+          pairs.push({ extractedIdx: i, templateIdx: j, similarity: sim })
+        }
+      } catch {
+        // Skip if vectors have different lengths
+      }
+    }
+  }
+
+  pairs.sort((a, b) => b.similarity - a.similarity)
+
+  const usedExtracted = new Set<number>()
+  const usedTemplate = new Set<number>()
+  let matchCount = 0
+
+  for (const p of pairs) {
+    if (usedExtracted.has(p.extractedIdx) || usedTemplate.has(p.templateIdx)) continue
+    usedExtracted.add(p.extractedIdx)
+    usedTemplate.add(p.templateIdx)
+    matchCount++
+  }
+
+  return matchCount
+}
+
+function computeAdditionalTypes(
+  extracted: ExtractionResult,
+  templateNodeSet: Map<string, TypeEntry>,
+  templateEdgeSet: Map<string, TypeEntry>,
+): TypeEntry[] {
+  const additional: TypeEntry[] = []
+  for (const nt of extracted.nodeTypes) {
+    if (!templateNodeSet.has(nt.type)) additional.push(nt)
+  }
+  for (const et of extracted.edgeTypes) {
+    if (!templateEdgeSet.has(et.type)) additional.push(et)
+  }
+  return additional
+}
+
+function computeMissingTypes(
+  tmpl: IndustryTemplate,
+  extractedNodeSet: Map<string, TypeEntry>,
+  extractedEdgeSet: Map<string, TypeEntry>,
+): TypeEntry[] {
+  const missing: TypeEntry[] = []
+  for (const nt of tmpl.nodeTypes) {
+    if (!extractedNodeSet.has(nt.type)) missing.push(nt)
+  }
+  for (const et of tmpl.edgeTypes) {
+    if (!extractedEdgeSet.has(et.type)) missing.push(et)
+  }
+  return missing
+}
+
+function combineTypes(
+  nodeTypes: readonly TypeEntry[],
+  edgeTypes: readonly TypeEntry[],
+): TypeEntry[] {
+  return [...nodeTypes, ...edgeTypes]
+}

--- a/sdks/ts/memory/src/ontology/types-extraction.ts
+++ b/sdks/ts/memory/src/ontology/types-extraction.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ExtractionResult holds extracted ontology types from a document.
+ * Defined in a shared file so that both template matching (P6-6) and
+ * the proposal workflow (P6-7) can reference it without duplication.
+ * When P6-4 is merged, the canonical definition in extract.ts will
+ * supersede this one.
+ */
+
+import type { TypeEntry } from './templates.js'
+
+export type ExtractionResult = {
+  readonly nodeTypes: readonly TypeEntry[]
+  readonly edgeTypes: readonly TypeEntry[]
+  readonly businessCategories: readonly string[]
+  readonly domain: string
+  readonly confidence: number
+}


### PR DESCRIPTION
## Summary
- Implement template matching in Go (`go/ontology/template_match.go`) and TypeScript (`sdks/ts/memory/src/ontology/template-match.ts`)
- Score extracted types against all 6 industry templates using exact set intersection and semantic embedding similarity
- Combined score = (overlap + coverage) / 2 with configurable 0.3 minimum threshold
- Greedy bipartite matching for semantic tier (cosine >= 0.8)
- Computes additional types (extracted but not in template) and missing types (template but not extracted)
- Graceful fallback to exact-only when no embedder is available

## Files Changed
- `go/ontology/template_match.go` — TemplateMatcher with exact + semantic matching
- `go/ontology/template_match_test.go` — 14 unit tests
- `sdks/ts/memory/src/ontology/template-match.ts` — TS mirror of Go implementation
- `sdks/ts/memory/src/ontology/template-match.test.ts` — 12 unit tests
- `sdks/ts/memory/src/ontology/index.ts` — barrel exports

## Test plan
- [x] Go tests pass: `go test ./ontology/... -v` (all pass including 14 new tests)
- [x] TS tests pass: `vitest run sdks/ts/memory/src/ontology/` (233 tests, 12 new)
- [x] Perfect overlap returns 1.0 overlap and coverage scores
- [x] Partial overlap calculates correct scores
- [x] No overlap returns nil/undefined
- [x] Best template selected from all 6
- [x] Additional types correctly identified
- [x] Missing types correctly identified
- [x] Empty extraction returns nil/undefined
- [x] Fallback to exact when no embedder
- [x] Semantic matching runs without error with mock embedder
- [x] Greedy bipartite matching with identical/orthogonal vectors