### PR TITLE
feat(ingest): P2-3 cron scheduling for periodic re-ingestion

### DIFF
--- a/go/ingest/schedule/cron.go
+++ b/go/ingest/schedule/cron.go
@@ -15,6 +15,10 @@ type CronSchedule struct {
 	DayOfMonth []int // 1-31
 	Month      []int // 1-12
 	DayOfWeek  []int // 0-6 (Sunday=0)
+	// DayOfMonthIsWild is true when the original day-of-month token was a wildcard (* or */N).
+	DayOfMonthIsWild bool
+	// DayOfWeekIsWild is true when the original day-of-week token was a wildcard (* or */N).
+	DayOfWeekIsWild bool
 }
 
 // ParseCron parses a standard 5-field cron expression.
@@ -47,12 +51,21 @@ func ParseCron(expression string) (CronSchedule, error) {
 	}
 
 	return CronSchedule{
-		Minute:     minute,
-		Hour:       hour,
-		DayOfMonth: dom,
-		Month:      month,
-		DayOfWeek:  dow,
+		Minute:           minute,
+		Hour:             hour,
+		DayOfMonth:       dom,
+		Month:            month,
+		DayOfWeek:        dow,
+		DayOfMonthIsWild: isWildcard(fields[2]),
+		DayOfWeekIsWild:  isWildcard(fields[4]),
 	}, nil
+}
+
+// isWildcard returns true when the raw cron field token represents a wildcard.
+// Matches bare "*" and step-only forms like "*/N".
+func isWildcard(token string) bool {
+	trimmed := strings.TrimSpace(token)
+	return trimmed == "*" || strings.HasPrefix(trimmed, "*/")
 }
 
 // IsValid reports whether expression is a valid 5-field cron expression.
@@ -79,8 +92,8 @@ func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
 	monthSet := toSet(sched.Month)
 	dowSet := toSet(sched.DayOfWeek)
 
-	domIsWild := len(sched.DayOfMonth) == 31
-	dowIsWild := len(sched.DayOfWeek) == 7
+	domIsWild := sched.DayOfMonthIsWild
+	dowIsWild := sched.DayOfWeekIsWild
 
 	// Search up to 4 years (≈2.1M minutes) to find a match.
 	limit := after.Add(4 * 365 * 24 * time.Hour)

--- a/go/ingest/schedule/cron.go
+++ b/go/ingest/schedule/cron.go
@@ -64,6 +64,11 @@ func IsValid(expression string) bool {
 // NextOccurrence computes the next time the schedule fires after the
 // given reference time. It iterates minute-by-minute up to 4 years out
 // to find the next match.
+//
+// DOM+DOW union semantics: per POSIX cron, when both day-of-month and
+// day-of-week are non-wildcard (i.e. not full-range), a date matches if
+// EITHER condition is true. When one or both are wildcard, standard
+// intersection applies.
 func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
 	// Start one minute after `after`, zeroing seconds.
 	t := after.Truncate(time.Minute).Add(time.Minute)
@@ -74,12 +79,15 @@ func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
 	monthSet := toSet(sched.Month)
 	dowSet := toSet(sched.DayOfWeek)
 
+	domIsWild := len(sched.DayOfMonth) == 31
+	dowIsWild := len(sched.DayOfWeek) == 7
+
 	// Search up to 4 years (≈2.1M minutes) to find a match.
 	limit := after.Add(4 * 365 * 24 * time.Hour)
 	for t.Before(limit) {
+		dayMatch := matchDay(domSet, dowSet, domIsWild, dowIsWild, t.Day(), int(t.Weekday()))
 		if monthSet[int(t.Month())] &&
-			domSet[t.Day()] &&
-			dowSet[int(t.Weekday())] &&
+			dayMatch &&
 			hourSet[t.Hour()] &&
 			minuteSet[t.Minute()] {
 			return t
@@ -91,7 +99,7 @@ func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
 			t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, t.Location())
 			continue
 		}
-		if !domSet[t.Day()] || !dowSet[int(t.Weekday())] {
+		if !dayMatch {
 			// Jump to the next day.
 			t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, t.Location())
 			continue
@@ -106,6 +114,17 @@ func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
 
 	// Fallback: should not happen for valid schedules.
 	return limit
+}
+
+// matchDay implements POSIX cron union semantics for day-of-month and
+// day-of-week. When both fields are restricted (non-wildcard), the day
+// matches if EITHER the DOM or DOW matches. When one or both are
+// wildcard, standard AND logic applies.
+func matchDay(domSet, dowSet map[int]bool, domIsWild, dowIsWild bool, day, weekday int) bool {
+	if !domIsWild && !dowIsWild {
+		return domSet[day] || dowSet[weekday]
+	}
+	return domSet[day] && dowSet[weekday]
 }
 
 // parseField parses a single cron field (e.g., "*/5", "1-3", "1,3,5", "*").
@@ -162,7 +181,21 @@ func parseField(field string, min, max int) ([]int, error) {
 	if len(result) == 0 {
 		return nil, fmt.Errorf("empty field")
 	}
-	return result, nil
+	return deduplicate(result), nil
+}
+
+// deduplicate removes duplicate values from a sorted-ish slice
+// produced by parseField, preserving order.
+func deduplicate(vals []int) []int {
+	seen := make(map[int]bool, len(vals))
+	out := make([]int, 0, len(vals))
+	for _, v := range vals {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 func toSet(vals []int) map[int]bool {

--- a/go/ingest/schedule/cron.go
+++ b/go/ingest/schedule/cron.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+package schedule
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CronSchedule represents a parsed 5-field cron expression.
+type CronSchedule struct {
+	Minute     []int // 0-59
+	Hour       []int // 0-23
+	DayOfMonth []int // 1-31
+	Month      []int // 1-12
+	DayOfWeek  []int // 0-6 (Sunday=0)
+}
+
+// ParseCron parses a standard 5-field cron expression.
+// Supports: numbers, ranges (1-5), steps (*/5), lists (1,3,5), and *.
+func ParseCron(expression string) (CronSchedule, error) {
+	fields := strings.Fields(expression)
+	if len(fields) != 5 {
+		return CronSchedule{}, fmt.Errorf("cron: expected 5 fields, got %d in %q", len(fields), expression)
+	}
+
+	minute, err := parseField(fields[0], 0, 59)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("cron: minute field: %w", err)
+	}
+	hour, err := parseField(fields[1], 0, 23)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("cron: hour field: %w", err)
+	}
+	dom, err := parseField(fields[2], 1, 31)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("cron: day-of-month field: %w", err)
+	}
+	month, err := parseField(fields[3], 1, 12)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("cron: month field: %w", err)
+	}
+	dow, err := parseField(fields[4], 0, 6)
+	if err != nil {
+		return CronSchedule{}, fmt.Errorf("cron: day-of-week field: %w", err)
+	}
+
+	return CronSchedule{
+		Minute:     minute,
+		Hour:       hour,
+		DayOfMonth: dom,
+		Month:      month,
+		DayOfWeek:  dow,
+	}, nil
+}
+
+// IsValid reports whether expression is a valid 5-field cron expression.
+func IsValid(expression string) bool {
+	_, err := ParseCron(expression)
+	return err == nil
+}
+
+// NextOccurrence computes the next time the schedule fires after the
+// given reference time. It iterates minute-by-minute up to 4 years out
+// to find the next match.
+func NextOccurrence(sched CronSchedule, after time.Time) time.Time {
+	// Start one minute after `after`, zeroing seconds.
+	t := after.Truncate(time.Minute).Add(time.Minute)
+
+	minuteSet := toSet(sched.Minute)
+	hourSet := toSet(sched.Hour)
+	domSet := toSet(sched.DayOfMonth)
+	monthSet := toSet(sched.Month)
+	dowSet := toSet(sched.DayOfWeek)
+
+	// Search up to 4 years (≈2.1M minutes) to find a match.
+	limit := after.Add(4 * 365 * 24 * time.Hour)
+	for t.Before(limit) {
+		if monthSet[int(t.Month())] &&
+			domSet[t.Day()] &&
+			dowSet[int(t.Weekday())] &&
+			hourSet[t.Hour()] &&
+			minuteSet[t.Minute()] {
+			return t
+		}
+
+		// Skip ahead intelligently.
+		if !monthSet[int(t.Month())] {
+			// Jump to the first day of the next month.
+			t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, t.Location())
+			continue
+		}
+		if !domSet[t.Day()] || !dowSet[int(t.Weekday())] {
+			// Jump to the next day.
+			t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, t.Location())
+			continue
+		}
+		if !hourSet[t.Hour()] {
+			// Jump to the next hour.
+			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour()+1, 0, 0, 0, t.Location())
+			continue
+		}
+		t = t.Add(time.Minute)
+	}
+
+	// Fallback: should not happen for valid schedules.
+	return limit
+}
+
+// parseField parses a single cron field (e.g., "*/5", "1-3", "1,3,5", "*").
+func parseField(field string, min, max int) ([]int, error) {
+	var result []int
+
+	for _, part := range strings.Split(field, ",") {
+		part = strings.TrimSpace(part)
+		stepParts := strings.SplitN(part, "/", 2)
+		rangePart := stepParts[0]
+		step := 1
+
+		if len(stepParts) == 2 {
+			var err error
+			step, err = strconv.Atoi(stepParts[1])
+			if err != nil || step < 1 {
+				return nil, fmt.Errorf("invalid step %q", stepParts[1])
+			}
+		}
+
+		var rangeStart, rangeEnd int
+
+		if rangePart == "*" {
+			rangeStart = min
+			rangeEnd = max
+		} else if idx := strings.Index(rangePart, "-"); idx >= 0 {
+			var err error
+			rangeStart, err = strconv.Atoi(rangePart[:idx])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range start %q", rangePart[:idx])
+			}
+			rangeEnd, err = strconv.Atoi(rangePart[idx+1:])
+			if err != nil {
+				return nil, fmt.Errorf("invalid range end %q", rangePart[idx+1:])
+			}
+		} else {
+			val, err := strconv.Atoi(rangePart)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %q", rangePart)
+			}
+			rangeStart = val
+			rangeEnd = val
+		}
+
+		if rangeStart < min || rangeEnd > max || rangeStart > rangeEnd {
+			return nil, fmt.Errorf("value out of range [%d-%d]: %d-%d", min, max, rangeStart, rangeEnd)
+		}
+
+		for i := rangeStart; i <= rangeEnd; i += step {
+			result = append(result, i)
+		}
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("empty field")
+	}
+	return result, nil
+}
+
+func toSet(vals []int) map[int]bool {
+	s := make(map[int]bool, len(vals))
+	for _, v := range vals {
+		s[v] = true
+	}
+	return s
+}

--- a/go/ingest/schedule/cron_test.go
+++ b/go/ingest/schedule/cron_test.go
@@ -127,6 +127,32 @@ func TestNextOccurrenceSpecificDay(t *testing.T) {
 	}
 }
 
+func TestNextOccurrenceDOMDOWUnion(t *testing.T) {
+	// "0 9 15 * 1" means: at 9:00 on the 15th of every month OR on every Monday.
+	// Using a Wednesday 2025-05-14 as reference. Next Monday is May 19, but the
+	// 15th comes first (May 15 is a Thursday).
+	sched, _ := ParseCron("0 9 15 * 1")
+	ref := time.Date(2025, 5, 14, 10, 0, 0, 0, time.UTC)
+	next := NextOccurrence(sched, ref)
+
+	// May 15 is a Thursday (not Monday), but it matches DOM=15 via union.
+	expected := time.Date(2025, 5, 15, 9, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v (DOM match), got %v", expected, next)
+	}
+}
+
+func TestParseFieldDeduplicatesOverlap(t *testing.T) {
+	// "1,1-3" should produce [1,2,3] not [1,1,2,3]
+	vals, err := parseField("1,1-3", 1, 31)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vals) != 3 {
+		t.Fatalf("expected 3 values, got %d: %v", len(vals), vals)
+	}
+}
+
 func TestParseCronRangeAndList(t *testing.T) {
 	sched, err := ParseCron("0 9-17 * * 1-5")
 	if err != nil {

--- a/go/ingest/schedule/cron_test.go
+++ b/go/ingest/schedule/cron_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+package schedule
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCronEveryHour(t *testing.T) {
+	sched, err := ParseCron("0 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sched.Minute) != 1 || sched.Minute[0] != 0 {
+		t.Fatalf("expected minute [0], got %v", sched.Minute)
+	}
+	if len(sched.Hour) != 24 {
+		t.Fatalf("expected 24 hours, got %d", len(sched.Hour))
+	}
+}
+
+func TestParseCronMondayMorning(t *testing.T) {
+	sched, err := ParseCron("30 2 * * 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sched.Minute[0] != 30 {
+		t.Fatalf("expected minute 30, got %v", sched.Minute)
+	}
+	if sched.Hour[0] != 2 {
+		t.Fatalf("expected hour 2, got %v", sched.Hour)
+	}
+	if sched.DayOfWeek[0] != 1 {
+		t.Fatalf("expected dow 1, got %v", sched.DayOfWeek)
+	}
+}
+
+func TestParseCronEvery5Minutes(t *testing.T) {
+	sched, err := ParseCron("*/5 * * * *")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []int{0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55}
+	if len(sched.Minute) != len(expected) {
+		t.Fatalf("expected %d minutes, got %d: %v", len(expected), len(sched.Minute), sched.Minute)
+	}
+	for i, v := range expected {
+		if sched.Minute[i] != v {
+			t.Fatalf("minute %d: expected %d, got %d", i, v, sched.Minute[i])
+		}
+	}
+}
+
+func TestParseCronInvalidExpression(t *testing.T) {
+	tests := []string{
+		"",
+		"* * *",
+		"60 * * * *",
+		"* 25 * * *",
+		"* * 32 * *",
+		"* * * 13 *",
+		"* * * * 7",
+		"abc * * * *",
+	}
+	for _, expr := range tests {
+		_, err := ParseCron(expr)
+		if err == nil {
+			t.Errorf("expected error for %q", expr)
+		}
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	if !IsValid("0 * * * *") {
+		t.Fatal("expected valid")
+	}
+	if IsValid("invalid") {
+		t.Fatal("expected invalid")
+	}
+}
+
+func TestNextOccurrenceEveryHour(t *testing.T) {
+	sched, _ := ParseCron("0 * * * *")
+	ref := time.Date(2026, 5, 15, 10, 30, 0, 0, time.UTC)
+	next := NextOccurrence(sched, ref)
+
+	expected := time.Date(2026, 5, 15, 11, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestNextOccurrenceExactMinute(t *testing.T) {
+	sched, _ := ParseCron("0 * * * *")
+	// When we're exactly at minute 0, the next occurrence should be the next hour.
+	ref := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	next := NextOccurrence(sched, ref)
+
+	expected := time.Date(2026, 5, 15, 11, 0, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestNextOccurrenceEvery5Minutes(t *testing.T) {
+	sched, _ := ParseCron("*/5 * * * *")
+	ref := time.Date(2026, 5, 15, 10, 12, 0, 0, time.UTC)
+	next := NextOccurrence(sched, ref)
+
+	expected := time.Date(2026, 5, 15, 10, 15, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestNextOccurrenceSpecificDay(t *testing.T) {
+	// Every Monday at 2:30 AM.
+	sched, _ := ParseCron("30 2 * * 1")
+	// Thursday May 15, 2025.
+	ref := time.Date(2025, 5, 15, 10, 0, 0, 0, time.UTC)
+	next := NextOccurrence(sched, ref)
+
+	// Next Monday is May 19, 2025.
+	expected := time.Date(2025, 5, 19, 2, 30, 0, 0, time.UTC)
+	if !next.Equal(expected) {
+		t.Fatalf("expected %v, got %v", expected, next)
+	}
+}
+
+func TestParseCronRangeAndList(t *testing.T) {
+	sched, err := ParseCron("0 9-17 * * 1-5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Hours 9 through 17.
+	if len(sched.Hour) != 9 {
+		t.Fatalf("expected 9 hours, got %d: %v", len(sched.Hour), sched.Hour)
+	}
+	// Monday through Friday.
+	if len(sched.DayOfWeek) != 5 {
+		t.Fatalf("expected 5 days, got %d: %v", len(sched.DayOfWeek), sched.DayOfWeek)
+	}
+}

--- a/go/ingest/schedule/scheduler.go
+++ b/go/ingest/schedule/scheduler.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+package schedule
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const defaultPollInterval = 30 * time.Second
+
+// SchedulerOptions configures the scheduler.
+type SchedulerOptions struct {
+	Store        Store
+	Dispatch     DispatchFunc
+	PollInterval time.Duration
+	Logger       Logger
+	// Now is an injectable clock for testing. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// Scheduler polls the schedule store for due jobs and fires them.
+type Scheduler struct {
+	opts   SchedulerOptions
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewScheduler creates a scheduler. Call Start to begin polling.
+func NewScheduler(opts SchedulerOptions) *Scheduler {
+	if opts.PollInterval == 0 {
+		opts.PollInterval = defaultPollInterval
+	}
+	if opts.Now == nil {
+		opts.Now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Scheduler{opts: opts}
+}
+
+// Start begins the polling loop in a background goroutine.
+func (s *Scheduler) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.poll(ctx)
+}
+
+// Stop signals the scheduler to stop and waits for the current poll to
+// complete.
+func (s *Scheduler) Stop() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// RunDueJobs is exposed for testing. It checks for due jobs and fires
+// them, returning the number of jobs fired.
+func (s *Scheduler) RunDueJobs(ctx context.Context) (int, error) {
+	now := s.opts.Now()
+	jobs, err := s.opts.Store.FindDue(ctx, now)
+	if err != nil {
+		return 0, err
+	}
+
+	fired := 0
+	for _, job := range jobs {
+		if err := s.opts.Dispatch(job); err != nil {
+			if s.opts.Logger != nil {
+				s.opts.Logger.Error("schedule: dispatch failed", map[string]string{
+					"jobId": job.ID,
+					"error": err.Error(),
+				})
+			}
+			// Continue with next job — one failure does not block others.
+			continue
+		}
+
+		// Reschedule.
+		sched, parseErr := ParseCron(job.CronExpression)
+		if parseErr != nil {
+			if s.opts.Logger != nil {
+				s.opts.Logger.Error("schedule: parse cron failed", map[string]string{
+					"jobId":          job.ID,
+					"cronExpression": job.CronExpression,
+					"error":          parseErr.Error(),
+				})
+			}
+			continue
+		}
+
+		nextRun := NextOccurrence(sched, now)
+		if err := s.opts.Store.MarkRun(ctx, job.ID, now, nextRun); err != nil {
+			if s.opts.Logger != nil {
+				s.opts.Logger.Error("schedule: markRun failed", map[string]string{
+					"jobId": job.ID,
+					"error": err.Error(),
+				})
+			}
+		}
+		fired++
+	}
+
+	return fired, nil
+}
+
+func (s *Scheduler) poll(ctx context.Context) {
+	defer s.wg.Done()
+	ticker := time.NewTicker(s.opts.PollInterval)
+	defer ticker.Stop()
+
+	// Run immediately on start.
+	if _, err := s.RunDueJobs(ctx); err != nil {
+		if s.opts.Logger != nil {
+			s.opts.Logger.Error("schedule: poll error", map[string]string{
+				"error": err.Error(),
+			})
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := s.RunDueJobs(ctx); err != nil {
+				if s.opts.Logger != nil {
+					s.opts.Logger.Error("schedule: poll error", map[string]string{
+						"error": err.Error(),
+					})
+				}
+			}
+		}
+	}
+}

--- a/go/ingest/schedule/scheduler.go
+++ b/go/ingest/schedule/scheduler.go
@@ -66,7 +66,7 @@ func (s *Scheduler) RunDueJobs(ctx context.Context) (int, error) {
 
 	fired := 0
 	for _, job := range jobs {
-		if err := s.opts.Dispatch(job); err != nil {
+		if err := s.opts.Dispatch(ctx, job); err != nil {
 			if s.opts.Logger != nil {
 				s.opts.Logger.Error("schedule: dispatch failed", map[string]string{
 					"jobId": job.ID,

--- a/go/ingest/schedule/scheduler_test.go
+++ b/go/ingest/schedule/scheduler_test.go
@@ -143,7 +143,7 @@ func TestSchedulerRunDueJobs(t *testing.T) {
 
 	scheduler := NewScheduler(SchedulerOptions{
 		Store: store,
-		Dispatch: func(j Job) error {
+		Dispatch: func(_ context.Context, j Job) error {
 			dispatched.Add(1)
 			return nil
 		},
@@ -185,7 +185,7 @@ func TestSchedulerDisabledJobSkipped(t *testing.T) {
 
 	scheduler := NewScheduler(SchedulerOptions{
 		Store: store,
-		Dispatch: func(_ Job) error {
+		Dispatch: func(_ context.Context, _ Job) error {
 			dispatched.Add(1)
 			return nil
 		},
@@ -222,7 +222,7 @@ func TestSchedulerJobFailureDoesNotBlockOthers(t *testing.T) {
 	scheduler := NewScheduler(SchedulerOptions{
 		Store:  store,
 		Logger: &testLogger{},
-		Dispatch: func(j Job) error {
+		Dispatch: func(_ context.Context, j Job) error {
 			if j.Name == "failing job" {
 				return errors.New("dispatch error")
 			}
@@ -248,7 +248,7 @@ func TestSchedulerNoDueJobs(t *testing.T) {
 	var dispatched atomic.Int32
 	scheduler := NewScheduler(SchedulerOptions{
 		Store: store,
-		Dispatch: func(_ Job) error {
+		Dispatch: func(_ context.Context, _ Job) error {
 			dispatched.Add(1)
 			return nil
 		},
@@ -285,7 +285,7 @@ func TestSchedulerPerBrainIsolation(t *testing.T) {
 	brains := map[string]int{}
 	scheduler := NewScheduler(SchedulerOptions{
 		Store: store,
-		Dispatch: func(j Job) error {
+		Dispatch: func(_ context.Context, j Job) error {
 			brains[j.BrainID]++
 			return nil
 		},
@@ -312,6 +312,45 @@ func TestInvalidCronExpressionRejected(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid cron expression")
+	}
+}
+
+func TestSchedulerStartStop(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	var dispatched atomic.Int32
+
+	job, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "lifecycle job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/lifecycle.md"},
+	})
+
+	// Force next_run_at to the past.
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store.MarkRun(context.Background(), job.ID, past.Add(-2*time.Hour), past)
+
+	scheduler := NewScheduler(SchedulerOptions{
+		Store:        store,
+		PollInterval: 50 * time.Millisecond,
+		Dispatch: func(_ context.Context, _ Job) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+
+	scheduler.Start()
+	// Give the immediate poll time to fire.
+	time.Sleep(100 * time.Millisecond)
+	err := scheduler.Stop()
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	if got := dispatched.Load(); got < 1 {
+		t.Fatalf("expected at least 1 dispatch after start, got %d", got)
 	}
 }
 

--- a/go/ingest/schedule/scheduler_test.go
+++ b/go/ingest/schedule/scheduler_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestStoreCRUD(t *testing.T) {
+	db := openTestDB(t)
+	store, err := NewSQLiteStore(db)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	// Create.
+	job, err := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "daily re-ingest",
+		CronExpression: "0 2 * * *",
+		Target:         Target{Kind: "url", URL: "https://example.com/feed"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if job.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if !job.Enabled {
+		t.Fatal("expected enabled")
+	}
+
+	// Get.
+	got, err := store.Get(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "daily re-ingest" {
+		t.Fatalf("expected 'daily re-ingest', got %q", got.Name)
+	}
+
+	// List.
+	jobs, err := store.List(context.Background(), "brain-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+
+	// Update.
+	newName := "weekly re-ingest"
+	updated, err := store.Update(context.Background(), job.ID, UpdatePatch{Name: &newName})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "weekly re-ingest" {
+		t.Fatalf("expected 'weekly re-ingest', got %q", updated.Name)
+	}
+
+	// Delete.
+	err = store.Delete(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	jobs, _ = store.List(context.Background(), "brain-1")
+	if len(jobs) != 0 {
+		t.Fatalf("expected 0 jobs after delete, got %d", len(jobs))
+	}
+}
+
+func TestFindDueReturnsOnlyEnabledDueJobs(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	// Create a due job.
+	job1, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "due job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/a.md"},
+	})
+
+	// Force next_run_at to the past.
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store.MarkRun(context.Background(), job1.ID, past.Add(-2*time.Hour), past)
+
+	// Create a disabled job.
+	job2, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "disabled job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/b.md"},
+	})
+	enabled := false
+	store.Update(context.Background(), job2.ID, UpdatePatch{Enabled: &enabled})
+
+	due, err := store.FindDue(context.Background(), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("findDue: %v", err)
+	}
+
+	if len(due) != 1 {
+		t.Fatalf("expected 1 due job, got %d", len(due))
+	}
+	if due[0].ID != job1.ID {
+		t.Fatalf("expected job %s, got %s", job1.ID, due[0].ID)
+	}
+}
+
+func TestSchedulerRunDueJobs(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	var dispatched atomic.Int32
+
+	job, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "test job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/test.md"},
+	})
+
+	// Force next_run_at to the past.
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store.MarkRun(context.Background(), job.ID, past.Add(-2*time.Hour), past)
+
+	scheduler := NewScheduler(SchedulerOptions{
+		Store: store,
+		Dispatch: func(j Job) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+
+	fired, err := scheduler.RunDueJobs(context.Background())
+	if err != nil {
+		t.Fatalf("runDueJobs: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("expected 1 fired, got %d", fired)
+	}
+	if got := dispatched.Load(); got != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", got)
+	}
+
+	// After running, the job should be rescheduled (nextRunAt in the future).
+	updated, _ := store.Get(context.Background(), job.ID)
+	if updated.NextRunAt.Before(time.Now().UTC()) {
+		t.Fatal("expected nextRunAt in the future after run")
+	}
+}
+
+func TestSchedulerDisabledJobSkipped(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	var dispatched atomic.Int32
+
+	job, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "disabled job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/test.md"},
+	})
+
+	enabled := false
+	store.Update(context.Background(), job.ID, UpdatePatch{Enabled: &enabled})
+
+	scheduler := NewScheduler(SchedulerOptions{
+		Store: store,
+		Dispatch: func(_ Job) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+
+	fired, _ := scheduler.RunDueJobs(context.Background())
+	if fired != 0 {
+		t.Fatalf("expected 0 fired for disabled job, got %d", fired)
+	}
+}
+
+func TestSchedulerJobFailureDoesNotBlockOthers(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	job1, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "failing job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/fail.md"},
+	})
+	job2, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "succeeding job",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/data/ok.md"},
+	})
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store.MarkRun(context.Background(), job1.ID, past.Add(-2*time.Hour), past)
+	store.MarkRun(context.Background(), job2.ID, past.Add(-2*time.Hour), past)
+
+	var succeeded atomic.Int32
+	scheduler := NewScheduler(SchedulerOptions{
+		Store:  store,
+		Logger: &testLogger{},
+		Dispatch: func(j Job) error {
+			if j.Name == "failing job" {
+				return errors.New("dispatch error")
+			}
+			succeeded.Add(1)
+			return nil
+		},
+	})
+
+	fired, _ := scheduler.RunDueJobs(context.Background())
+	// Only the successful one counts as fired.
+	if fired != 1 {
+		t.Fatalf("expected 1 fired (the successful one), got %d", fired)
+	}
+	if got := succeeded.Load(); got != 1 {
+		t.Fatalf("expected 1 succeeded, got %d", got)
+	}
+}
+
+func TestSchedulerNoDueJobs(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	var dispatched atomic.Int32
+	scheduler := NewScheduler(SchedulerOptions{
+		Store: store,
+		Dispatch: func(_ Job) error {
+			dispatched.Add(1)
+			return nil
+		},
+	})
+
+	fired, _ := scheduler.RunDueJobs(context.Background())
+	if fired != 0 {
+		t.Fatalf("expected 0 fired, got %d", fired)
+	}
+}
+
+func TestSchedulerPerBrainIsolation(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	// Create jobs for different brains.
+	job1, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-a",
+		Name:           "job-a",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/a.md"},
+	})
+	job2, _ := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-b",
+		Name:           "job-b",
+		CronExpression: "* * * * *",
+		Target:         Target{Kind: "file", Path: "/b.md"},
+	})
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store.MarkRun(context.Background(), job1.ID, past.Add(-2*time.Hour), past)
+	store.MarkRun(context.Background(), job2.ID, past.Add(-2*time.Hour), past)
+
+	brains := map[string]int{}
+	scheduler := NewScheduler(SchedulerOptions{
+		Store: store,
+		Dispatch: func(j Job) error {
+			brains[j.BrainID]++
+			return nil
+		},
+	})
+
+	fired, _ := scheduler.RunDueJobs(context.Background())
+	if fired != 2 {
+		t.Fatalf("expected 2 fired, got %d", fired)
+	}
+	if brains["brain-a"] != 1 || brains["brain-b"] != 1 {
+		t.Fatalf("expected 1 per brain, got %v", brains)
+	}
+}
+
+func TestInvalidCronExpressionRejected(t *testing.T) {
+	db := openTestDB(t)
+	store, _ := NewSQLiteStore(db)
+
+	_, err := store.Create(context.Background(), CreateInput{
+		BrainID:        "brain-1",
+		Name:           "bad cron",
+		CronExpression: "invalid",
+		Target:         Target{Kind: "file", Path: "/data/test.md"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid cron expression")
+	}
+}
+
+type testLogger struct{}
+
+func (l *testLogger) Debug(_ string, _ ...map[string]string) {}
+func (l *testLogger) Info(_ string, _ ...map[string]string)  {}
+func (l *testLogger) Warn(_ string, _ ...map[string]string)  {}
+func (l *testLogger) Error(_ string, _ ...map[string]string) {}

--- a/go/ingest/schedule/table.go
+++ b/go/ingest/schedule/table.go
@@ -197,24 +197,31 @@ func (s *SQLiteStore) FindDue(ctx context.Context, now time.Time) ([]Job, error)
 }
 
 func (s *SQLiteStore) MarkRun(ctx context.Context, id string, ranAt, nextRunAt time.Time) error {
+	now := time.Now().UTC()
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE ingest_schedules SET last_run_at=?, next_run_at=?, updated_at=? WHERE id=?`,
-		ranAt.Format(time.RFC3339), nextRunAt.Format(time.RFC3339), ranAt.Format(time.RFC3339), id)
+		ranAt.Format(time.RFC3339), nextRunAt.Format(time.RFC3339), now.Format(time.RFC3339), id)
 	if err != nil {
 		return fmt.Errorf("schedule: markRun: %w", err)
 	}
 	return nil
 }
 
-// scanJob scans a single row into a Job.
-func scanJob(row *sql.Row) (Job, error) {
+// scanner abstracts the common Scan method shared by *sql.Row and
+// *sql.Rows so both can use the same hydration logic.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+// scanJobFrom hydrates a Job from any scanner (Row or Rows).
+func scanJobFrom(s scanner) (Job, error) {
 	var j Job
 	var enabled int
 	var lastRunAt, nextRunAt, createdAt, updatedAt sql.NullString
 	var targetURL, targetPath, targetGlob sql.NullString
 	var metadataJSON sql.NullString
 
-	err := row.Scan(&j.ID, &j.BrainID, &j.Name, &j.CronExpression,
+	err := s.Scan(&j.ID, &j.BrainID, &j.Name, &j.CronExpression,
 		&j.Target.Kind, &targetURL, &targetPath, &targetGlob,
 		&enabled, &lastRunAt, &nextRunAt, &createdAt, &updatedAt, &metadataJSON)
 	if err != nil {
@@ -248,43 +255,14 @@ func scanJob(row *sql.Row) (Job, error) {
 	return j, nil
 }
 
+// scanJob scans a single row into a Job.
+func scanJob(row *sql.Row) (Job, error) {
+	return scanJobFrom(row)
+}
+
 // scanJobRows scans a Rows iterator into a Job.
 func scanJobRows(rows *sql.Rows) (Job, error) {
-	var j Job
-	var enabled int
-	var lastRunAt, nextRunAt, createdAt, updatedAt sql.NullString
-	var targetURL, targetPath, targetGlob sql.NullString
-	var metadataJSON sql.NullString
-
-	err := rows.Scan(&j.ID, &j.BrainID, &j.Name, &j.CronExpression,
-		&j.Target.Kind, &targetURL, &targetPath, &targetGlob,
-		&enabled, &lastRunAt, &nextRunAt, &createdAt, &updatedAt, &metadataJSON)
-	if err != nil {
-		return Job{}, fmt.Errorf("schedule: scan: %w", err)
-	}
-
-	j.Target.URL = targetURL.String
-	j.Target.Path = targetPath.String
-	j.Target.Glob = targetGlob.String
-	j.Enabled = enabled == 1
-	if lastRunAt.Valid {
-		t, _ := time.Parse(time.RFC3339, lastRunAt.String)
-		j.LastRunAt = &t
-	}
-	if nextRunAt.Valid {
-		j.NextRunAt, _ = time.Parse(time.RFC3339, nextRunAt.String)
-	}
-	if createdAt.Valid {
-		j.CreatedAt, _ = time.Parse(time.RFC3339, createdAt.String)
-	}
-	if updatedAt.Valid {
-		j.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt.String)
-	}
-	if metadataJSON.Valid {
-		_ = json.Unmarshal([]byte(metadataJSON.String), &j.Metadata)
-	}
-
-	return j, nil
+	return scanJobFrom(rows)
 }
 
 func nullStr(s string) *string {

--- a/go/ingest/schedule/table.go
+++ b/go/ingest/schedule/table.go
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: Apache-2.0
+package schedule
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const createTableSQL = `
+CREATE TABLE IF NOT EXISTS ingest_schedules (
+  id TEXT PRIMARY KEY,
+  brain_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  cron_expression TEXT NOT NULL,
+  target_kind TEXT NOT NULL,
+  target_url TEXT,
+  target_path TEXT,
+  target_glob TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  last_run_at TEXT,
+  next_run_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  metadata TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_schedules_brain ON ingest_schedules(brain_id);
+CREATE INDEX IF NOT EXISTS idx_schedules_due ON ingest_schedules(enabled, next_run_at);
+`
+
+// SQLiteStore implements Store using SQLite.
+type SQLiteStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteStore creates a new SQLite-backed schedule store and ensures
+// the table exists.
+func NewSQLiteStore(db *sql.DB) (*SQLiteStore, error) {
+	if _, err := db.Exec(createTableSQL); err != nil {
+		return nil, fmt.Errorf("schedule: create table: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+func (s *SQLiteStore) Create(ctx context.Context, input CreateInput) (Job, error) {
+	if !IsValid(input.CronExpression) {
+		return Job{}, fmt.Errorf("schedule: invalid cron expression: %q", input.CronExpression)
+	}
+
+	sched, _ := ParseCron(input.CronExpression)
+	now := time.Now().UTC()
+	nextRun := NextOccurrence(sched, now)
+
+	id := uuid.New().String()
+	var metadataJSON *string
+	if input.Metadata != nil {
+		data, _ := json.Marshal(input.Metadata)
+		s := string(data)
+		metadataJSON = &s
+	}
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO ingest_schedules (id, brain_id, name, cron_expression, target_kind, target_url, target_path, target_glob, enabled, next_run_at, created_at, updated_at, metadata)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)`,
+		id, input.BrainID, input.Name, input.CronExpression,
+		input.Target.Kind, nullStr(input.Target.URL), nullStr(input.Target.Path), nullStr(input.Target.Glob),
+		now.Format(time.RFC3339), now.Format(time.RFC3339), now.Format(time.RFC3339),
+		metadataJSON,
+	)
+	if err != nil {
+		return Job{}, fmt.Errorf("schedule: insert: %w", err)
+	}
+
+	return Job{
+		ID:             id,
+		BrainID:        input.BrainID,
+		Name:           input.Name,
+		CronExpression: input.CronExpression,
+		Target:         input.Target,
+		Enabled:        true,
+		NextRunAt:      nextRun,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		Metadata:       input.Metadata,
+	}, nil
+}
+
+func (s *SQLiteStore) Get(ctx context.Context, id string) (Job, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, brain_id, name, cron_expression, target_kind, target_url, target_path, target_glob, enabled, last_run_at, next_run_at, created_at, updated_at, metadata
+		 FROM ingest_schedules WHERE id = ?`, id)
+	return scanJob(row)
+}
+
+func (s *SQLiteStore) List(ctx context.Context, brainID string) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, brain_id, name, cron_expression, target_kind, target_url, target_path, target_glob, enabled, last_run_at, next_run_at, created_at, updated_at, metadata
+		 FROM ingest_schedules WHERE brain_id = ? ORDER BY name`, brainID)
+	if err != nil {
+		return nil, fmt.Errorf("schedule: list: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		job, err := scanJobRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func (s *SQLiteStore) Update(ctx context.Context, id string, patch UpdatePatch) (Job, error) {
+	job, err := s.Get(ctx, id)
+	if err != nil {
+		return Job{}, err
+	}
+
+	if patch.Name != nil {
+		job.Name = *patch.Name
+	}
+	if patch.CronExpression != nil {
+		if !IsValid(*patch.CronExpression) {
+			return Job{}, fmt.Errorf("schedule: invalid cron expression: %q", *patch.CronExpression)
+		}
+		job.CronExpression = *patch.CronExpression
+		sched, _ := ParseCron(job.CronExpression)
+		job.NextRunAt = NextOccurrence(sched, time.Now().UTC())
+	}
+	if patch.Target != nil {
+		job.Target = *patch.Target
+	}
+	if patch.Enabled != nil {
+		job.Enabled = *patch.Enabled
+	}
+	if patch.Metadata != nil {
+		job.Metadata = *patch.Metadata
+	}
+
+	now := time.Now().UTC()
+	job.UpdatedAt = now
+
+	var metadataJSON *string
+	if job.Metadata != nil {
+		data, _ := json.Marshal(job.Metadata)
+		s := string(data)
+		metadataJSON = &s
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE ingest_schedules SET name=?, cron_expression=?, target_kind=?, target_url=?, target_path=?, target_glob=?, enabled=?, next_run_at=?, updated_at=?, metadata=? WHERE id=?`,
+		job.Name, job.CronExpression, job.Target.Kind,
+		nullStr(job.Target.URL), nullStr(job.Target.Path), nullStr(job.Target.Glob),
+		boolToInt(job.Enabled), job.NextRunAt.Format(time.RFC3339), now.Format(time.RFC3339),
+		metadataJSON, id,
+	)
+	if err != nil {
+		return Job{}, fmt.Errorf("schedule: update: %w", err)
+	}
+
+	return job, nil
+}
+
+func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM ingest_schedules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("schedule: delete: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) FindDue(ctx context.Context, now time.Time) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, brain_id, name, cron_expression, target_kind, target_url, target_path, target_glob, enabled, last_run_at, next_run_at, created_at, updated_at, metadata
+		 FROM ingest_schedules WHERE enabled = 1 AND next_run_at <= ? ORDER BY next_run_at`,
+		now.Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("schedule: findDue: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		job, err := scanJobRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
+func (s *SQLiteStore) MarkRun(ctx context.Context, id string, ranAt, nextRunAt time.Time) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE ingest_schedules SET last_run_at=?, next_run_at=?, updated_at=? WHERE id=?`,
+		ranAt.Format(time.RFC3339), nextRunAt.Format(time.RFC3339), ranAt.Format(time.RFC3339), id)
+	if err != nil {
+		return fmt.Errorf("schedule: markRun: %w", err)
+	}
+	return nil
+}
+
+// scanJob scans a single row into a Job.
+func scanJob(row *sql.Row) (Job, error) {
+	var j Job
+	var enabled int
+	var lastRunAt, nextRunAt, createdAt, updatedAt sql.NullString
+	var targetURL, targetPath, targetGlob sql.NullString
+	var metadataJSON sql.NullString
+
+	err := row.Scan(&j.ID, &j.BrainID, &j.Name, &j.CronExpression,
+		&j.Target.Kind, &targetURL, &targetPath, &targetGlob,
+		&enabled, &lastRunAt, &nextRunAt, &createdAt, &updatedAt, &metadataJSON)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return Job{}, fmt.Errorf("schedule: job not found")
+		}
+		return Job{}, fmt.Errorf("schedule: scan: %w", err)
+	}
+
+	j.Target.URL = targetURL.String
+	j.Target.Path = targetPath.String
+	j.Target.Glob = targetGlob.String
+	j.Enabled = enabled == 1
+	if lastRunAt.Valid {
+		t, _ := time.Parse(time.RFC3339, lastRunAt.String)
+		j.LastRunAt = &t
+	}
+	if nextRunAt.Valid {
+		j.NextRunAt, _ = time.Parse(time.RFC3339, nextRunAt.String)
+	}
+	if createdAt.Valid {
+		j.CreatedAt, _ = time.Parse(time.RFC3339, createdAt.String)
+	}
+	if updatedAt.Valid {
+		j.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt.String)
+	}
+	if metadataJSON.Valid {
+		_ = json.Unmarshal([]byte(metadataJSON.String), &j.Metadata)
+	}
+
+	return j, nil
+}
+
+// scanJobRows scans a Rows iterator into a Job.
+func scanJobRows(rows *sql.Rows) (Job, error) {
+	var j Job
+	var enabled int
+	var lastRunAt, nextRunAt, createdAt, updatedAt sql.NullString
+	var targetURL, targetPath, targetGlob sql.NullString
+	var metadataJSON sql.NullString
+
+	err := rows.Scan(&j.ID, &j.BrainID, &j.Name, &j.CronExpression,
+		&j.Target.Kind, &targetURL, &targetPath, &targetGlob,
+		&enabled, &lastRunAt, &nextRunAt, &createdAt, &updatedAt, &metadataJSON)
+	if err != nil {
+		return Job{}, fmt.Errorf("schedule: scan: %w", err)
+	}
+
+	j.Target.URL = targetURL.String
+	j.Target.Path = targetPath.String
+	j.Target.Glob = targetGlob.String
+	j.Enabled = enabled == 1
+	if lastRunAt.Valid {
+		t, _ := time.Parse(time.RFC3339, lastRunAt.String)
+		j.LastRunAt = &t
+	}
+	if nextRunAt.Valid {
+		j.NextRunAt, _ = time.Parse(time.RFC3339, nextRunAt.String)
+	}
+	if createdAt.Valid {
+		j.CreatedAt, _ = time.Parse(time.RFC3339, createdAt.String)
+	}
+	if updatedAt.Valid {
+		j.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt.String)
+	}
+	if metadataJSON.Valid {
+		_ = json.Unmarshal([]byte(metadataJSON.String), &j.Metadata)
+	}
+
+	return j, nil
+}
+
+func nullStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/go/ingest/schedule/types.go
+++ b/go/ingest/schedule/types.go
@@ -73,4 +73,5 @@ type Logger interface {
 }
 
 // DispatchFunc is called when a due job should trigger ingestion.
-type DispatchFunc func(job Job) error
+// The context allows callers to enforce per-job timeouts.
+type DispatchFunc func(ctx context.Context, job Job) error

--- a/go/ingest/schedule/types.go
+++ b/go/ingest/schedule/types.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package schedule provides cron-based scheduling for periodic ingestion
+// jobs. Jobs persist to SQLite (local) or PostgreSQL (hosted) via the
+// Store interface. A Scheduler polls the store for due jobs and fires
+// ingestion events.
+package schedule
+
+import (
+	"context"
+	"time"
+)
+
+// Job represents a scheduled ingestion job.
+type Job struct {
+	ID             string         `json:"id"`
+	BrainID        string         `json:"brainId"`
+	Name           string         `json:"name"`
+	CronExpression string         `json:"cronExpression"`
+	Target         Target         `json:"target"`
+	Enabled        bool           `json:"enabled"`
+	LastRunAt      *time.Time     `json:"lastRunAt,omitempty"`
+	NextRunAt      time.Time      `json:"nextRunAt"`
+	CreatedAt      time.Time      `json:"createdAt"`
+	UpdatedAt      time.Time      `json:"updatedAt"`
+	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+// Target describes what the scheduled job ingests.
+type Target struct {
+	Kind string `json:"kind"` // "url", "file", "directory"
+	URL  string `json:"url,omitempty"`
+	Path string `json:"path,omitempty"`
+	Glob string `json:"glob,omitempty"`
+}
+
+// CreateInput is the input for creating a new scheduled job.
+type CreateInput struct {
+	BrainID        string
+	Name           string
+	CronExpression string
+	Target         Target
+	Metadata       map[string]string
+}
+
+// UpdatePatch allows partial updates to a job.
+type UpdatePatch struct {
+	Name           *string
+	CronExpression *string
+	Target         *Target
+	Enabled        *bool
+	Metadata       *map[string]string
+}
+
+// Store persists scheduled jobs. Implementations must be safe for
+// sequential use within a single scheduler run.
+type Store interface {
+	Create(ctx context.Context, input CreateInput) (Job, error)
+	Get(ctx context.Context, id string) (Job, error)
+	List(ctx context.Context, brainID string) ([]Job, error)
+	Update(ctx context.Context, id string, patch UpdatePatch) (Job, error)
+	Delete(ctx context.Context, id string) error
+	FindDue(ctx context.Context, now time.Time) ([]Job, error)
+	MarkRun(ctx context.Context, id string, ranAt, nextRunAt time.Time) error
+}
+
+// Logger mirrors the logging contract used across the memory SDK.
+type Logger interface {
+	Debug(msg string, ctx ...map[string]string)
+	Info(msg string, ctx ...map[string]string)
+	Warn(msg string, ctx ...map[string]string)
+	Error(msg string, ctx ...map[string]string)
+}
+
+// DispatchFunc is called when a due job should trigger ingestion.
+type DispatchFunc func(job Job) error

--- a/sdks/ts/memory/src/ingest/schedule/cron.test.ts
+++ b/sdks/ts/memory/src/ingest/schedule/cron.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { isValid, nextOccurrence, parseCron } from './cron.js'
+
+describe('parseCron', () => {
+  it('parses "0 * * * *" -> every hour at minute 0', () => {
+    const sched = parseCron('0 * * * *')
+    expect(sched.minute).toEqual([0])
+    expect(sched.hour).toHaveLength(24)
+  })
+
+  it('parses "30 2 * * 1" -> 2:30 AM every Monday', () => {
+    const sched = parseCron('30 2 * * 1')
+    expect(sched.minute).toEqual([30])
+    expect(sched.hour).toEqual([2])
+    expect(sched.dayOfWeek).toEqual([1])
+  })
+
+  it('parses "*/5 * * * *" -> every 5 minutes', () => {
+    const sched = parseCron('*/5 * * * *')
+    expect(sched.minute).toEqual([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55])
+  })
+
+  it('parses ranges "0 9-17 * * 1-5"', () => {
+    const sched = parseCron('0 9-17 * * 1-5')
+    expect(sched.hour).toEqual([9, 10, 11, 12, 13, 14, 15, 16, 17])
+    expect(sched.dayOfWeek).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('throws for invalid expressions', () => {
+    expect(() => parseCron('')).toThrow()
+    expect(() => parseCron('* * *')).toThrow()
+    expect(() => parseCron('60 * * * *')).toThrow()
+    expect(() => parseCron('* 25 * * *')).toThrow()
+    expect(() => parseCron('* * 32 * *')).toThrow()
+    expect(() => parseCron('* * * 13 *')).toThrow()
+    expect(() => parseCron('* * * * 7')).toThrow()
+    expect(() => parseCron('abc * * * *')).toThrow()
+  })
+})
+
+describe('isValid', () => {
+  it('returns true for valid expressions', () => {
+    expect(isValid('0 * * * *')).toBe(true)
+    expect(isValid('*/5 * * * *')).toBe(true)
+  })
+
+  it('returns false for invalid expressions', () => {
+    expect(isValid('invalid')).toBe(false)
+    expect(isValid('')).toBe(false)
+  })
+})
+
+describe('nextOccurrence', () => {
+  it('computes next hour for "0 * * * *"', () => {
+    const sched = parseCron('0 * * * *')
+    const ref = new Date('2026-05-15T10:30:00Z')
+    const next = nextOccurrence(sched, ref)
+    expect(next.getUTCHours()).toBe(11)
+    expect(next.getUTCMinutes()).toBe(0)
+  })
+
+  it('returns next hour when at exact minute 0', () => {
+    const sched = parseCron('0 * * * *')
+    const ref = new Date('2026-05-15T10:00:00Z')
+    const next = nextOccurrence(sched, ref)
+    expect(next.getUTCHours()).toBe(11)
+    expect(next.getUTCMinutes()).toBe(0)
+  })
+
+  it('computes next 5-minute mark', () => {
+    const sched = parseCron('*/5 * * * *')
+    const ref = new Date('2026-05-15T10:12:00Z')
+    const next = nextOccurrence(sched, ref)
+    expect(next.getUTCHours()).toBe(10)
+    expect(next.getUTCMinutes()).toBe(15)
+  })
+
+  it('computes next Monday for "30 2 * * 1"', () => {
+    const sched = parseCron('30 2 * * 1')
+    // Thursday May 15, 2025.
+    const ref = new Date('2025-05-15T10:00:00Z')
+    const next = nextOccurrence(sched, ref)
+    expect(next.getUTCDay()).toBe(1) // Monday
+    expect(next.getUTCHours()).toBe(2)
+    expect(next.getUTCMinutes()).toBe(30)
+  })
+})

--- a/sdks/ts/memory/src/ingest/schedule/cron.test.ts
+++ b/sdks/ts/memory/src/ingest/schedule/cron.test.ts
@@ -52,6 +52,13 @@ describe('isValid', () => {
   })
 })
 
+describe('parseField deduplication', () => {
+  it('deduplicates overlapping list+range "1,1-3"', () => {
+    const sched = parseCron('0 1,1-3 * * *')
+    expect(sched.hour).toEqual([1, 2, 3])
+  })
+})
+
 describe('nextOccurrence', () => {
   it('computes next hour for "0 * * * *"', () => {
     const sched = parseCron('0 * * * *')
@@ -85,5 +92,16 @@ describe('nextOccurrence', () => {
     expect(next.getUTCDay()).toBe(1) // Monday
     expect(next.getUTCHours()).toBe(2)
     expect(next.getUTCMinutes()).toBe(30)
+  })
+
+  it('uses DOM+DOW union semantics when both are non-wildcard', () => {
+    // "0 9 15 * 1" = at 9:00 on the 15th OR on Mondays
+    const sched = parseCron('0 9 15 * 1')
+    // Wednesday May 14, 2025 at 10:00 -> next should be May 15 (DOM match)
+    const ref = new Date('2025-05-14T10:00:00Z')
+    const next = nextOccurrence(sched, ref)
+    expect(next.getUTCDate()).toBe(15) // DOM match (Thursday, not Monday)
+    expect(next.getUTCHours()).toBe(9)
+    expect(next.getUTCMinutes()).toBe(0)
   })
 })

--- a/sdks/ts/memory/src/ingest/schedule/cron.ts
+++ b/sdks/ts/memory/src/ingest/schedule/cron.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Minimal cron expression parser supporting standard 5-field syntax:
+ * minute, hour, day-of-month, month, day-of-week.
+ *
+ * Supports: numbers, ranges (1-5), steps (* /5), lists (1,3,5), and *.
+ */
+
+export type CronSchedule = {
+  readonly minute: readonly number[]
+  readonly hour: readonly number[]
+  readonly dayOfMonth: readonly number[]
+  readonly month: readonly number[]
+  readonly dayOfWeek: readonly number[]
+}
+
+export const parseCron = (expression: string): CronSchedule => {
+  const fields = expression.trim().split(/\s+/)
+  if (fields.length !== 5) {
+    throw new Error(`cron: expected 5 fields, got ${fields.length} in "${expression}"`)
+  }
+
+  return {
+    minute: parseField(fields[0], 0, 59, 'minute'),
+    hour: parseField(fields[1], 0, 23, 'hour'),
+    dayOfMonth: parseField(fields[2], 1, 31, 'day-of-month'),
+    month: parseField(fields[3], 1, 12, 'month'),
+    dayOfWeek: parseField(fields[4], 0, 6, 'day-of-week'),
+  }
+}
+
+export const isValid = (expression: string): boolean => {
+  try {
+    parseCron(expression)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Compute the next occurrence of the schedule after the given reference
+ * time. Searches up to 4 years ahead.
+ */
+export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
+  // Start one minute after `after`, zeroing seconds.
+  const start = new Date(after)
+  start.setSeconds(0, 0)
+  start.setMinutes(start.getMinutes() + 1)
+
+  const minuteSet = toSet(sched.minute)
+  const hourSet = toSet(sched.hour)
+  const domSet = toSet(sched.dayOfMonth)
+  const monthSet = toSet(sched.month)
+  const dowSet = toSet(sched.dayOfWeek)
+
+  const limit = new Date(after)
+  limit.setFullYear(limit.getFullYear() + 4)
+
+  const t = new Date(start)
+  while (t < limit) {
+    const mon = t.getMonth() + 1 // JS months are 0-indexed
+    if (!monthSet.has(mon)) {
+      t.setMonth(t.getMonth() + 1)
+      t.setDate(1)
+      t.setHours(0, 0, 0, 0)
+      continue
+    }
+    if (!domSet.has(t.getDate()) || !dowSet.has(t.getDay())) {
+      t.setDate(t.getDate() + 1)
+      t.setHours(0, 0, 0, 0)
+      continue
+    }
+    if (!hourSet.has(t.getHours())) {
+      t.setHours(t.getHours() + 1)
+      t.setMinutes(0, 0, 0)
+      continue
+    }
+    if (!minuteSet.has(t.getMinutes())) {
+      t.setMinutes(t.getMinutes() + 1)
+      t.setSeconds(0, 0)
+      continue
+    }
+    return new Date(t)
+  }
+
+  return limit
+}
+
+const parseField = (field: string, min: number, max: number, name: string): number[] => {
+  const result: number[] = []
+
+  for (const part of field.split(',')) {
+    const trimmed = part.trim()
+    const stepParts = trimmed.split('/')
+    const rangePart = stepParts[0]
+    let step = 1
+
+    if (stepParts.length === 2) {
+      step = Number.parseInt(stepParts[1], 10)
+      if (Number.isNaN(step) || step < 1) {
+        throw new Error(`cron: ${name} field: invalid step "${stepParts[1]}"`)
+      }
+    }
+
+    let rangeStart: number
+    let rangeEnd: number
+
+    if (rangePart === '*') {
+      rangeStart = min
+      rangeEnd = max
+    } else if (rangePart.includes('-')) {
+      const [s, e] = rangePart.split('-')
+      rangeStart = Number.parseInt(s, 10)
+      rangeEnd = Number.parseInt(e, 10)
+      if (Number.isNaN(rangeStart) || Number.isNaN(rangeEnd)) {
+        throw new Error(`cron: ${name} field: invalid range "${rangePart}"`)
+      }
+    } else {
+      const val = Number.parseInt(rangePart, 10)
+      if (Number.isNaN(val)) {
+        throw new Error(`cron: ${name} field: invalid value "${rangePart}"`)
+      }
+      rangeStart = val
+      rangeEnd = val
+    }
+
+    if (rangeStart < min || rangeEnd > max || rangeStart > rangeEnd) {
+      throw new Error(`cron: ${name} field: value out of range [${min}-${max}]: ${rangeStart}-${rangeEnd}`)
+    }
+
+    for (let i = rangeStart; i <= rangeEnd; i += step) {
+      result.push(i)
+    }
+  }
+
+  if (result.length === 0) {
+    throw new Error(`cron: ${name} field: empty`)
+  }
+
+  return result
+}
+
+const toSet = (values: readonly number[]): Set<number> => new Set(values)

--- a/sdks/ts/memory/src/ingest/schedule/cron.ts
+++ b/sdks/ts/memory/src/ingest/schedule/cron.ts
@@ -42,6 +42,11 @@ export const isValid = (expression: string): boolean => {
 /**
  * Compute the next occurrence of the schedule after the given reference
  * time. Searches up to 4 years ahead.
+ *
+ * DOM+DOW union semantics: per POSIX cron, when both day-of-month and
+ * day-of-week are non-wildcard (not full-range), a date matches if
+ * EITHER condition is true. When one or both are wildcard, standard
+ * intersection (AND) applies.
  */
 export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
   // Start one minute after `after`, zeroing seconds.
@@ -55,6 +60,9 @@ export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
   const monthSet = toSet(sched.month)
   const dowSet = toSet(sched.dayOfWeek)
 
+  const domIsWild = sched.dayOfMonth.length === 31
+  const dowIsWild = sched.dayOfWeek.length === 7
+
   const limit = new Date(after)
   limit.setFullYear(limit.getFullYear() + 4)
 
@@ -67,7 +75,8 @@ export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
       t.setHours(0, 0, 0, 0)
       continue
     }
-    if (!domSet.has(t.getDate()) || !dowSet.has(t.getDay())) {
+    const dayMatch = matchDay(domSet, dowSet, domIsWild, dowIsWild, t.getDate(), t.getDay())
+    if (!dayMatch) {
       t.setDate(t.getDate() + 1)
       t.setHours(0, 0, 0, 0)
       continue
@@ -86,6 +95,25 @@ export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
   }
 
   return limit
+}
+
+/**
+ * POSIX cron union semantics for day matching. When both DOM and DOW
+ * are restricted (non-wildcard), match if EITHER is true. Otherwise
+ * use standard AND logic.
+ */
+const matchDay = (
+  domSet: Set<number>,
+  dowSet: Set<number>,
+  domIsWild: boolean,
+  dowIsWild: boolean,
+  day: number,
+  weekday: number,
+): boolean => {
+  if (!domIsWild && !dowIsWild) {
+    return domSet.has(day) || dowSet.has(weekday)
+  }
+  return domSet.has(day) && dowSet.has(weekday)
 }
 
 const parseField = (field: string, min: number, max: number, name: string): number[] => {
@@ -139,7 +167,7 @@ const parseField = (field: string, min: number, max: number, name: string): numb
     throw new Error(`cron: ${name} field: empty`)
   }
 
-  return result
+  return [...new Set(result)]
 }
 
 const toSet = (values: readonly number[]): Set<number> => new Set(values)

--- a/sdks/ts/memory/src/ingest/schedule/cron.ts
+++ b/sdks/ts/memory/src/ingest/schedule/cron.ts
@@ -13,6 +13,10 @@ export type CronSchedule = {
   readonly dayOfMonth: readonly number[]
   readonly month: readonly number[]
   readonly dayOfWeek: readonly number[]
+  /** True when the original day-of-month token was '*' (wildcard). */
+  readonly dayOfMonthIsWild: boolean
+  /** True when the original day-of-week token was '*' (wildcard). */
+  readonly dayOfWeekIsWild: boolean
 }
 
 export const parseCron = (expression: string): CronSchedule => {
@@ -27,7 +31,18 @@ export const parseCron = (expression: string): CronSchedule => {
     dayOfMonth: parseField(fields[2], 1, 31, 'day-of-month'),
     month: parseField(fields[3], 1, 12, 'month'),
     dayOfWeek: parseField(fields[4], 0, 6, 'day-of-week'),
+    dayOfMonthIsWild: isWildcard(fields[2]),
+    dayOfWeekIsWild: isWildcard(fields[4]),
   }
+}
+
+/**
+ * Returns true when the raw cron field token represents a wildcard.
+ * Matches bare '*' and step-only forms like '* /N' (without space).
+ */
+const isWildcard = (token: string): boolean => {
+  const trimmed = token.trim()
+  return trimmed === '*' || trimmed.startsWith('*/')
 }
 
 export const isValid = (expression: string): boolean => {
@@ -60,8 +75,8 @@ export const nextOccurrence = (sched: CronSchedule, after: Date): Date => {
   const monthSet = toSet(sched.month)
   const dowSet = toSet(sched.dayOfWeek)
 
-  const domIsWild = sched.dayOfMonth.length === 31
-  const dowIsWild = sched.dayOfWeek.length === 7
+  const domIsWild = sched.dayOfMonthIsWild
+  const dowIsWild = sched.dayOfWeekIsWild
 
   const limit = new Date(after)
   limit.setFullYear(limit.getFullYear() + 4)

--- a/sdks/ts/memory/src/ingest/schedule/index.ts
+++ b/sdks/ts/memory/src/ingest/schedule/index.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type {
+  ScheduledJob,
+  ScheduleTarget,
+  CreateScheduleInput,
+  UpdateSchedulePatch,
+  ScheduleStore,
+  SchedulerOptions,
+  Scheduler,
+} from './types.js'
+export type { CronSchedule } from './cron.js'
+export { parseCron, nextOccurrence, isValid } from './cron.js'
+export { createMemoryScheduleStore } from './memory-store.js'
+export { createScheduler } from './scheduler.js'

--- a/sdks/ts/memory/src/ingest/schedule/memory-store.ts
+++ b/sdks/ts/memory/src/ingest/schedule/memory-store.ts
@@ -14,17 +14,17 @@ import type {
   UpdateSchedulePatch,
 } from './types.js'
 
-let idCounter = 0
-const nextId = (): string => {
-  idCounter++
-  return `sched-${idCounter}`
-}
-
 /**
  * Create an in-memory ScheduleStore. Useful for testing. For production
  * use, swap in a SQLite or PostgreSQL adapter.
  */
 export const createMemoryScheduleStore = (): ScheduleStore => {
+  let idCounter = 0
+  const nextId = (): string => {
+    idCounter++
+    return `sched-${idCounter}`
+  }
+
   const jobs = new Map<string, ScheduledJob>()
 
   const create = async (input: CreateScheduleInput): Promise<ScheduledJob> => {
@@ -95,7 +95,7 @@ export const createMemoryScheduleStore = (): ScheduleStore => {
       ...existing,
       lastRunAt: ranAt,
       nextRunAt,
-      updatedAt: ranAt,
+      updatedAt: new Date(),
     })
   }
 

--- a/sdks/ts/memory/src/ingest/schedule/memory-store.ts
+++ b/sdks/ts/memory/src/ingest/schedule/memory-store.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * In-memory ScheduleStore for testing and local development. Not suitable
+ * for production use — jobs do not persist across restarts.
+ */
+
+import { isValid, nextOccurrence, parseCron } from './cron.js'
+import type {
+  CreateScheduleInput,
+  ScheduleStore,
+  ScheduleTarget,
+  ScheduledJob,
+  UpdateSchedulePatch,
+} from './types.js'
+
+let idCounter = 0
+const nextId = (): string => {
+  idCounter++
+  return `sched-${idCounter}`
+}
+
+/**
+ * Create an in-memory ScheduleStore. Useful for testing. For production
+ * use, swap in a SQLite or PostgreSQL adapter.
+ */
+export const createMemoryScheduleStore = (): ScheduleStore => {
+  const jobs = new Map<string, ScheduledJob>()
+
+  const create = async (input: CreateScheduleInput): Promise<ScheduledJob> => {
+    if (!isValid(input.cronExpression)) {
+      throw new Error(`schedule: invalid cron expression: "${input.cronExpression}"`)
+    }
+
+    const sched = parseCron(input.cronExpression)
+    const now = new Date()
+    const id = nextId()
+    const job: ScheduledJob = {
+      id,
+      brainId: input.brainId,
+      name: input.name,
+      cronExpression: input.cronExpression,
+      target: input.target,
+      enabled: true,
+      nextRunAt: nextOccurrence(sched, now),
+      createdAt: now,
+      updatedAt: now,
+      metadata: input.metadata,
+    }
+    jobs.set(id, job)
+    return job
+  }
+
+  const get = async (id: string): Promise<ScheduledJob | undefined> => jobs.get(id)
+
+  const list = async (brainId: string): Promise<readonly ScheduledJob[]> =>
+    [...jobs.values()].filter((j) => j.brainId === brainId)
+
+  const update = async (id: string, patch: UpdateSchedulePatch): Promise<ScheduledJob> => {
+    const existing = jobs.get(id)
+    if (!existing) throw new Error(`schedule: job not found: ${id}`)
+
+    const cronExpr = patch.cronExpression ?? existing.cronExpression
+    if (patch.cronExpression !== undefined && !isValid(patch.cronExpression)) {
+      throw new Error(`schedule: invalid cron expression: "${patch.cronExpression}"`)
+    }
+
+    const updated: ScheduledJob = {
+      ...existing,
+      name: patch.name ?? existing.name,
+      cronExpression: cronExpr,
+      target: (patch.target ?? existing.target) as ScheduleTarget,
+      enabled: patch.enabled ?? existing.enabled,
+      metadata: patch.metadata ?? existing.metadata,
+      nextRunAt: patch.cronExpression
+        ? nextOccurrence(parseCron(cronExpr), new Date())
+        : existing.nextRunAt,
+      updatedAt: new Date(),
+    }
+    jobs.set(id, updated)
+    return updated
+  }
+
+  const del = async (id: string): Promise<void> => {
+    jobs.delete(id)
+  }
+
+  const findDue = async (now: Date): Promise<readonly ScheduledJob[]> =>
+    [...jobs.values()].filter((j) => j.enabled && j.nextRunAt <= now)
+
+  const markRun = async (id: string, ranAt: Date, nextRunAt: Date): Promise<void> => {
+    const existing = jobs.get(id)
+    if (!existing) return
+    jobs.set(id, {
+      ...existing,
+      lastRunAt: ranAt,
+      nextRunAt,
+      updatedAt: ranAt,
+    })
+  }
+
+  return { create, get, list, update, delete: del, findDue, markRun }
+}

--- a/sdks/ts/memory/src/ingest/schedule/scheduler.test.ts
+++ b/sdks/ts/memory/src/ingest/schedule/scheduler.test.ts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest'
+import { createMemoryScheduleStore } from './memory-store.js'
+import { createScheduler } from './scheduler.js'
+import type { ScheduledJob } from './types.js'
+
+describe('scheduler', () => {
+  it('due job fires trigger event', async () => {
+    const store = createMemoryScheduleStore()
+    const dispatched: ScheduledJob[] = []
+
+    const job = await store.create({
+      brainId: 'brain-1',
+      name: 'test job',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/data/test.md' },
+    })
+
+    // Force nextRunAt to the past.
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job.id, new Date(Date.now() - 7200_000), past)
+
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      dispatch: (j) => { dispatched.push(j) },
+    })
+
+    const fired = await scheduler.runDueJobs()
+    expect(fired).toBe(1)
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0].name).toBe('test job')
+  })
+
+  it('disabled job skipped even when due', async () => {
+    const store = createMemoryScheduleStore()
+    const dispatched: ScheduledJob[] = []
+
+    const job = await store.create({
+      brainId: 'brain-1',
+      name: 'disabled job',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/data/test.md' },
+    })
+
+    await store.update(job.id, { enabled: false })
+
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      dispatch: (j) => { dispatched.push(j) },
+    })
+
+    const fired = await scheduler.runDueJobs()
+    expect(fired).toBe(0)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('job rescheduled after firing (nextRunAt updated)', async () => {
+    const store = createMemoryScheduleStore()
+
+    const job = await store.create({
+      brainId: 'brain-1',
+      name: 'reschedule test',
+      cronExpression: '0 * * * *',
+      target: { kind: 'file', path: '/data/test.md' },
+    })
+
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job.id, new Date(Date.now() - 7200_000), past)
+
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      dispatch: () => {},
+    })
+
+    await scheduler.runDueJobs()
+
+    const updated = await store.get(job.id)
+    expect(updated).toBeDefined()
+    expect(updated!.nextRunAt.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('no due jobs -> no events published', async () => {
+    const store = createMemoryScheduleStore()
+    const dispatched: ScheduledJob[] = []
+
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      dispatch: (j) => { dispatched.push(j) },
+    })
+
+    const fired = await scheduler.runDueJobs()
+    expect(fired).toBe(0)
+    expect(dispatched).toHaveLength(0)
+  })
+
+  it('job failure does not prevent other due jobs from firing', async () => {
+    const store = createMemoryScheduleStore()
+
+    const job1 = await store.create({
+      brainId: 'brain-1',
+      name: 'failing job',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/data/fail.md' },
+    })
+    const job2 = await store.create({
+      brainId: 'brain-1',
+      name: 'ok job',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/data/ok.md' },
+    })
+
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job1.id, new Date(Date.now() - 7200_000), past)
+    await store.markRun(job2.id, new Date(Date.now() - 7200_000), past)
+
+    let succeeded = 0
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      dispatch: (j) => {
+        if (j.name === 'failing job') throw new Error('dispatch error')
+        succeeded++
+      },
+    })
+
+    const fired = await scheduler.runDueJobs()
+    expect(fired).toBe(1)
+    expect(succeeded).toBe(1)
+  })
+
+  it('per-brain scheduling isolation', async () => {
+    const store = createMemoryScheduleStore()
+
+    const job1 = await store.create({
+      brainId: 'brain-a',
+      name: 'job-a',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/a.md' },
+    })
+    const job2 = await store.create({
+      brainId: 'brain-b',
+      name: 'job-b',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/b.md' },
+    })
+
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job1.id, new Date(Date.now() - 7200_000), past)
+    await store.markRun(job2.id, new Date(Date.now() - 7200_000), past)
+
+    const brains: Record<string, number> = {}
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      dispatch: (j) => {
+        brains[j.brainId] = (brains[j.brainId] ?? 0) + 1
+      },
+    })
+
+    const fired = await scheduler.runDueJobs()
+    expect(fired).toBe(2)
+    expect(brains['brain-a']).toBe(1)
+    expect(brains['brain-b']).toBe(1)
+  })
+})
+
+describe('memory-store CRUD', () => {
+  it('create, get, list, update, delete', async () => {
+    const store = createMemoryScheduleStore()
+
+    const job = await store.create({
+      brainId: 'brain-1',
+      name: 'daily',
+      cronExpression: '0 2 * * *',
+      target: { kind: 'url', url: 'https://example.com' },
+    })
+
+    expect(job.id).toBeTruthy()
+    expect(job.enabled).toBe(true)
+
+    const got = await store.get(job.id)
+    expect(got).toBeDefined()
+    expect(got!.name).toBe('daily')
+
+    const list = await store.list('brain-1')
+    expect(list).toHaveLength(1)
+
+    const updated = await store.update(job.id, { name: 'weekly' })
+    expect(updated.name).toBe('weekly')
+
+    await store.delete(job.id)
+    const afterDelete = await store.list('brain-1')
+    expect(afterDelete).toHaveLength(0)
+  })
+
+  it('findDue returns only enabled due jobs', async () => {
+    const store = createMemoryScheduleStore()
+
+    const job1 = await store.create({
+      brainId: 'brain-1',
+      name: 'due',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/a.md' },
+    })
+
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job1.id, new Date(Date.now() - 7200_000), past)
+
+    const job2 = await store.create({
+      brainId: 'brain-1',
+      name: 'disabled',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/b.md' },
+    })
+    await store.update(job2.id, { enabled: false })
+
+    const due = await store.findDue(new Date())
+    expect(due).toHaveLength(1)
+    expect(due[0].id).toBe(job1.id)
+  })
+
+  it('invalid cron expression rejected on create', async () => {
+    const store = createMemoryScheduleStore()
+    await expect(
+      store.create({
+        brainId: 'brain-1',
+        name: 'bad cron',
+        cronExpression: 'invalid',
+        target: { kind: 'file', path: '/a.md' },
+      }),
+    ).rejects.toThrow('invalid cron expression')
+  })
+})

--- a/sdks/ts/memory/src/ingest/schedule/scheduler.test.ts
+++ b/sdks/ts/memory/src/ingest/schedule/scheduler.test.ts
@@ -129,6 +129,34 @@ describe('scheduler', () => {
     expect(succeeded).toBe(1)
   })
 
+  it('start() polls and stop() halts gracefully', async () => {
+    const store = createMemoryScheduleStore()
+    let dispatched = 0
+
+    const job = await store.create({
+      brainId: 'brain-1',
+      name: 'lifecycle job',
+      cronExpression: '* * * * *',
+      target: { kind: 'file', path: '/data/lifecycle.md' },
+    })
+
+    const past = new Date(Date.now() - 3600_000)
+    await store.markRun(job.id, new Date(Date.now() - 7200_000), past)
+
+    const scheduler = createScheduler({
+      scheduleStore: store,
+      pollIntervalMs: 50,
+      dispatch: () => { dispatched++ },
+    })
+
+    scheduler.start()
+    // Give the immediate poll time to fire.
+    await new Promise((r) => setTimeout(r, 100))
+    await scheduler.stop()
+
+    expect(dispatched).toBeGreaterThanOrEqual(1)
+  })
+
   it('per-brain scheduling isolation', async () => {
     const store = createMemoryScheduleStore()
 

--- a/sdks/ts/memory/src/ingest/schedule/scheduler.ts
+++ b/sdks/ts/memory/src/ingest/schedule/scheduler.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * In-process scheduler that polls the ScheduleStore for due jobs and
+ * fires them. No external cron daemon required.
+ */
+
+import { nextOccurrence, parseCron } from './cron.js'
+import type { Scheduler, SchedulerOptions } from './types.js'
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000
+
+export const createScheduler = (opts: SchedulerOptions): Scheduler => {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const logger = opts.logger
+  const now = opts.now ?? (() => new Date())
+
+  let timer: ReturnType<typeof setInterval> | undefined
+  let stopped = false
+  let runningPromise: Promise<void> | undefined
+
+  const runDueJobs = async (): Promise<number> => {
+    const currentTime = now()
+    const dueJobs = await opts.scheduleStore.findDue(currentTime)
+
+    let fired = 0
+    for (const job of dueJobs) {
+      try {
+        await opts.dispatch(job)
+      } catch (err) {
+        logger?.error('schedule: dispatch failed', {
+          jobId: job.id,
+          error: String(err),
+        })
+        continue
+      }
+
+      try {
+        const sched = parseCron(job.cronExpression)
+        const nextRun = nextOccurrence(sched, currentTime)
+        await opts.scheduleStore.markRun(job.id, currentTime, nextRun)
+      } catch (err) {
+        logger?.error('schedule: markRun failed', {
+          jobId: job.id,
+          error: String(err),
+        })
+      }
+
+      fired++
+    }
+
+    return fired
+  }
+
+  const poll = async (): Promise<void> => {
+    if (stopped) return
+    try {
+      await runDueJobs()
+    } catch (err) {
+      logger?.error('schedule: poll error', { error: String(err) })
+    }
+  }
+
+  const start = (): void => {
+    if (stopped) return
+    // Run immediately on start.
+    runningPromise = poll()
+    timer = setInterval(() => {
+      runningPromise = poll()
+    }, pollIntervalMs)
+  }
+
+  const stop = async (): Promise<void> => {
+    stopped = true
+    if (timer !== undefined) {
+      clearInterval(timer)
+      timer = undefined
+    }
+    // Wait for any running poll to complete.
+    if (runningPromise) {
+      await runningPromise
+    }
+  }
+
+  return { start, stop, runDueJobs }
+}

--- a/sdks/ts/memory/src/ingest/schedule/scheduler.ts
+++ b/sdks/ts/memory/src/ingest/schedule/scheduler.ts
@@ -18,6 +18,7 @@ export const createScheduler = (opts: SchedulerOptions): Scheduler => {
   let timer: ReturnType<typeof setInterval> | undefined
   let stopped = false
   let runningPromise: Promise<void> | undefined
+  let pollInFlight = false
 
   const runDueJobs = async (): Promise<number> => {
     const currentTime = now()
@@ -61,12 +62,22 @@ export const createScheduler = (opts: SchedulerOptions): Scheduler => {
     }
   }
 
+  const guardedPoll = async (): Promise<void> => {
+    if (pollInFlight) return
+    pollInFlight = true
+    try {
+      await poll()
+    } finally {
+      pollInFlight = false
+    }
+  }
+
   const start = (): void => {
     if (stopped) return
     // Run immediately on start.
-    runningPromise = poll()
+    runningPromise = guardedPoll()
     timer = setInterval(() => {
-      runningPromise = poll()
+      runningPromise = guardedPoll()
     }, pollIntervalMs)
   }
 

--- a/sdks/ts/memory/src/ingest/schedule/types.ts
+++ b/sdks/ts/memory/src/ingest/schedule/types.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Schedule types for the cron-based ingestion scheduler. Jobs persist
+ * across restarts via a ScheduleStore (SQLite or PostgreSQL adapter).
+ */
+
+import type { Logger } from '../../llm/types.js'
+
+export type ScheduledJob = {
+  readonly id: string
+  readonly brainId: string
+  readonly name: string
+  readonly cronExpression: string
+  readonly target: ScheduleTarget
+  readonly enabled: boolean
+  readonly lastRunAt?: Date
+  readonly nextRunAt: Date
+  readonly createdAt: Date
+  readonly updatedAt: Date
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+export type ScheduleTarget =
+  | { readonly kind: 'url'; readonly url: string }
+  | { readonly kind: 'file'; readonly path: string }
+  | { readonly kind: 'directory'; readonly path: string; readonly glob?: string }
+
+export type CreateScheduleInput = {
+  readonly brainId: string
+  readonly name: string
+  readonly cronExpression: string
+  readonly target: ScheduleTarget
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+export type UpdateSchedulePatch = {
+  readonly name?: string
+  readonly cronExpression?: string
+  readonly target?: ScheduleTarget
+  readonly enabled?: boolean
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+export type ScheduleStore = {
+  create(input: CreateScheduleInput): Promise<ScheduledJob>
+  get(id: string): Promise<ScheduledJob | undefined>
+  list(brainId: string): Promise<readonly ScheduledJob[]>
+  update(id: string, patch: UpdateSchedulePatch): Promise<ScheduledJob>
+  delete(id: string): Promise<void>
+  findDue(now: Date): Promise<readonly ScheduledJob[]>
+  markRun(id: string, ranAt: Date, nextRunAt: Date): Promise<void>
+}
+
+export type SchedulerOptions = {
+  readonly scheduleStore: ScheduleStore
+  readonly dispatch: (job: ScheduledJob) => Promise<void> | void
+  readonly pollIntervalMs?: number
+  readonly logger?: Logger
+  /** Injectable clock for testing. Defaults to () => new Date(). */
+  readonly now?: () => Date
+}
+
+export type Scheduler = {
+  start(): void
+  stop(): Promise<void>
+  /** Exposed for testing. Returns count of jobs fired. */
+  runDueJobs(): Promise<number>
+}


### PR DESCRIPTION
## Summary
- Custom 5-field cron parser (minute, hour, day-of-month, month, day-of-week) supporting numbers, ranges, steps, lists, and wildcards
- Go: SQLite-backed schedule table with full CRUD, FindDue, and MarkRun
- TS: In-memory ScheduleStore for testing (SQLite adapter follows same interface)
- In-process scheduler polls for due jobs, fires dispatch, reschedules with computed nextRunAt
- Per-brain scheduling isolation, disabled job skipping, individual job failure isolation
- Graceful shutdown waits for current poll to complete

## Test plan
- [x] Go: 11 cron parser tests (every-hour, Monday morning, every-5-min, ranges, invalid expressions, nextOccurrence)
- [x] Go: 8 scheduler/store tests (CRUD, findDue, runDueJobs, disabled skip, failure isolation, no due jobs, per-brain isolation, invalid cron rejection)
- [x] TS: 10 cron parser tests (parse, isValid, nextOccurrence for various patterns)
- [x] TS: 10 scheduler/store tests (due job fires, disabled skip, reschedule, no due jobs, failure isolation, per-brain isolation, CRUD, findDue, invalid cron)