### PR TITLE
feat(ontology): document classification and entity tagging (P6-8) LLE-9796

### DIFF
--- a/go/ontology/classify.go
+++ b/go/ontology/classify.go
@@ -203,8 +203,9 @@ func buildClassificationPrompt(content string, fileName string) string {
 		b.WriteString(fileName)
 		b.WriteString("\n\n")
 	}
-	b.WriteString("Document content:\n")
+	b.WriteString("Document content:\n<ingested-document>\n")
 	b.WriteString(content)
+	b.WriteString("\n</ingested-document>")
 	return b.String()
 }
 

--- a/go/ontology/classify.go
+++ b/go/ontology/classify.go
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+// CategoryWinnerThreshold is the minimum proportion of entity type
+// matches required for a business category to win classification.
+// Matching the intelligence service constant.
+const CategoryWinnerThreshold = 0.4
+
+// DocumentClass categorises documents by structure.
+type DocumentClass string
+
+const (
+	DocumentClassStructured   DocumentClass = "structured"
+	DocumentClassTabular      DocumentClass = "tabular"
+	DocumentClassUnstructured DocumentClass = "unstructured"
+)
+
+// ClassificationResult describes a classified document.
+type ClassificationResult struct {
+	Class        DocumentClass `json:"class"`
+	Category     string        `json:"category"`
+	Confidence   float64       `json:"confidence"`
+	IsStructured bool          `json:"isStructured"`
+}
+
+// Classifier classifies documents and tags chunks with type metadata.
+// When a Provider is supplied, unstructured documents use LLM-powered
+// classification. Without a Provider, heuristic-only mode is used.
+type Classifier struct {
+	provider llm.Provider
+}
+
+// NewClassifier creates a classifier. Provider may be nil for
+// heuristic-only mode.
+func NewClassifier(provider llm.Provider) *Classifier {
+	return &Classifier{provider: provider}
+}
+
+// Classify determines the document class and business category.
+// Classification cascade: JSON detection -> tabular detection -> LLM.
+func (c *Classifier) Classify(ctx context.Context, content string, fileName string) (ClassificationResult, error) {
+	if IsJsonDocument(content) {
+		return ClassificationResult{
+			Class:        DocumentClassStructured,
+			Category:     inferCategoryFromJSON(content),
+			Confidence:   0.95,
+			IsStructured: true,
+		}, nil
+	}
+
+	if IsTabularDocument(content) {
+		return ClassificationResult{
+			Class:        DocumentClassTabular,
+			Category:     inferCategoryFromFileName(fileName),
+			Confidence:   0.85,
+			IsStructured: true,
+		}, nil
+	}
+
+	if c.provider != nil {
+		return c.classifyWithLLM(ctx, content, fileName)
+	}
+
+	return ClassificationResult{
+		Class:        DocumentClassUnstructured,
+		Category:     "general",
+		Confidence:   0.5,
+		IsStructured: false,
+	}, nil
+}
+
+// IsJsonDocument returns true if content parses as JSON with
+// business-relevant structure (object or array, not a bare primitive).
+func IsJsonDocument(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if len(trimmed) == 0 {
+		return false
+	}
+
+	first := trimmed[0]
+	if first != '{' && first != '[' {
+		return false
+	}
+
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return false
+	}
+
+	switch parsed.(type) {
+	case map[string]interface{}, []interface{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsTabularDocument returns true if content appears to be CSV/TSV data.
+// Uses a heuristic: checks the first 5 lines for consistent comma or
+// pipe delimiters (>= 2 delimiters per line on >= 3 of the first 5 lines).
+func IsTabularDocument(content string) bool {
+	lines := strings.SplitN(content, "\n", 6)
+	if len(lines) < 3 {
+		return false
+	}
+
+	checkLines := lines
+	if len(checkLines) > 5 {
+		checkLines = checkLines[:5]
+	}
+
+	commaCount := 0
+	pipeCount := 0
+
+	for _, line := range checkLines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		commas := strings.Count(trimmed, ",")
+		pipes := strings.Count(trimmed, "|")
+
+		if commas >= 2 {
+			commaCount++
+		}
+		if pipes >= 2 {
+			pipeCount++
+		}
+	}
+
+	return commaCount >= 3 || pipeCount >= 3
+}
+
+// classifyWithLLM uses the LLM provider to classify unstructured
+// content.
+func (c *Classifier) classifyWithLLM(ctx context.Context, content string, fileName string) (ClassificationResult, error) {
+	preview := content
+	if len(preview) > 2000 {
+		preview = preview[:2000]
+	}
+
+	prompt := buildClassificationPrompt(preview, fileName)
+
+	resp, err := c.provider.Complete(ctx, llm.CompleteRequest{
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: classificationSystemPrompt},
+			{Role: llm.RoleUser, Content: prompt},
+		},
+		Temperature:        0.1,
+		MaxTokens:          256,
+		ResponseFormatJSON: true,
+	})
+	if err != nil {
+		return ClassificationResult{
+			Class:        DocumentClassUnstructured,
+			Category:     "general",
+			Confidence:   0.3,
+			IsStructured: false,
+		}, nil
+	}
+
+	return parseClassificationResponse(resp.Text)
+}
+
+const classificationSystemPrompt = `You are a document classifier. Analyse the provided document content and classify it into one of these categories:
+- entity: Documents about customers, products, suppliers, or other business entities
+- rule: Documents describing business rules, constraints, policies, or validation logic
+- exception: Documents about workarounds, overrides, or special cases
+- decision: Documents about decision trees, escalation paths, or branch logic
+- process: Documents about workflows, procedures, approval chains, or integrations
+- reference: General reference documentation that does not fit the above
+
+Respond with a JSON object containing:
+- "category": one of "entity", "rule", "exception", "decision", "process", "reference"
+- "confidence": a number between 0 and 1 indicating your confidence
+- "reasoning": a brief explanation of why you chose this category`
+
+func buildClassificationPrompt(content string, fileName string) string {
+	var b strings.Builder
+	if fileName != "" {
+		b.WriteString("File: ")
+		b.WriteString(fileName)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("Document content:\n")
+	b.WriteString(content)
+	return b.String()
+}
+
+// llmClassification is the JSON shape returned by the LLM.
+type llmClassification struct {
+	Category   string  `json:"category"`
+	Confidence float64 `json:"confidence"`
+}
+
+func parseClassificationResponse(text string) (ClassificationResult, error) {
+	trimmed := strings.TrimSpace(text)
+
+	// Find the first '{' and last '}'
+	start := strings.IndexByte(trimmed, '{')
+	end := strings.LastIndexByte(trimmed, '}')
+	if start < 0 || end <= start {
+		return ClassificationResult{
+			Class:        DocumentClassUnstructured,
+			Category:     "general",
+			Confidence:   0.3,
+			IsStructured: false,
+		}, nil
+	}
+
+	var result llmClassification
+	if err := json.Unmarshal([]byte(trimmed[start:end+1]), &result); err != nil {
+		return ClassificationResult{
+			Class:        DocumentClassUnstructured,
+			Category:     "general",
+			Confidence:   0.3,
+			IsStructured: false,
+		}, nil
+	}
+
+	category := mapLLMCategory(result.Category)
+	confidence := result.Confidence
+	if confidence <= 0 || confidence > 1 {
+		confidence = 0.7
+	}
+
+	return ClassificationResult{
+		Class:        DocumentClassUnstructured,
+		Category:     category,
+		Confidence:   confidence,
+		IsStructured: false,
+	}, nil
+}
+
+// mapLLMCategory maps the LLM's category response to a business
+// category string. Falls back to "general" for unrecognised values.
+func mapLLMCategory(raw string) string {
+	categoryMap := map[string]string{
+		"entity":    "general",
+		"rule":      "general",
+		"exception": "general",
+		"decision":  "general",
+		"process":   "general",
+		"reference": "general",
+		"customer":  "customer",
+		"order":     "order",
+		"product":   "product",
+		"address":   "address",
+		"document":  "document",
+	}
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	if mapped, ok := categoryMap[lower]; ok {
+		return mapped
+	}
+	if IsValidBusinessCategory(lower) {
+		return lower
+	}
+	return "general"
+}
+
+// inferCategoryFromJSON attempts to determine a business category by
+// inspecting JSON key names.
+func inferCategoryFromJSON(content string) string {
+	lower := strings.ToLower(content)
+	categoryKeywords := map[string][]string{
+		"customer":      {"customer", "client", "account"},
+		"order":         {"order", "purchase", "transaction"},
+		"product":       {"product", "item", "sku", "catalog"},
+		"address":       {"address", "location", "postal", "zip"},
+		"document":      {"document", "file", "attachment"},
+		"authorization": {"authorization", "permission", "role", "access"},
+		"integration":   {"integration", "api", "endpoint", "webhook"},
+	}
+
+	var bestCategory string
+	bestCount := 0
+
+	for category, keywords := range categoryKeywords {
+		count := 0
+		for _, kw := range keywords {
+			count += strings.Count(lower, kw)
+		}
+		if count > bestCount {
+			bestCount = count
+			bestCategory = category
+		}
+	}
+
+	if bestCategory != "" && bestCount >= 2 {
+		return bestCategory
+	}
+	return "general"
+}
+
+// inferCategoryFromFileName attempts to determine a business category
+// from the file name.
+func inferCategoryFromFileName(fileName string) string {
+	lower := strings.ToLower(fileName)
+	keywords := map[string]string{
+		"customer": "customer",
+		"order":    "order",
+		"product":  "product",
+		"address":  "address",
+		"invoice":  "order",
+		"shipping": "order",
+		"price":    "product",
+		"auth":     "authorization",
+		"api":      "integration",
+	}
+	for kw, category := range keywords {
+		if strings.Contains(lower, kw) {
+			return category
+		}
+	}
+	return "general"
+}
+
+// buildCategoryCounts computes weighted category votes from ontology
+// entity types found in content.
+func buildCategoryCounts(content string, ontology *ResolvedOntology) map[string]int {
+	counts := make(map[string]int)
+	lower := strings.ToLower(content)
+
+	for _, nt := range ontology.NodeTypes {
+		parts := strings.SplitN(nt.Type, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := parts[1]
+		if strings.Contains(lower, strings.ReplaceAll(name, "_", " ")) ||
+			strings.Contains(lower, name) {
+			for _, cat := range ontology.BusinessCategories {
+				if strings.Contains(strings.ToLower(nt.Description), cat) {
+					counts[cat]++
+				}
+			}
+		}
+	}
+
+	return counts
+}
+
+// categoryWinner returns the business category with the highest vote
+// count if it exceeds CategoryWinnerThreshold of total votes.
+func categoryWinner(counts map[string]int) string {
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+	if total == 0 {
+		return "general"
+	}
+
+	var bestCategory string
+	bestCount := 0
+	for cat, count := range counts {
+		if count > bestCount {
+			bestCount = count
+			bestCategory = cat
+		}
+	}
+
+	if float64(bestCount)/float64(total) >= CategoryWinnerThreshold {
+		return bestCategory
+	}
+	return "general"
+}
+
+// DetermineCategory uses ontology-aware weighted voting to determine
+// the best business category for content. Falls back to "general" if
+// no category exceeds the winner threshold.
+func DetermineCategory(content string, ontology *ResolvedOntology) string {
+	if ontology == nil {
+		return "general"
+	}
+	counts := buildCategoryCounts(content, ontology)
+	return categoryWinner(counts)
+}
+
+// classificationPromptForAppendixA4 is the system prompt from the
+// plan's Appendix A4 for document-level classification.
+const classificationPromptForAppendixA4 = classificationSystemPrompt
+
+// classificationPromptForAppendixA5 returns the chunk-level entity
+// tagging prompt. Used by TagChunk when LLM is available.
+func classificationPromptForAppendixA5() string {
+	return fmt.Sprintf(`You are a chunk-level entity tagger. Given a text chunk, identify which ontology entity types are mentioned or implied.
+
+Return a JSON object with:
+- "entityTypes": array of dotted type identifiers (e.g., "entity.customer", "rule.validation")
+- "businessCategory": the dominant business category
+- "confidence": your confidence in the tagging (0-1)
+
+Only use types from the standard ontology prefixes: entity., rule., exception., decision., process.`)
+}

--- a/go/ontology/classify.go
+++ b/go/ontology/classify.go
@@ -4,7 +4,6 @@ package ontology
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/jeffs-brain/memory/go/llm"
@@ -79,7 +78,9 @@ func (c *Classifier) Classify(ctx context.Context, content string, fileName stri
 }
 
 // IsJsonDocument returns true if content parses as JSON with
-// business-relevant structure (object or array, not a bare primitive).
+// business-relevant structure: a non-empty object, or an array
+// containing at least one object or nested array. Bare primitives,
+// empty structures, and primitive-only arrays are excluded.
 func IsJsonDocument(content string) bool {
 	trimmed := strings.TrimSpace(content)
 	if len(trimmed) == 0 {
@@ -96,9 +97,20 @@ func IsJsonDocument(content string) bool {
 		return false
 	}
 
-	switch parsed.(type) {
-	case map[string]interface{}, []interface{}:
-		return true
+	switch v := parsed.(type) {
+	case map[string]interface{}:
+		return len(v) > 0
+	case []interface{}:
+		if len(v) == 0 {
+			return false
+		}
+		for _, item := range v {
+			switch item.(type) {
+			case map[string]interface{}, []interface{}:
+				return true
+			}
+		}
+		return false
 	default:
 		return false
 	}
@@ -202,13 +214,59 @@ type llmClassification struct {
 	Confidence float64 `json:"confidence"`
 }
 
+// extractJSONObject finds the first balanced JSON object in text using
+// depth-tracking. Returns the extracted JSON string, or a non-empty
+// error message on failure.
+func extractJSONObject(text string) (string, string) {
+	start := strings.IndexByte(text, '{')
+	if start < 0 {
+		return "", "no JSON object found"
+	}
+
+	depth := 0
+	inString := false
+	escaping := false
+
+	for i := start; i < len(text); i++ {
+		ch := text[i]
+		if escaping {
+			escaping = false
+			continue
+		}
+		if inString {
+			if ch == '\\' {
+				escaping = true
+			} else if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				candidate := text[start : i+1]
+				var check json.RawMessage
+				if json.Unmarshal([]byte(candidate), &check) == nil {
+					return candidate, ""
+				}
+				return "", "extracted JSON is not valid"
+			}
+		}
+	}
+
+	return "", "unclosed JSON object"
+}
+
 func parseClassificationResponse(text string) (ClassificationResult, error) {
 	trimmed := strings.TrimSpace(text)
 
-	// Find the first '{' and last '}'
-	start := strings.IndexByte(trimmed, '{')
-	end := strings.LastIndexByte(trimmed, '}')
-	if start < 0 || end <= start {
+	jsonStr, extractErr := extractJSONObject(trimmed)
+	if extractErr != "" {
 		return ClassificationResult{
 			Class:        DocumentClassUnstructured,
 			Category:     "general",
@@ -218,7 +276,7 @@ func parseClassificationResponse(text string) (ClassificationResult, error) {
 	}
 
 	var result llmClassification
-	if err := json.Unmarshal([]byte(trimmed[start:end+1]), &result); err != nil {
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
 		return ClassificationResult{
 			Class:        DocumentClassUnstructured,
 			Category:     "general",
@@ -242,15 +300,20 @@ func parseClassificationResponse(text string) (ClassificationResult, error) {
 }
 
 // mapLLMCategory maps the LLM's category response to a business
-// category string. Falls back to "general" for unrecognised values.
+// category string. The system prompt instructs the LLM to return one
+// of: entity, rule, exception, decision, process, reference. These
+// are preserved as-is since they are the ontology type prefixes the
+// pipeline already understands. Additionally, common business
+// categories like "customer" and "order" pass through directly.
+// Falls back to "general" for unrecognised values.
 func mapLLMCategory(raw string) string {
 	categoryMap := map[string]string{
-		"entity":    "general",
-		"rule":      "general",
-		"exception": "general",
-		"decision":  "general",
-		"process":   "general",
-		"reference": "general",
+		"entity":    "entity",
+		"rule":      "rule",
+		"exception": "exception",
+		"decision":  "decision",
+		"process":   "process",
+		"reference": "reference",
 		"customer":  "customer",
 		"order":     "order",
 		"product":   "product",
@@ -386,19 +449,3 @@ func DetermineCategory(content string, ontology *ResolvedOntology) string {
 	return categoryWinner(counts)
 }
 
-// classificationPromptForAppendixA4 is the system prompt from the
-// plan's Appendix A4 for document-level classification.
-const classificationPromptForAppendixA4 = classificationSystemPrompt
-
-// classificationPromptForAppendixA5 returns the chunk-level entity
-// tagging prompt. Used by TagChunk when LLM is available.
-func classificationPromptForAppendixA5() string {
-	return fmt.Sprintf(`You are a chunk-level entity tagger. Given a text chunk, identify which ontology entity types are mentioned or implied.
-
-Return a JSON object with:
-- "entityTypes": array of dotted type identifiers (e.g., "entity.customer", "rule.validation")
-- "businessCategory": the dominant business category
-- "confidence": your confidence in the tagging (0-1)
-
-Only use types from the standard ontology prefixes: entity., rule., exception., decision., process.`)
-}

--- a/go/ontology/classify_test.go
+++ b/go/ontology/classify_test.go
@@ -63,6 +63,27 @@ func TestIsJsonDocument_TrivialJson(t *testing.T) {
 	}
 }
 
+func TestIsJsonDocument_PrimitiveArray(t *testing.T) {
+	t.Parallel()
+	// Primitive-only arrays are not business-relevant
+	if ontology.IsJsonDocument(`[1, 2, 3]`) {
+		t.Fatal("expected false for primitive array")
+	}
+	if ontology.IsJsonDocument(`["a", "b", "c"]`) {
+		t.Fatal("expected false for string array")
+	}
+}
+
+func TestIsJsonDocument_EmptyStructures(t *testing.T) {
+	t.Parallel()
+	if ontology.IsJsonDocument(`{}`) {
+		t.Fatal("expected false for empty object")
+	}
+	if ontology.IsJsonDocument(`[]`) {
+		t.Fatal("expected false for empty array")
+	}
+}
+
 func TestIsTabularDocument_Csv(t *testing.T) {
 	t.Parallel()
 	content := "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n"
@@ -195,9 +216,10 @@ func TestDetermineCategory_WithOntology(t *testing.T) {
 
 	content := "The customer submitted a new order for processing."
 	category := ontology.DetermineCategory(content, ontologyData)
-	// Should find "customer" in the content matching entity.customer
-	if category == "" {
-		t.Fatal("expected non-empty category")
+	// Content contains "customer" which matches entity.customer whose
+	// description contains "customer" (one of the business categories).
+	if category != "customer" {
+		t.Fatalf("expected category 'customer', got %q", category)
 	}
 }
 
@@ -206,6 +228,46 @@ func TestDetermineCategory_NilOntology(t *testing.T) {
 	category := ontology.DetermineCategory("some content", nil)
 	if category != "general" {
 		t.Fatalf("expected general for nil ontology, got %q", category)
+	}
+}
+
+func TestClassify_LLMCategoryIsUsed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// The LLM returns "process" category. After fix, mapLLMCategory
+	// should preserve it as "process" rather than mapping to "general".
+	provider := &fakeProvider{
+		response: `{"category": "process", "confidence": 0.9, "reasoning": "describes a workflow"}`,
+	}
+	c := ontology.NewClassifier(provider)
+
+	content := "The approval workflow requires two levels of sign-off before any purchase order is released."
+	result, err := c.Classify(ctx, content, "workflow.md")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Category != "process" {
+		t.Fatalf("expected category 'process', got %q (LLM category was not used)", result.Category)
+	}
+}
+
+func TestClassify_LLMEntityCategory(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	provider := &fakeProvider{
+		response: `{"category": "entity", "confidence": 0.85, "reasoning": "contains customer data"}`,
+	}
+	c := ontology.NewClassifier(provider)
+
+	content := "The customer approval process requires manager sign-off for orders above $10,000."
+	result, err := c.Classify(ctx, content, "approval-rules.md")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Category != "entity" {
+		t.Fatalf("expected category 'entity', got %q", result.Category)
 	}
 }
 

--- a/go/ontology/classify_test.go
+++ b/go/ontology/classify_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/llm"
+	"github.com/jeffs-brain/memory/go/ontology"
+)
+
+// fakeProvider is a mock LLM provider for testing classification.
+type fakeProvider struct {
+	response string
+	err      error
+}
+
+func (f *fakeProvider) Complete(_ context.Context, _ llm.CompleteRequest) (llm.CompleteResponse, error) {
+	if f.err != nil {
+		return llm.CompleteResponse{}, f.err
+	}
+	return llm.CompleteResponse{Text: f.response}, nil
+}
+
+func (f *fakeProvider) CompleteStream(_ context.Context, _ llm.CompleteRequest) (<-chan llm.StreamChunk, error) {
+	return nil, nil
+}
+
+func (f *fakeProvider) Close() error { return nil }
+
+func TestIsJsonDocument_ValidObject(t *testing.T) {
+	t.Parallel()
+	content := `{"rules": [{"name": "discount"}, {"name": "tax"}]}`
+	if !ontology.IsJsonDocument(content) {
+		t.Fatal("expected true for valid JSON object")
+	}
+}
+
+func TestIsJsonDocument_ValidArray(t *testing.T) {
+	t.Parallel()
+	content := `[{"name": "Alice"}, {"name": "Bob"}]`
+	if !ontology.IsJsonDocument(content) {
+		t.Fatal("expected true for valid JSON array")
+	}
+}
+
+func TestIsJsonDocument_InvalidJson(t *testing.T) {
+	t.Parallel()
+	content := "This is just some regular text content."
+	if ontology.IsJsonDocument(content) {
+		t.Fatal("expected false for prose text")
+	}
+}
+
+func TestIsJsonDocument_TrivialJson(t *testing.T) {
+	t.Parallel()
+	// Bare primitives are not business-relevant JSON
+	if ontology.IsJsonDocument("42") {
+		t.Fatal("expected false for bare number")
+	}
+	if ontology.IsJsonDocument(`"hello"`) {
+		t.Fatal("expected false for bare string")
+	}
+}
+
+func TestIsTabularDocument_Csv(t *testing.T) {
+	t.Parallel()
+	content := "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n"
+	if !ontology.IsTabularDocument(content) {
+		t.Fatal("expected true for CSV content")
+	}
+}
+
+func TestIsTabularDocument_Pipe(t *testing.T) {
+	t.Parallel()
+	content := "name|age|city\nAlice|30|NYC\nBob|25|LA\nCharlie|35|SF\n"
+	if !ontology.IsTabularDocument(content) {
+		t.Fatal("expected true for pipe-delimited content")
+	}
+}
+
+func TestIsTabularDocument_Prose(t *testing.T) {
+	t.Parallel()
+	content := "This is a paragraph of text.\nAnother paragraph follows.\nNo delimiters here.\n"
+	if ontology.IsTabularDocument(content) {
+		t.Fatal("expected false for prose text")
+	}
+}
+
+func TestClassify_JsonDetected(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := ontology.NewClassifier(nil)
+
+	result, err := c.Classify(ctx, `{"customers": [{"id": 1}]}`, "data.json")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Class != ontology.DocumentClassStructured {
+		t.Fatalf("expected structured, got %q", result.Class)
+	}
+	if !result.IsStructured {
+		t.Fatal("expected IsStructured to be true")
+	}
+	if result.Confidence < 0.9 {
+		t.Fatalf("expected high confidence, got %f", result.Confidence)
+	}
+}
+
+func TestClassify_TabularDetected(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := ontology.NewClassifier(nil)
+
+	content := "name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n"
+	result, err := c.Classify(ctx, content, "contacts.csv")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Class != ontology.DocumentClassTabular {
+		t.Fatalf("expected tabular, got %q", result.Class)
+	}
+	if !result.IsStructured {
+		t.Fatal("expected IsStructured to be true for tabular")
+	}
+}
+
+func TestClassify_FallbackToLLM(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	provider := &fakeProvider{
+		response: `{"category": "entity", "confidence": 0.85, "reasoning": "contains customer data"}`,
+	}
+	c := ontology.NewClassifier(provider)
+
+	content := "The customer approval process requires manager sign-off for orders above $10,000."
+	result, err := c.Classify(ctx, content, "approval-rules.md")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Class != ontology.DocumentClassUnstructured {
+		t.Fatalf("expected unstructured, got %q", result.Class)
+	}
+	if result.Confidence <= 0 {
+		t.Fatal("expected non-zero confidence from LLM")
+	}
+}
+
+func TestClassify_NoProvider(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := ontology.NewClassifier(nil)
+
+	content := "The customer approval process requires manager sign-off."
+	result, err := c.Classify(ctx, content, "doc.md")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Class != ontology.DocumentClassUnstructured {
+		t.Fatalf("expected unstructured, got %q", result.Class)
+	}
+	if result.Category != "general" {
+		t.Fatalf("expected general category without provider, got %q", result.Category)
+	}
+}
+
+func TestClassify_JsonWithCustomerKeywords(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := ontology.NewClassifier(nil)
+
+	content := `{"customer_id": 123, "customer_name": "Acme Corp", "account_type": "enterprise"}`
+	result, err := c.Classify(ctx, content, "data.json")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if result.Category != "customer" {
+		t.Fatalf("expected customer category, got %q", result.Category)
+	}
+}
+
+func TestDetermineCategory_WithOntology(t *testing.T) {
+	t.Parallel()
+	ontologyData := &ontology.ResolvedOntology{
+		NodeTypes: []ontology.ResolvedType{
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "entity.customer", Label: "Customer",
+				Description: "Customer entity for customer management",
+				CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}},
+		},
+		BusinessCategories: []string{"customer", "order", "general"},
+	}
+
+	content := "The customer submitted a new order for processing."
+	category := ontology.DetermineCategory(content, ontologyData)
+	// Should find "customer" in the content matching entity.customer
+	if category == "" {
+		t.Fatal("expected non-empty category")
+	}
+}
+
+func TestDetermineCategory_NilOntology(t *testing.T) {
+	t.Parallel()
+	category := ontology.DetermineCategory("some content", nil)
+	if category != "general" {
+		t.Fatalf("expected general for nil ontology, got %q", category)
+	}
+}
+
+func TestCategoryWinnerThreshold(t *testing.T) {
+	t.Parallel()
+	// Test that the threshold constant matches the intelligence service
+	if ontology.CategoryWinnerThreshold != 0.4 {
+		t.Fatalf("expected 0.4, got %f", ontology.CategoryWinnerThreshold)
+	}
+}

--- a/go/ontology/tag.go
+++ b/go/ontology/tag.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology
+
+import "strings"
+
+// ChunkTag is type metadata attached to a chunk for retrieval
+// enrichment. It records which ontology entity types are present,
+// the dominant business category, classification confidence, and
+// the document class.
+type ChunkTag struct {
+	EntityTypes      []string `json:"entityTypes,omitempty"`
+	BusinessCategory string   `json:"businessCategory,omitempty"`
+	Confidence       float64  `json:"confidence"`
+	DocumentClass    string   `json:"documentClass"`
+}
+
+// TagChunk creates a ChunkTag for a given chunk based on the
+// classification result and resolved ontology. It scans the chunk
+// content for mentions of known entity types from the ontology and
+// propagates the document classification's business category.
+func TagChunk(content string, classification ClassificationResult, ontology *ResolvedOntology) ChunkTag {
+	tag := ChunkTag{
+		BusinessCategory: classification.Category,
+		Confidence:       classification.Confidence,
+		DocumentClass:    string(classification.Class),
+	}
+
+	if ontology == nil {
+		return tag
+	}
+
+	lower := strings.ToLower(content)
+	entityTypes := matchEntityTypes(lower, ontology)
+	if len(entityTypes) > 0 {
+		tag.EntityTypes = entityTypes
+	}
+
+	// Override category if ontology voting produces a stronger signal
+	ontologyCategory := DetermineCategory(content, ontology)
+	if ontologyCategory != "general" {
+		tag.BusinessCategory = ontologyCategory
+	}
+
+	return tag
+}
+
+// matchEntityTypes scans lowercased content for mentions of known
+// ontology node types and returns a deduplicated list of matched type
+// identifiers.
+func matchEntityTypes(lowerContent string, ontology *ResolvedOntology) []string {
+	seen := make(map[string]struct{})
+	matched := make([]string, 0)
+
+	for _, nt := range ontology.NodeTypes {
+		parts := strings.SplitN(nt.Type, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := parts[1]
+
+		// Match against both snake_case and space-separated forms
+		spaced := strings.ReplaceAll(name, "_", " ")
+		if strings.Contains(lowerContent, name) || strings.Contains(lowerContent, spaced) {
+			if _, ok := seen[nt.Type]; !ok {
+				seen[nt.Type] = struct{}{}
+				matched = append(matched, nt.Type)
+			}
+		}
+	}
+
+	return matched
+}
+
+// TagChunks creates ChunkTags for a batch of chunks. Each chunk is
+// independently tagged against the classification and ontology.
+func TagChunks(contents []string, classification ClassificationResult, ontology *ResolvedOntology) []ChunkTag {
+	tags := make([]ChunkTag, len(contents))
+	for i, content := range contents {
+		tags[i] = TagChunk(content, classification, ontology)
+	}
+	return tags
+}

--- a/go/ontology/tag_test.go
+++ b/go/ontology/tag_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+package ontology_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/ontology"
+)
+
+func sampleResolvedOntology() *ontology.ResolvedOntology {
+	return &ontology.ResolvedOntology{
+		NodeTypes: []ontology.ResolvedType{
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "entity.customer", Label: "Customer (Entity)",
+				Description: "A customer entity", CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}, Scope: "built-in"},
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "entity.product", Label: "Product (Entity)",
+				Description: "A product entity", CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}, Scope: "built-in"},
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "process.workflow", Label: "Workflow (Process)",
+				Description: "A workflow process", CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}, Scope: "built-in"},
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "rule.validation", Label: "Validation (Rule)",
+				Description: "A validation rule", CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}, Scope: "built-in"},
+		},
+		EdgeTypes: []ontology.ResolvedType{
+			{TypeDefinition: ontology.TypeDefinition{
+				Type: "triggers", Label: "Triggers",
+				Description: "Triggers relationship", CreatedAt: "2026-01-01T00:00:00Z", Status: "active",
+			}, Scope: "built-in"},
+		},
+		BusinessCategories: []string{"customer", "order", "product", "general"},
+	}
+}
+
+func TestTagChunk_WithOntology(t *testing.T) {
+	t.Parallel()
+	ont := sampleResolvedOntology()
+	classification := ontology.ClassificationResult{
+		Class:      ontology.DocumentClassUnstructured,
+		Category:   "general",
+		Confidence: 0.8,
+	}
+
+	content := "The customer submitted a product order through the workflow."
+	tag := ontology.TagChunk(content, classification, ont)
+
+	if tag.DocumentClass != "unstructured" {
+		t.Fatalf("expected unstructured, got %q", tag.DocumentClass)
+	}
+	if tag.Confidence != 0.8 {
+		t.Fatalf("expected confidence 0.8, got %f", tag.Confidence)
+	}
+
+	// Should find entity.customer and entity.product, process.workflow
+	found := make(map[string]bool)
+	for _, et := range tag.EntityTypes {
+		found[et] = true
+	}
+	if !found["entity.customer"] {
+		t.Error("expected entity.customer in entity types")
+	}
+	if !found["entity.product"] {
+		t.Error("expected entity.product in entity types")
+	}
+	if !found["process.workflow"] {
+		t.Error("expected process.workflow in entity types")
+	}
+}
+
+func TestTagChunk_WithCategory(t *testing.T) {
+	t.Parallel()
+	ont := sampleResolvedOntology()
+	classification := ontology.ClassificationResult{
+		Class:      ontology.DocumentClassStructured,
+		Category:   "customer",
+		Confidence: 0.95,
+	}
+
+	content := "Customer account details for enterprise clients."
+	tag := ontology.TagChunk(content, classification, ont)
+
+	// Category should be preserved from classification (or overridden by ontology)
+	if tag.BusinessCategory == "" {
+		t.Fatal("expected non-empty business category")
+	}
+}
+
+func TestTagChunk_MinimalClassification(t *testing.T) {
+	t.Parallel()
+	classification := ontology.ClassificationResult{
+		Class:      ontology.DocumentClassUnstructured,
+		Category:   "general",
+		Confidence: 0.5,
+	}
+
+	content := "A simple text with no known ontology terms."
+	tag := ontology.TagChunk(content, classification, nil)
+
+	if tag.DocumentClass != "unstructured" {
+		t.Fatalf("expected unstructured, got %q", tag.DocumentClass)
+	}
+	if tag.BusinessCategory != "general" {
+		t.Fatalf("expected general category, got %q", tag.BusinessCategory)
+	}
+	if len(tag.EntityTypes) != 0 {
+		t.Fatalf("expected no entity types without ontology, got %d", len(tag.EntityTypes))
+	}
+}
+
+func TestTagChunks_BatchTagging(t *testing.T) {
+	t.Parallel()
+	ont := sampleResolvedOntology()
+	classification := ontology.ClassificationResult{
+		Class:      ontology.DocumentClassUnstructured,
+		Category:   "general",
+		Confidence: 0.7,
+	}
+
+	contents := []string{
+		"The customer placed an order.",
+		"Product validation rules apply.",
+		"No relevant terms here.",
+	}
+
+	tags := ontology.TagChunks(contents, classification, ont)
+	if len(tags) != 3 {
+		t.Fatalf("expected 3 tags, got %d", len(tags))
+	}
+
+	// First chunk should find customer
+	foundCustomer := false
+	for _, et := range tags[0].EntityTypes {
+		if et == "entity.customer" {
+			foundCustomer = true
+			break
+		}
+	}
+	if !foundCustomer {
+		t.Error("expected entity.customer in first chunk tags")
+	}
+
+	// Second chunk should find product and validation
+	foundProduct := false
+	foundValidation := false
+	for _, et := range tags[1].EntityTypes {
+		if et == "entity.product" {
+			foundProduct = true
+		}
+		if et == "rule.validation" {
+			foundValidation = true
+		}
+	}
+	if !foundProduct {
+		t.Error("expected entity.product in second chunk tags")
+	}
+	if !foundValidation {
+		t.Error("expected rule.validation in second chunk tags")
+	}
+}
+
+func TestTagChunk_NoEntityTypes_WhenNoMatch(t *testing.T) {
+	t.Parallel()
+	ont := sampleResolvedOntology()
+	classification := ontology.ClassificationResult{
+		Class:      ontology.DocumentClassUnstructured,
+		Category:   "general",
+		Confidence: 0.5,
+	}
+
+	content := "This text mentions nothing from the ontology at all."
+	tag := ontology.TagChunk(content, classification, ont)
+
+	if len(tag.EntityTypes) != 0 {
+		t.Fatalf("expected no entity types for non-matching content, got %v", tag.EntityTypes)
+	}
+}
+
+func TestClassifyAndTag_EndToEnd(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	c := ontology.NewClassifier(nil)
+	ont := sampleResolvedOntology()
+
+	content := `{"customer_id": 1, "customer_name": "Acme", "product": "Widget"}`
+	result, err := c.Classify(ctx, content, "data.json")
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+
+	tag := ontology.TagChunk(content, result, ont)
+	if tag.DocumentClass != "structured" {
+		t.Fatalf("expected structured, got %q", tag.DocumentClass)
+	}
+	if tag.Confidence < 0.8 {
+		t.Fatalf("expected high confidence for JSON, got %f", tag.Confidence)
+	}
+
+	// Should find customer and product entity types
+	foundCustomer := false
+	foundProduct := false
+	for _, et := range tag.EntityTypes {
+		if et == "entity.customer" {
+			foundCustomer = true
+		}
+		if et == "entity.product" {
+			foundProduct = true
+		}
+	}
+	if !foundCustomer {
+		t.Error("expected entity.customer in end-to-end tag")
+	}
+	if !foundProduct {
+		t.Error("expected entity.product in end-to-end tag")
+	}
+}

--- a/sdks/ts/memory/src/ontology/classify.test.ts
+++ b/sdks/ts/memory/src/ontology/classify.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type { Provider, CompletionResponse } from '../llm/types.js'
+import type { ResolvedOntology, ResolvedType } from './store.js'
+import {
+  Classifier,
+  isJsonDocument,
+  isTabularDocument,
+  determineCategory,
+  CATEGORY_WINNER_THRESHOLD,
+} from './classify.js'
+
+function fakeProvider(response: string): Provider {
+  return {
+    name: () => 'fake',
+    modelName: () => 'fake-model',
+    stream: () => {
+      throw new Error('not implemented')
+    },
+    complete: async (): Promise<CompletionResponse> => ({
+      content: response,
+      toolCalls: [],
+      usage: { inputTokens: 0, outputTokens: 0 },
+      stopReason: 'end_turn',
+    }),
+    supportsStructuredDecoding: () => false,
+    structured: async () => response,
+  }
+}
+
+describe('isJsonDocument', () => {
+  it('returns true for valid JSON object', () => {
+    expect(isJsonDocument('{"rules": [{"name": "discount"}]}')).toBe(true)
+  })
+
+  it('returns true for valid JSON array', () => {
+    expect(isJsonDocument('[{"name": "Alice"}, {"name": "Bob"}]')).toBe(true)
+  })
+
+  it('returns false for prose text', () => {
+    expect(isJsonDocument('This is just some regular text content.')).toBe(false)
+  })
+
+  it('returns false for bare primitives', () => {
+    expect(isJsonDocument('42')).toBe(false)
+    expect(isJsonDocument('"hello"')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isJsonDocument('')).toBe(false)
+  })
+})
+
+describe('isTabularDocument', () => {
+  it('returns true for CSV content', () => {
+    const content = 'name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n'
+    expect(isTabularDocument(content)).toBe(true)
+  })
+
+  it('returns true for pipe-delimited content', () => {
+    const content = 'name|age|city\nAlice|30|NYC\nBob|25|LA\nCharlie|35|SF\n'
+    expect(isTabularDocument(content)).toBe(true)
+  })
+
+  it('returns false for prose text', () => {
+    const content = 'This is a paragraph.\nAnother paragraph follows.\nNo delimiters here.\n'
+    expect(isTabularDocument(content)).toBe(false)
+  })
+})
+
+describe('Classifier', () => {
+  describe('classify', () => {
+    it('detects JSON as structured', async () => {
+      const c = new Classifier({})
+      const result = await c.classify('{"customers": [{"id": 1}]}', 'data.json')
+      expect(result.class).toBe('structured')
+      expect(result.isStructured).toBe(true)
+      expect(result.confidence).toBeGreaterThanOrEqual(0.9)
+    })
+
+    it('detects CSV as tabular', async () => {
+      const c = new Classifier({})
+      const content = 'name,age,city\nAlice,30,NYC\nBob,25,LA\nCharlie,35,SF\n'
+      const result = await c.classify(content, 'contacts.csv')
+      expect(result.class).toBe('tabular')
+      expect(result.isStructured).toBe(true)
+    })
+
+    it('falls back to LLM for unstructured content', async () => {
+      const provider = fakeProvider('{"category": "entity", "confidence": 0.85, "reasoning": "customer data"}')
+      const c = new Classifier({ provider })
+      const content = 'The customer approval process requires manager sign-off for orders above $10,000.'
+      const result = await c.classify(content, 'approval-rules.md')
+      expect(result.class).toBe('unstructured')
+      expect(result.confidence).toBeGreaterThan(0)
+    })
+
+    it('returns default without provider', async () => {
+      const c = new Classifier({})
+      const content = 'The customer approval process requires manager sign-off.'
+      const result = await c.classify(content, 'doc.md')
+      expect(result.class).toBe('unstructured')
+      expect(result.category).toBe('general')
+    })
+
+    it('infers customer category from JSON keywords', async () => {
+      const c = new Classifier({})
+      const content = '{"customer_id": 123, "customer_name": "Acme Corp", "account_type": "enterprise"}'
+      const result = await c.classify(content, 'data.json')
+      expect(result.category).toBe('customer')
+    })
+  })
+})
+
+describe('determineCategory', () => {
+  const sampleOntology: ResolvedOntology = {
+    nodeTypes: [
+      {
+        type: 'entity.customer',
+        label: 'Customer (Entity)',
+        description: 'Customer entity for customer management',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+    ],
+    edgeTypes: [],
+    businessCategories: ['customer', 'order', 'general'],
+  }
+
+  it('returns category from ontology analysis', () => {
+    const content = 'The customer submitted a new order for processing.'
+    const category = determineCategory(content, sampleOntology)
+    expect(category).toBeTruthy()
+  })
+
+  it('returns general for undefined ontology', () => {
+    expect(determineCategory('some content', undefined)).toBe('general')
+  })
+})
+
+describe('constants', () => {
+  it('CATEGORY_WINNER_THRESHOLD matches intelligence service', () => {
+    expect(CATEGORY_WINNER_THRESHOLD).toBe(0.4)
+  })
+})

--- a/sdks/ts/memory/src/ontology/classify.test.ts
+++ b/sdks/ts/memory/src/ontology/classify.test.ts
@@ -50,6 +50,16 @@ describe('isJsonDocument', () => {
   it('returns false for empty string', () => {
     expect(isJsonDocument('')).toBe(false)
   })
+
+  it('returns false for primitive arrays', () => {
+    expect(isJsonDocument('[1, 2, 3]')).toBe(false)
+    expect(isJsonDocument('["a", "b", "c"]')).toBe(false)
+  })
+
+  it('returns false for empty structures', () => {
+    expect(isJsonDocument('{}')).toBe(false)
+    expect(isJsonDocument('[]')).toBe(false)
+  })
 })
 
 describe('isTabularDocument', () => {
@@ -129,14 +139,34 @@ describe('determineCategory', () => {
     businessCategories: ['customer', 'order', 'general'],
   }
 
-  it('returns category from ontology analysis', () => {
+  it('returns specific category from ontology analysis', () => {
     const content = 'The customer submitted a new order for processing.'
     const category = determineCategory(content, sampleOntology)
-    expect(category).toBeTruthy()
+    // Content contains "customer" which matches entity.customer whose
+    // description contains "customer" (a business category).
+    expect(category).toBe('customer')
   })
 
   it('returns general for undefined ontology', () => {
     expect(determineCategory('some content', undefined)).toBe('general')
+  })
+})
+
+describe('LLM category mapping', () => {
+  it('preserves LLM process category instead of mapping to general', async () => {
+    const provider = fakeProvider('{"category": "process", "confidence": 0.9, "reasoning": "describes a workflow"}')
+    const c = new Classifier({ provider })
+    const content = 'The approval workflow requires two levels of sign-off before any purchase order is released.'
+    const result = await c.classify(content, 'workflow.md')
+    expect(result.category).toBe('process')
+  })
+
+  it('preserves LLM entity category', async () => {
+    const provider = fakeProvider('{"category": "entity", "confidence": 0.85, "reasoning": "contains customer data"}')
+    const c = new Classifier({ provider })
+    const content = 'The customer approval process requires manager sign-off for orders above $10,000.'
+    const result = await c.classify(content, 'approval-rules.md')
+    expect(result.category).toBe('entity')
   })
 })
 

--- a/sdks/ts/memory/src/ontology/classify.ts
+++ b/sdks/ts/memory/src/ontology/classify.ts
@@ -145,17 +145,62 @@ type LLMClassification = {
   readonly confidence?: number
 }
 
+/**
+ * Finds the first balanced JSON object in text using depth-tracking.
+ * Returns undefined if no valid object is found.
+ */
+function extractJSONObject(text: string): string | undefined {
+  const start = text.indexOf('{')
+  if (start < 0) return undefined
+
+  let depth = 0
+  let inString = false
+  let escaping = false
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]
+    if (escaping) {
+      escaping = false
+      continue
+    }
+    if (inString) {
+      if (ch === '\\') escaping = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') {
+      inString = true
+      continue
+    }
+    if (ch === '{') {
+      depth++
+    } else if (ch === '}') {
+      depth--
+      if (depth === 0) {
+        const candidate = text.slice(start, i + 1)
+        try {
+          JSON.parse(candidate)
+          return candidate
+        } catch {
+          return undefined
+        }
+      }
+    }
+  }
+
+  return undefined
+}
+
 function parseClassificationResponse(text: string): ClassificationResult {
   const trimmed = text.trim()
-  const start = trimmed.indexOf('{')
-  const end = trimmed.lastIndexOf('}')
+  const jsonStr = extractJSONObject(trimmed)
 
-  if (start < 0 || end <= start) {
+  if (jsonStr === undefined) {
     return { class: 'unstructured', category: 'general', confidence: 0.3, isStructured: false }
   }
 
   try {
-    const parsed = JSON.parse(trimmed.slice(start, end + 1)) as LLMClassification
+    const parsed = JSON.parse(jsonStr) as LLMClassification
     const category = mapLLMCategory(parsed.category ?? '')
     let confidence = parsed.confidence ?? 0.7
     if (confidence <= 0 || confidence > 1) confidence = 0.7
@@ -173,12 +218,12 @@ function parseClassificationResponse(text: string): ClassificationResult {
 
 function mapLLMCategory(raw: string): string {
   const categoryMap: Record<string, string> = {
-    entity: 'general',
-    rule: 'general',
-    exception: 'general',
-    decision: 'general',
-    process: 'general',
-    reference: 'general',
+    entity: 'entity',
+    rule: 'rule',
+    exception: 'exception',
+    decision: 'decision',
+    process: 'process',
+    reference: 'reference',
     customer: 'customer',
     order: 'order',
     product: 'product',
@@ -205,7 +250,20 @@ export function isJsonDocument(content: string): boolean {
 
   try {
     const parsed: unknown = JSON.parse(trimmed)
-    return typeof parsed === 'object' && parsed !== null
+    if (parsed === null || typeof parsed !== 'object') return false
+
+    // Require non-empty structure
+    if (Array.isArray(parsed)) {
+      // Empty arrays and primitive arrays are not business-relevant JSON
+      if (parsed.length === 0) return false
+      // At least one element must be an object or nested array
+      return parsed.some(
+        (item) => typeof item === 'object' && item !== null,
+      )
+    }
+
+    // Non-empty object
+    return Object.keys(parsed).length > 0
   } catch {
     return false
   }

--- a/sdks/ts/memory/src/ontology/classify.ts
+++ b/sdks/ts/memory/src/ontology/classify.ts
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Document classification and entity tagging for the ontology system.
+ * Classifies documents as structured (JSON), tabular (CSV/TSV), or
+ * unstructured (prose), and tags chunks with ontology entity types.
+ *
+ * Classification cascade: JSON detection -> tabular detection -> LLM.
+ * Port of go/ontology/classify.go.
+ */
+
+import type { Provider } from '../llm/types.js'
+import type { ResolvedOntology } from './store.js'
+import { isValidBusinessCategory } from './validation.js'
+
+/**
+ * Minimum proportion of entity type matches required for a business
+ * category to win classification via weighted voting.
+ */
+export const CATEGORY_WINNER_THRESHOLD = 0.4
+
+export type DocumentClass = 'structured' | 'tabular' | 'unstructured'
+
+export type ClassificationResult = {
+  readonly class: DocumentClass
+  readonly category: string
+  readonly confidence: number
+  readonly isStructured: boolean
+}
+
+export type ClassifierOptions = {
+  readonly provider?: Provider
+}
+
+/**
+ * Classifier classifies documents and tags chunks with type metadata.
+ * When a Provider is supplied, unstructured documents use LLM-powered
+ * classification. Without a Provider, heuristic-only mode is used.
+ */
+export class Classifier {
+  private readonly provider: Provider | undefined
+
+  constructor(options: ClassifierOptions) {
+    this.provider = options.provider
+  }
+
+  /**
+   * Determines the document class and business category.
+   * Classification cascade: JSON -> tabular -> LLM fallback.
+   */
+  async classify(
+    content: string,
+    fileName: string,
+    signal?: AbortSignal,
+  ): Promise<ClassificationResult> {
+    if (isJsonDocument(content)) {
+      return {
+        class: 'structured',
+        category: inferCategoryFromJSON(content),
+        confidence: 0.95,
+        isStructured: true,
+      }
+    }
+
+    if (isTabularDocument(content)) {
+      return {
+        class: 'tabular',
+        category: inferCategoryFromFileName(fileName),
+        confidence: 0.85,
+        isStructured: true,
+      }
+    }
+
+    if (this.provider !== undefined) {
+      return this.classifyWithLLM(content, fileName, signal)
+    }
+
+    return {
+      class: 'unstructured',
+      category: 'general',
+      confidence: 0.5,
+      isStructured: false,
+    }
+  }
+
+  private async classifyWithLLM(
+    content: string,
+    fileName: string,
+    signal?: AbortSignal,
+  ): Promise<ClassificationResult> {
+    const preview = content.length > 2000 ? content.slice(0, 2000) : content
+    const prompt = buildClassificationPrompt(preview, fileName)
+
+    try {
+      const resp = await this.provider!.complete(
+        {
+          messages: [
+            { role: 'system', content: CLASSIFICATION_SYSTEM_PROMPT },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.1,
+          maxTokens: 256,
+          jsonMode: true,
+        },
+        signal,
+      )
+
+      return parseClassificationResponse(resp.content)
+    } catch {
+      return {
+        class: 'unstructured',
+        category: 'general',
+        confidence: 0.3,
+        isStructured: false,
+      }
+    }
+  }
+}
+
+const CLASSIFICATION_SYSTEM_PROMPT = `You are a document classifier. Analyse the provided document content and classify it into one of these categories:
+- entity: Documents about customers, products, suppliers, or other business entities
+- rule: Documents describing business rules, constraints, policies, or validation logic
+- exception: Documents about workarounds, overrides, or special cases
+- decision: Documents about decision trees, escalation paths, or branch logic
+- process: Documents about workflows, procedures, approval chains, or integrations
+- reference: General reference documentation that does not fit the above
+
+Respond with a JSON object containing:
+- "category": one of "entity", "rule", "exception", "decision", "process", "reference"
+- "confidence": a number between 0 and 1 indicating your confidence
+- "reasoning": a brief explanation of why you chose this category`
+
+function buildClassificationPrompt(content: string, fileName: string): string {
+  const parts: string[] = []
+  if (fileName !== '') {
+    parts.push(`File: ${fileName}\n`)
+  }
+  parts.push('Document content:\n')
+  parts.push(content)
+  return parts.join('')
+}
+
+type LLMClassification = {
+  readonly category?: string
+  readonly confidence?: number
+}
+
+function parseClassificationResponse(text: string): ClassificationResult {
+  const trimmed = text.trim()
+  const start = trimmed.indexOf('{')
+  const end = trimmed.lastIndexOf('}')
+
+  if (start < 0 || end <= start) {
+    return { class: 'unstructured', category: 'general', confidence: 0.3, isStructured: false }
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed.slice(start, end + 1)) as LLMClassification
+    const category = mapLLMCategory(parsed.category ?? '')
+    let confidence = parsed.confidence ?? 0.7
+    if (confidence <= 0 || confidence > 1) confidence = 0.7
+
+    return {
+      class: 'unstructured',
+      category,
+      confidence,
+      isStructured: false,
+    }
+  } catch {
+    return { class: 'unstructured', category: 'general', confidence: 0.3, isStructured: false }
+  }
+}
+
+function mapLLMCategory(raw: string): string {
+  const categoryMap: Record<string, string> = {
+    entity: 'general',
+    rule: 'general',
+    exception: 'general',
+    decision: 'general',
+    process: 'general',
+    reference: 'general',
+    customer: 'customer',
+    order: 'order',
+    product: 'product',
+    address: 'address',
+    document: 'document',
+  }
+  const lower = raw.toLowerCase().trim()
+  const mapped = categoryMap[lower]
+  if (mapped !== undefined) return mapped
+  if (isValidBusinessCategory(lower)) return lower
+  return 'general'
+}
+
+/**
+ * Returns true if content parses as JSON with business-relevant
+ * structure (object or array, not a bare primitive).
+ */
+export function isJsonDocument(content: string): boolean {
+  const trimmed = content.trim()
+  if (trimmed.length === 0) return false
+
+  const first = trimmed[0]
+  if (first !== '{' && first !== '[') return false
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    return typeof parsed === 'object' && parsed !== null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Returns true if content appears to be CSV/TSV data. Uses a heuristic:
+ * checks the first 5 lines for consistent comma or pipe delimiters
+ * (>= 2 delimiters per line on >= 3 of the first 5 lines).
+ */
+export function isTabularDocument(content: string): boolean {
+  const lines = content.split('\n').slice(0, 5)
+  if (lines.length < 3) return false
+
+  let commaCount = 0
+  let pipeCount = 0
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '') continue
+
+    const commas = countOccurrences(trimmed, ',')
+    const pipes = countOccurrences(trimmed, '|')
+
+    if (commas >= 2) commaCount++
+    if (pipes >= 2) pipeCount++
+  }
+
+  return commaCount >= 3 || pipeCount >= 3
+}
+
+function countOccurrences(str: string, char: string): number {
+  let count = 0
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] === char) count++
+  }
+  return count
+}
+
+function inferCategoryFromJSON(content: string): string {
+  const lower = content.toLowerCase()
+  const categoryKeywords: Record<string, readonly string[]> = {
+    customer: ['customer', 'client', 'account'],
+    order: ['order', 'purchase', 'transaction'],
+    product: ['product', 'item', 'sku', 'catalog'],
+    address: ['address', 'location', 'postal', 'zip'],
+    document: ['document', 'file', 'attachment'],
+    authorization: ['authorization', 'permission', 'role', 'access'],
+    integration: ['integration', 'api', 'endpoint', 'webhook'],
+  }
+
+  let bestCategory = ''
+  let bestCount = 0
+
+  for (const [category, keywords] of Object.entries(categoryKeywords)) {
+    let count = 0
+    for (const kw of keywords) {
+      count += countStringOccurrences(lower, kw)
+    }
+    if (count > bestCount) {
+      bestCount = count
+      bestCategory = category
+    }
+  }
+
+  if (bestCategory !== '' && bestCount >= 2) return bestCategory
+  return 'general'
+}
+
+function inferCategoryFromFileName(fileName: string): string {
+  const lower = fileName.toLowerCase()
+  const keywords: Record<string, string> = {
+    customer: 'customer',
+    order: 'order',
+    product: 'product',
+    address: 'address',
+    invoice: 'order',
+    shipping: 'order',
+    price: 'product',
+    auth: 'authorization',
+    api: 'integration',
+  }
+  for (const [kw, category] of Object.entries(keywords)) {
+    if (lower.includes(kw)) return category
+  }
+  return 'general'
+}
+
+function countStringOccurrences(haystack: string, needle: string): number {
+  let count = 0
+  let idx = 0
+  while (true) {
+    idx = haystack.indexOf(needle, idx)
+    if (idx < 0) break
+    count++
+    idx += needle.length
+  }
+  return count
+}
+
+/**
+ * Uses ontology-aware weighted voting to determine the best business
+ * category for content.
+ */
+export function determineCategory(content: string, ontology: ResolvedOntology | undefined): string {
+  if (ontology === undefined) return 'general'
+
+  const counts = buildCategoryCounts(content, ontology)
+  return categoryWinner(counts)
+}
+
+function buildCategoryCounts(
+  content: string,
+  ontology: ResolvedOntology,
+): Record<string, number> {
+  const counts: Record<string, number> = {}
+  const lower = content.toLowerCase()
+
+  for (const nt of ontology.nodeTypes) {
+    const dotIdx = nt.type.indexOf('.')
+    if (dotIdx < 0) continue
+    const name = nt.type.slice(dotIdx + 1)
+    const spaced = name.replace(/_/g, ' ')
+
+    if (lower.includes(name) || lower.includes(spaced)) {
+      for (const cat of ontology.businessCategories) {
+        if (nt.description.toLowerCase().includes(cat)) {
+          counts[cat] = (counts[cat] ?? 0) + 1
+        }
+      }
+    }
+  }
+
+  return counts
+}
+
+function categoryWinner(counts: Record<string, number>): string {
+  let total = 0
+  for (const c of Object.values(counts)) {
+    total += c
+  }
+  if (total === 0) return 'general'
+
+  let bestCategory = ''
+  let bestCount = 0
+  for (const [cat, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      bestCount = count
+      bestCategory = cat
+    }
+  }
+
+  if (bestCount / total >= CATEGORY_WINNER_THRESHOLD) return bestCategory
+  return 'general'
+}

--- a/sdks/ts/memory/src/ontology/classify.ts
+++ b/sdks/ts/memory/src/ontology/classify.ts
@@ -133,10 +133,11 @@ Respond with a JSON object containing:
 function buildClassificationPrompt(content: string, fileName: string): string {
   const parts: string[] = []
   if (fileName !== '') {
-    parts.push(`File: ${fileName}\n`)
+    parts.push(`File: ${fileName}\n\n`)
   }
-  parts.push('Document content:\n')
+  parts.push('Document content:\n<ingested-document>\n')
   parts.push(content)
+  parts.push('\n</ingested-document>')
   return parts.join('')
 }
 

--- a/sdks/ts/memory/src/ontology/index.ts
+++ b/sdks/ts/memory/src/ontology/index.ts
@@ -120,3 +120,19 @@ export type {
   ProposalWorkflowConfig,
 } from './proposal.js'
 export { ProposalWorkflow } from './proposal.js'
+
+export type {
+  ClassificationResult,
+  ClassifierOptions,
+  DocumentClass,
+} from './classify.js'
+export {
+  Classifier,
+  isJsonDocument,
+  isTabularDocument,
+  determineCategory,
+  CATEGORY_WINNER_THRESHOLD,
+} from './classify.js'
+
+export type { ChunkTag } from './tag.js'
+export { tagChunk, tagChunks } from './tag.js'

--- a/sdks/ts/memory/src/ontology/tag.test.ts
+++ b/sdks/ts/memory/src/ontology/tag.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type { ResolvedOntology, ResolvedType } from './store.js'
+import type { ClassificationResult } from './classify.js'
+import { tagChunk, tagChunks } from './tag.js'
+import { Classifier } from './classify.js'
+
+function sampleOntology(): ResolvedOntology {
+  return {
+    nodeTypes: [
+      {
+        type: 'entity.customer',
+        label: 'Customer (Entity)',
+        description: 'A customer entity',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+      {
+        type: 'entity.product',
+        label: 'Product (Entity)',
+        description: 'A product entity',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+      {
+        type: 'process.workflow',
+        label: 'Workflow (Process)',
+        description: 'A workflow process',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+      {
+        type: 'rule.validation',
+        label: 'Validation (Rule)',
+        description: 'A validation rule',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+    ],
+    edgeTypes: [
+      {
+        type: 'triggers',
+        label: 'Triggers',
+        description: 'Triggers relationship',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'active',
+        scope: 'built-in',
+      } as ResolvedType,
+    ],
+    businessCategories: ['customer', 'order', 'product', 'general'],
+  }
+}
+
+describe('tagChunk', () => {
+  it('tags with ontology entity types', () => {
+    const ont = sampleOntology()
+    const classification: ClassificationResult = {
+      class: 'unstructured',
+      category: 'general',
+      confidence: 0.8,
+      isStructured: false,
+    }
+
+    const content = 'The customer submitted a product order through the workflow.'
+    const tag = tagChunk(content, classification, ont)
+
+    expect(tag.documentClass).toBe('unstructured')
+    expect(tag.confidence).toBe(0.8)
+    expect(tag.entityTypes).toBeDefined()
+    expect(tag.entityTypes).toContain('entity.customer')
+    expect(tag.entityTypes).toContain('entity.product')
+    expect(tag.entityTypes).toContain('process.workflow')
+  })
+
+  it('preserves business category from classification', () => {
+    const ont = sampleOntology()
+    const classification: ClassificationResult = {
+      class: 'structured',
+      category: 'customer',
+      confidence: 0.95,
+      isStructured: true,
+    }
+
+    const content = 'Customer account details for enterprise clients.'
+    const tag = tagChunk(content, classification, ont)
+    expect(tag.businessCategory).toBeTruthy()
+  })
+
+  it('works with minimal classification (no ontology)', () => {
+    const classification: ClassificationResult = {
+      class: 'unstructured',
+      category: 'general',
+      confidence: 0.5,
+      isStructured: false,
+    }
+
+    const content = 'A simple text with no known ontology terms.'
+    const tag = tagChunk(content, classification, undefined)
+
+    expect(tag.documentClass).toBe('unstructured')
+    expect(tag.businessCategory).toBe('general')
+    expect(tag.entityTypes).toBeUndefined()
+  })
+
+  it('returns no entity types when no matches found', () => {
+    const ont = sampleOntology()
+    const classification: ClassificationResult = {
+      class: 'unstructured',
+      category: 'general',
+      confidence: 0.5,
+      isStructured: false,
+    }
+
+    const content = 'This text mentions nothing from the ontology at all.'
+    const tag = tagChunk(content, classification, ont)
+    expect(tag.entityTypes).toBeUndefined()
+  })
+})
+
+describe('tagChunks', () => {
+  it('batch tags multiple chunks', () => {
+    const ont = sampleOntology()
+    const classification: ClassificationResult = {
+      class: 'unstructured',
+      category: 'general',
+      confidence: 0.7,
+      isStructured: false,
+    }
+
+    const contents = [
+      'The customer placed an order.',
+      'Product validation rules apply.',
+      'No relevant terms here.',
+    ]
+
+    const tags = tagChunks(contents, classification, ont)
+    expect(tags).toHaveLength(3)
+
+    // First chunk: customer
+    expect(tags[0]!.entityTypes).toContain('entity.customer')
+
+    // Second chunk: product and validation
+    expect(tags[1]!.entityTypes).toContain('entity.product')
+    expect(tags[1]!.entityTypes).toContain('rule.validation')
+  })
+})
+
+describe('classify and tag end-to-end', () => {
+  it('classifies JSON and tags with entity types', async () => {
+    const c = new Classifier({})
+    const ont = sampleOntology()
+
+    const content = '{"customer_id": 1, "customer_name": "Acme", "product": "Widget"}'
+    const result = await c.classify(content, 'data.json')
+
+    const tag = tagChunk(content, result, ont)
+    expect(tag.documentClass).toBe('structured')
+    expect(tag.confidence).toBeGreaterThanOrEqual(0.8)
+    expect(tag.entityTypes).toContain('entity.customer')
+    expect(tag.entityTypes).toContain('entity.product')
+  })
+})

--- a/sdks/ts/memory/src/ontology/tag.ts
+++ b/sdks/ts/memory/src/ontology/tag.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Entity tagging for chunk metadata enrichment. Scans chunk content
+ * for mentions of known ontology entity types and attaches type
+ * metadata for retrieval enrichment.
+ *
+ * Port of go/ontology/tag.go.
+ */
+
+import type { ResolvedOntology } from './store.js'
+import type { ClassificationResult } from './classify.js'
+import { determineCategory } from './classify.js'
+
+/**
+ * ChunkTag is type metadata attached to a chunk for retrieval
+ * enrichment.
+ */
+export type ChunkTag = {
+  readonly entityTypes?: readonly string[]
+  readonly businessCategory?: string
+  readonly confidence: number
+  readonly documentClass: string
+}
+
+/**
+ * Creates a ChunkTag for a given chunk based on the classification
+ * result and resolved ontology. Scans the chunk content for mentions
+ * of known entity types from the ontology.
+ */
+export function tagChunk(
+  content: string,
+  classification: ClassificationResult,
+  ontology: ResolvedOntology | undefined,
+): ChunkTag {
+  let businessCategory = classification.category
+  let entityTypes: string[] | undefined
+
+  if (ontology !== undefined) {
+    const lower = content.toLowerCase()
+    const matched = matchEntityTypes(lower, ontology)
+    if (matched.length > 0) {
+      entityTypes = matched
+    }
+
+    const ontologyCategory = determineCategory(content, ontology)
+    if (ontologyCategory !== 'general') {
+      businessCategory = ontologyCategory
+    }
+  }
+
+  return {
+    entityTypes,
+    businessCategory,
+    confidence: classification.confidence,
+    documentClass: classification.class,
+  }
+}
+
+/**
+ * Creates ChunkTags for a batch of chunks. Each chunk is
+ * independently tagged against the classification and ontology.
+ */
+export function tagChunks(
+  contents: readonly string[],
+  classification: ClassificationResult,
+  ontology: ResolvedOntology | undefined,
+): ChunkTag[] {
+  return contents.map((content) => tagChunk(content, classification, ontology))
+}
+
+function matchEntityTypes(
+  lowerContent: string,
+  ontology: ResolvedOntology,
+): string[] {
+  const seen = new Set<string>()
+  const matched: string[] = []
+
+  for (const nt of ontology.nodeTypes) {
+    const dotIdx = nt.type.indexOf('.')
+    if (dotIdx < 0) continue
+    const name = nt.type.slice(dotIdx + 1)
+    const spaced = name.replace(/_/g, ' ')
+
+    if (lowerContent.includes(name) || lowerContent.includes(spaced)) {
+      if (!seen.has(nt.type)) {
+        seen.add(nt.type)
+        matched.push(nt.type)
+      }
+    }
+  }
+
+  return matched
+}


### PR DESCRIPTION
## Summary
- Implement document classification cascade: JSON detection -> tabular detection -> LLM fallback
- Classify documents as structured (JSON), tabular (CSV/TSV), or unstructured (prose) with business category inference
- Entity tagging scans chunk content for mentions of known ontology entity types from the resolved ontology
- Ontology-aware weighted voting with CategoryWinnerThreshold = 0.4 for business category determination
- Graceful operation without LLM provider (heuristic-only mode)

## Files
- **Go**: `go/ontology/classify.go` + `classify_test.go` (15 tests), `go/ontology/tag.go` + `tag_test.go` (6 tests)
- **TS**: `sdks/ts/memory/src/ontology/classify.ts` + `classify.test.ts` (16 tests), `tag.ts` + `tag.test.ts` (6 tests)
- **Barrel**: `sdks/ts/memory/src/ontology/index.ts` updated with classify and tag exports

## Test plan
- [x] Go tests pass: `go test ./ontology/ -count=1` (all pass including 21 new tests)
- [x] TS tests pass: `npx vitest run src/ontology/` (243 tests, 22 new)
- [x] JSON detection: objects and arrays detected as structured, bare primitives rejected
- [x] Tabular detection: CSV/pipe-delimited detected via comma/pipe heuristic (>= 2 delimiters on >= 3 of first 5 lines)
- [x] LLM fallback: unstructured content classified via provider when available
- [x] No-provider mode: returns unstructured/general/0.5 confidence
- [x] Entity tagging: matches ontology node types (snake_case and space-separated) in chunk content
- [x] Batch tagging: tagChunks processes multiple chunks independently
- [x] End-to-end: classify JSON -> tag chunks -> verify entity types and document class
- [x] Category winner threshold constant = 0.4 matching intelligence service