### PR TITLE
feat: P2-6 agent ingest-then-extract pipeline (LLE-9802)

### DIFF
--- a/go/cmd/memory-mcp/client.go
+++ b/go/cmd/memory-mcp/client.go
@@ -109,12 +109,14 @@ type IngestURLArgs struct {
 }
 
 // ExtractAfterIngestArgs captures input for post-ingest extraction.
+// Content should be provided directly to avoid re-fetching.
+// When Content is empty, the DocumentSource label is used for logging.
 type ExtractAfterIngestArgs struct {
-	Path      string
-	URL       string
-	Brain     string
-	ActorID   string
-	SessionID string
+	Content        string
+	DocumentSource string
+	Brain          string
+	ActorID        string
+	SessionID      string
 }
 
 // ExtractMessage is one turn supplied to memory_extract.
@@ -648,6 +650,15 @@ func (c *localClient) IngestURL(ctx context.Context, args IngestURLArgs, progres
 	if progress != nil {
 		progress(1, "indexed")
 	}
+
+	// Read the stored content from the brain store so downstream
+	// extraction can use it without re-fetching the URL.
+	var storedContent string
+	raw, readErr := br.store.Read(ctx, resp.Path)
+	if readErr == nil {
+		storedContent = string(raw)
+	}
+
 	return map[string]any{
 		"path": "server",
 		"result": map[string]any{
@@ -659,6 +670,7 @@ func (c *localClient) IngestURL(ctx context.Context, args IngestURLArgs, progres
 			"duration_ms":    resp.TookMs,
 			"reused":         false,
 		},
+		"_document_content": storedContent,
 	}, nil
 }
 
@@ -742,67 +754,55 @@ func (c *localClient) Extract(ctx context.Context, args ExtractArgs, progress Pr
 	}, nil
 }
 
-// ExtractAfterIngest implements [MemoryClient]. Reads the ingested document
+// ExtractAfterIngest implements [MemoryClient]. Uses the provided document
 // content and runs the memory extractor to derive structured facts.
+// Content must be supplied directly (read from brain store or file);
+// no re-fetching of URLs occurs here.
 // Extraction failure is non-fatal: returns empty result.
 func (c *localClient) ExtractAfterIngest(ctx context.Context, args ExtractAfterIngestArgs) (map[string]any, error) {
+	emptyResult := map[string]any{"factsExtracted": 0, "memories": []any{}}
+
 	if c.provider == nil {
-		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		return emptyResult, nil
+	}
+
+	content := args.Content
+	if strings.TrimSpace(content) == "" {
+		return emptyResult, nil
 	}
 
 	brainID := c.resolveBrainID(args.Brain)
 	br, err := c.openBrain(ctx, brainID)
 	if err != nil {
-		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		c.log.Warn("extract-after-ingest: failed to open brain", "brain", brainID, "error", err)
+		return emptyResult, nil
 	}
 
-	var content string
-	if args.Path != "" {
-		raw, readErr := os.ReadFile(args.Path)
-		if readErr != nil {
-			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
-		}
-		content = string(raw)
-	} else if args.URL != "" {
-		resp, fetchErr := http.Get(args.URL) //nolint:gosec
-		if fetchErr != nil || resp.StatusCode >= 400 {
-			if resp != nil {
-				resp.Body.Close()
-			}
-			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
-		}
-		defer resp.Body.Close()
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 128_000))
-		if readErr != nil {
-			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
-		}
-		content = string(body)
-	} else {
-		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	// Truncate by rune count to avoid splitting multi-byte characters.
+	runes := []rune(content)
+	if len(runes) > 128_000 {
+		runes = runes[:128_000]
+		content = string(runes)
 	}
 
-	if strings.TrimSpace(content) == "" {
-		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
-	}
-
-	if len(content) > 128_000 {
-		content = content[:128_000]
-	}
-
-	source := args.Path
+	source := args.DocumentSource
 	if source == "" {
-		source = args.URL
+		source = "unknown"
 	}
 	messages := []memory.Message{
 		{
-			Role:    "user",
-			Content: fmt.Sprintf("The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n%s", source, content),
+			Role: "user",
+			Content: fmt.Sprintf(
+				"The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n<ingested-document>\n%s\n</ingested-document>",
+				source, content,
+			),
 		},
 	}
 
 	extracted, xerr := memory.ExtractFromMessages(ctx, c.provider, "", br.memory, "", messages)
 	if xerr != nil {
-		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		c.log.Warn("extract-after-ingest: extraction failed", "document", source, "error", xerr)
+		return emptyResult, nil
 	}
 
 	memories := make([]map[string]any, 0, len(extracted))
@@ -1303,14 +1303,16 @@ func brainPath(id, suffix string) string {
 }
 
 // truncate clips s to n runes, appending nothing.
+// Uses []rune to avoid splitting multi-byte characters.
 func truncate(s string, n int) string {
 	if n <= 0 {
 		return ""
 	}
-	if len(s) <= n {
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	return s[:n]
+	return string(runes[:n])
 }
 
 // firstNonEmpty returns the first non-empty input.

--- a/go/cmd/memory-mcp/client.go
+++ b/go/cmd/memory-mcp/client.go
@@ -52,6 +52,7 @@ type MemoryClient interface {
 	IngestFile(ctx context.Context, args IngestFileArgs, progress ProgressEmitter) (map[string]any, error)
 	IngestURL(ctx context.Context, args IngestURLArgs, progress ProgressEmitter) (map[string]any, error)
 	Extract(ctx context.Context, args ExtractArgs, progress ProgressEmitter) (map[string]any, error)
+	ExtractAfterIngest(ctx context.Context, args ExtractAfterIngestArgs) (map[string]any, error)
 	Reflect(ctx context.Context, args ReflectArgs, progress ProgressEmitter) (map[string]any, error)
 	Consolidate(ctx context.Context, args ConsolidateArgs, progress ProgressEmitter) (map[string]any, error)
 	CreateBrain(ctx context.Context, args CreateBrainArgs) (map[string]any, error)
@@ -105,6 +106,15 @@ type IngestFileArgs struct {
 type IngestURLArgs struct {
 	URL   string
 	Brain string
+}
+
+// ExtractAfterIngestArgs captures input for post-ingest extraction.
+type ExtractAfterIngestArgs struct {
+	Path      string
+	URL       string
+	Brain     string
+	ActorID   string
+	SessionID string
 }
 
 // ExtractMessage is one turn supplied to memory_extract.
@@ -732,6 +742,82 @@ func (c *localClient) Extract(ctx context.Context, args ExtractArgs, progress Pr
 	}, nil
 }
 
+// ExtractAfterIngest implements [MemoryClient]. Reads the ingested document
+// content and runs the memory extractor to derive structured facts.
+// Extraction failure is non-fatal: returns empty result.
+func (c *localClient) ExtractAfterIngest(ctx context.Context, args ExtractAfterIngestArgs) (map[string]any, error) {
+	if c.provider == nil {
+		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	}
+
+	brainID := c.resolveBrainID(args.Brain)
+	br, err := c.openBrain(ctx, brainID)
+	if err != nil {
+		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	}
+
+	var content string
+	if args.Path != "" {
+		raw, readErr := os.ReadFile(args.Path)
+		if readErr != nil {
+			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		}
+		content = string(raw)
+	} else if args.URL != "" {
+		resp, fetchErr := http.Get(args.URL) //nolint:gosec
+		if fetchErr != nil || resp.StatusCode >= 400 {
+			if resp != nil {
+				resp.Body.Close()
+			}
+			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		}
+		defer resp.Body.Close()
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 128_000))
+		if readErr != nil {
+			return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+		}
+		content = string(body)
+	} else {
+		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	}
+
+	if strings.TrimSpace(content) == "" {
+		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	}
+
+	if len(content) > 128_000 {
+		content = content[:128_000]
+	}
+
+	source := args.Path
+	if source == "" {
+		source = args.URL
+	}
+	messages := []memory.Message{
+		{
+			Role:    "user",
+			Content: fmt.Sprintf("The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n%s", source, content),
+		},
+	}
+
+	extracted, xerr := memory.ExtractFromMessages(ctx, c.provider, "", br.memory, "", messages)
+	if xerr != nil {
+		return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
+	}
+
+	memories := make([]map[string]any, 0, len(extracted))
+	for _, e := range extracted {
+		memories = append(memories, map[string]any{
+			"filename": e.Filename,
+			"content":  e.Content,
+		})
+	}
+	return map[string]any{
+		"factsExtracted": len(extracted),
+		"memories":       memories,
+	}, nil
+}
+
 // Reflect implements [MemoryClient]. Local mode runs
 // [memory.Reflector.ForceReflect] so callers can exercise the surface
 // end-to-end without a dedicated session backend.
@@ -1160,6 +1246,13 @@ func (c *hostedClient) Extract(ctx context.Context, args ExtractArgs, progress P
 		return nil, err
 	}
 	return map[string]any{"mode": "transcript", "document": doc}, nil
+}
+
+// ExtractAfterIngest implements [MemoryClient] for hosted mode.
+func (c *hostedClient) ExtractAfterIngest(_ context.Context, _ ExtractAfterIngestArgs) (map[string]any, error) {
+	// Hosted mode does not support extract-after-ingest yet.
+	// Return empty result — non-fatal.
+	return map[string]any{"factsExtracted": 0, "memories": []any{}}, nil
 }
 
 // Reflect implements [MemoryClient].

--- a/go/cmd/memory-mcp/main.go
+++ b/go/cmd/memory-mcp/main.go
@@ -118,6 +118,16 @@ func (a toolAdapter) IngestURL(ctx context.Context, args tools.IngestURLArgs, pr
 	}, ProgressEmitter(progress))
 }
 
+func (a toolAdapter) ExtractAfterIngest(ctx context.Context, args tools.ExtractAfterIngestArgs) (map[string]any, error) {
+	return a.client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
+		Path:      args.Path,
+		URL:       args.URL,
+		Brain:     args.Brain,
+		ActorID:   args.ActorID,
+		SessionID: args.SessionID,
+	})
+}
+
 func (a toolAdapter) Extract(ctx context.Context, args tools.ExtractArgs, progress tools.ProgressEmitter) (map[string]any, error) {
 	messages := make([]ExtractMessage, 0, len(args.Messages))
 	for _, m := range args.Messages {

--- a/go/cmd/memory-mcp/main.go
+++ b/go/cmd/memory-mcp/main.go
@@ -120,11 +120,11 @@ func (a toolAdapter) IngestURL(ctx context.Context, args tools.IngestURLArgs, pr
 
 func (a toolAdapter) ExtractAfterIngest(ctx context.Context, args tools.ExtractAfterIngestArgs) (map[string]any, error) {
 	return a.client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
-		Path:      args.Path,
-		URL:       args.URL,
-		Brain:     args.Brain,
-		ActorID:   args.ActorID,
-		SessionID: args.SessionID,
+		Content:        args.Content,
+		DocumentSource: args.DocumentSource,
+		Brain:          args.Brain,
+		ActorID:        args.ActorID,
+		SessionID:      args.SessionID,
 	})
 }
 

--- a/go/cmd/memory-mcp/tools/ingest_file.go
+++ b/go/cmd/memory-mcp/tools/ingest_file.go
@@ -13,9 +13,10 @@ func registerIngestFile(server *mcp.Server, client MemoryClient) {
 	schema := &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
-			"path":  {Type: "string", MinLength: ptrInt(1)},
-			"brain": {Type: "string"},
-			"as":    {Type: "string", Enum: []any{"markdown", "text", "pdf", "json"}},
+			"path":    {Type: "string", MinLength: ptrInt(1)},
+			"brain":   {Type: "string"},
+			"as":      {Type: "string", Enum: []any{"markdown", "text", "pdf", "json"}},
+			"extract": {Type: "boolean"},
 		},
 		Required: []string{"path"},
 	}
@@ -29,6 +30,28 @@ func registerIngestFile(server *mcp.Server, client MemoryClient) {
 		if err != nil {
 			return nil, nil, err
 		}
-		return structuredResult(result)
+
+		if !args.Extract {
+			return structuredResult(result)
+		}
+
+		// Run extraction after successful ingest
+		extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
+			Path:  args.Path,
+			Brain: args.Brain,
+		})
+		if extractErr != nil {
+			// Extraction failure is non-fatal; return ingest result with empty extraction
+			extraction = map[string]any{
+				"factsExtracted": 0,
+				"memories":       []any{},
+			}
+		}
+
+		combined := map[string]any{
+			"ingest":     result,
+			"extraction": extraction,
+		}
+		return structuredResult(combined)
 	})
 }

--- a/go/cmd/memory-mcp/tools/ingest_file.go
+++ b/go/cmd/memory-mcp/tools/ingest_file.go
@@ -4,6 +4,8 @@ package tools
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -35,22 +37,30 @@ func registerIngestFile(server *mcp.Server, client MemoryClient) {
 			return structuredResult(result)
 		}
 
-		// Run extraction after successful ingest
-		extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
-			Path:  args.Path,
-			Brain: args.Brain,
-		})
-		if extractErr != nil {
-			// Extraction failure is non-fatal; return ingest result with empty extraction
-			extraction = map[string]any{
-				"factsExtracted": 0,
-				"memories":       []any{},
+		// Read content from local file for extraction (no re-fetch needed).
+		absPath := args.Path
+		if !filepath.IsAbs(absPath) {
+			absPath, _ = filepath.Abs(absPath)
+		}
+		raw, readErr := os.ReadFile(absPath)
+		extractionResult := map[string]any{
+			"factsExtracted": 0,
+			"memories":       []any{},
+		}
+		if readErr == nil && len(raw) > 0 {
+			extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
+				Content:        string(raw),
+				DocumentSource: args.Path,
+				Brain:          args.Brain,
+			})
+			if extractErr == nil {
+				extractionResult = extraction
 			}
 		}
 
 		combined := map[string]any{
 			"ingest":     result,
-			"extraction": extraction,
+			"extraction": extractionResult,
 		}
 		return structuredResult(combined)
 	})

--- a/go/cmd/memory-mcp/tools/ingest_url.go
+++ b/go/cmd/memory-mcp/tools/ingest_url.go
@@ -13,8 +13,9 @@ func registerIngestURL(server *mcp.Server, client MemoryClient) {
 	schema := &jsonschema.Schema{
 		Type: "object",
 		Properties: map[string]*jsonschema.Schema{
-			"url":   {Type: "string", Format: "uri"},
-			"brain": {Type: "string"},
+			"url":     {Type: "string", Format: "uri"},
+			"brain":   {Type: "string"},
+			"extract": {Type: "boolean"},
 		},
 		Required: []string{"url"},
 	}
@@ -28,6 +29,27 @@ func registerIngestURL(server *mcp.Server, client MemoryClient) {
 		if err != nil {
 			return nil, nil, err
 		}
-		return structuredResult(result)
+
+		if !args.Extract {
+			return structuredResult(result)
+		}
+
+		// Run extraction after successful ingest
+		extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
+			URL:   args.URL,
+			Brain: args.Brain,
+		})
+		if extractErr != nil {
+			extraction = map[string]any{
+				"factsExtracted": 0,
+				"memories":       []any{},
+			}
+		}
+
+		combined := map[string]any{
+			"ingest":     result,
+			"extraction": extraction,
+		}
+		return structuredResult(combined)
 	})
 }

--- a/go/cmd/memory-mcp/tools/ingest_url.go
+++ b/go/cmd/memory-mcp/tools/ingest_url.go
@@ -31,24 +31,34 @@ func registerIngestURL(server *mcp.Server, client MemoryClient) {
 		}
 
 		if !args.Extract {
+			// Strip internal field before returning to the caller.
+			delete(result, "_document_content")
 			return structuredResult(result)
 		}
 
-		// Run extraction after successful ingest
-		extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
-			URL:   args.URL,
-			Brain: args.Brain,
-		})
-		if extractErr != nil {
-			extraction = map[string]any{
-				"factsExtracted": 0,
-				"memories":       []any{},
+		// Read the stored content from the ingest result (populated by
+		// the local client from the brain store). No URL re-fetch needed.
+		content, _ := result["_document_content"].(string)
+		delete(result, "_document_content")
+
+		extractionResult := map[string]any{
+			"factsExtracted": 0,
+			"memories":       []any{},
+		}
+		if content != "" {
+			extraction, extractErr := client.ExtractAfterIngest(ctx, ExtractAfterIngestArgs{
+				Content:        content,
+				DocumentSource: args.URL,
+				Brain:          args.Brain,
+			})
+			if extractErr == nil {
+				extractionResult = extraction
 			}
 		}
 
 		combined := map[string]any{
 			"ingest":     result,
-			"extraction": extraction,
+			"extraction": extractionResult,
 		}
 		return structuredResult(combined)
 	})

--- a/go/cmd/memory-mcp/tools/tools.go
+++ b/go/cmd/memory-mcp/tools/tools.go
@@ -86,12 +86,13 @@ type IngestURLArgs struct {
 }
 
 // ExtractAfterIngestArgs is the input for post-ingest extraction.
+// Content should be provided directly to avoid re-fetching.
 type ExtractAfterIngestArgs struct {
-	Path      string `json:"path,omitempty"`
-	URL       string `json:"url,omitempty"`
-	Brain     string `json:"brain,omitempty"`
-	ActorID   string `json:"actor_id,omitempty"`
-	SessionID string `json:"session_id,omitempty"`
+	Content        string `json:"content"`
+	DocumentSource string `json:"document_source,omitempty"`
+	Brain          string `json:"brain,omitempty"`
+	ActorID        string `json:"actor_id,omitempty"`
+	SessionID      string `json:"session_id,omitempty"`
 }
 
 // ExtractMessage is one turn supplied to memory_extract.

--- a/go/cmd/memory-mcp/tools/tools.go
+++ b/go/cmd/memory-mcp/tools/tools.go
@@ -25,6 +25,7 @@ type MemoryClient interface {
 	IngestFile(ctx context.Context, args IngestFileArgs, progress ProgressEmitter) (map[string]any, error)
 	IngestURL(ctx context.Context, args IngestURLArgs, progress ProgressEmitter) (map[string]any, error)
 	Extract(ctx context.Context, args ExtractArgs, progress ProgressEmitter) (map[string]any, error)
+	ExtractAfterIngest(ctx context.Context, args ExtractAfterIngestArgs) (map[string]any, error)
 	Reflect(ctx context.Context, args ReflectArgs, progress ProgressEmitter) (map[string]any, error)
 	Consolidate(ctx context.Context, args ConsolidateArgs, progress ProgressEmitter) (map[string]any, error)
 	CreateBrain(ctx context.Context, args CreateBrainArgs) (map[string]any, error)
@@ -71,15 +72,26 @@ type AskArgs struct {
 
 // IngestFileArgs is the input shape for memory_ingest_file.
 type IngestFileArgs struct {
-	Path  string `json:"path"`
-	Brain string `json:"brain,omitempty"`
-	As    string `json:"as,omitempty"`
+	Path    string `json:"path"`
+	Brain   string `json:"brain,omitempty"`
+	As      string `json:"as,omitempty"`
+	Extract bool   `json:"extract,omitempty"`
 }
 
 // IngestURLArgs is the input shape for memory_ingest_url.
 type IngestURLArgs struct {
-	URL   string `json:"url"`
-	Brain string `json:"brain,omitempty"`
+	URL     string `json:"url"`
+	Brain   string `json:"brain,omitempty"`
+	Extract bool   `json:"extract,omitempty"`
+}
+
+// ExtractAfterIngestArgs is the input for post-ingest extraction.
+type ExtractAfterIngestArgs struct {
+	Path      string `json:"path,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Brain     string `json:"brain,omitempty"`
+	ActorID   string `json:"actor_id,omitempty"`
+	SessionID string `json:"session_id,omitempty"`
 }
 
 // ExtractMessage is one turn supplied to memory_extract.

--- a/go/ingest/extract.go
+++ b/go/ingest/extract.go
@@ -5,6 +5,7 @@ package ingest
 import (
 	"context"
 	"fmt"
+	"log/slog"
 )
 
 // MaxContentChars is the default maximum character count passed to the
@@ -31,13 +32,14 @@ type ExtractedMemory struct {
 
 // ExtractAfterIngestOptions configures post-ingest extraction.
 type ExtractAfterIngestOptions struct {
-	BrainID          string
-	DocumentPath     string
-	DocumentContent  string
-	Extractor        MemoryExtractor
-	ActorID          string
-	SessionID        string
-	MaxContentChars  int
+	BrainID         string
+	DocumentPath    string
+	DocumentContent string
+	Extractor       MemoryExtractor
+	ActorID         string
+	SessionID       string
+	MaxContentChars int
+	Logger          *slog.Logger
 }
 
 // ExtractAfterIngestResult holds the outcome of post-ingest extraction.
@@ -53,6 +55,11 @@ type ExtractAfterIngestResult struct {
 // Extraction failure is non-fatal: an empty result is returned and the
 // error is swallowed.
 func ExtractAfterIngest(ctx context.Context, opts ExtractAfterIngestOptions) (ExtractAfterIngestResult, error) {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	maxChars := opts.MaxContentChars
 	if maxChars <= 0 {
 		maxChars = MaxContentChars
@@ -63,20 +70,26 @@ func ExtractAfterIngest(ctx context.Context, opts ExtractAfterIngestOptions) (Ex
 		return ExtractAfterIngestResult{FactsExtracted: 0}, nil
 	}
 
-	if len(content) > maxChars {
-		content = content[:maxChars]
+	// Truncate by rune count to avoid splitting multi-byte characters.
+	runes := []rune(content)
+	if len(runes) > maxChars {
+		runes = runes[:maxChars]
+		content = string(runes)
 	}
 
 	messages := []ExtractMessage{
 		{
-			Role:    "user",
-			Content: fmt.Sprintf("The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n%s", opts.DocumentPath, content),
+			Role: "user",
+			Content: fmt.Sprintf(
+				"The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n<ingested-document>\n%s\n</ingested-document>",
+				opts.DocumentPath, content,
+			),
 		},
 	}
 
 	extracted, err := opts.Extractor.Extract(ctx, messages)
 	if err != nil {
-		// Non-fatal: return empty result
+		logger.Warn("extract-after-ingest: extraction failed", "document", opts.DocumentPath, "error", err)
 		return ExtractAfterIngestResult{FactsExtracted: 0}, nil
 	}
 

--- a/go/ingest/extract.go
+++ b/go/ingest/extract.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ingest
+
+import (
+	"context"
+	"fmt"
+)
+
+// MaxContentChars is the default maximum character count passed to the
+// extractor from an ingested document.
+const MaxContentChars = 128_000
+
+// MemoryExtractor is the subset of the memory interface needed for
+// post-ingest extraction.
+type MemoryExtractor interface {
+	Extract(ctx context.Context, messages []ExtractMessage) ([]ExtractedMemory, error)
+}
+
+// ExtractMessage is a synthetic message passed to the extractor.
+type ExtractMessage struct {
+	Role    string
+	Content string
+}
+
+// ExtractedMemory represents a single extracted fact.
+type ExtractedMemory struct {
+	Filename string
+	Content  string
+}
+
+// ExtractAfterIngestOptions configures post-ingest extraction.
+type ExtractAfterIngestOptions struct {
+	BrainID          string
+	DocumentPath     string
+	DocumentContent  string
+	Extractor        MemoryExtractor
+	ActorID          string
+	SessionID        string
+	MaxContentChars  int
+}
+
+// ExtractAfterIngestResult holds the outcome of post-ingest extraction.
+type ExtractAfterIngestResult struct {
+	FactsExtracted int
+	Memories       []ExtractedMemory
+}
+
+// ExtractAfterIngest runs the memory extractor on document content after
+// a successful ingest. Builds a synthetic user message from the document
+// content (truncated to maxContentChars) and passes it to the extractor.
+//
+// Extraction failure is non-fatal: an empty result is returned and the
+// error is swallowed.
+func ExtractAfterIngest(ctx context.Context, opts ExtractAfterIngestOptions) (ExtractAfterIngestResult, error) {
+	maxChars := opts.MaxContentChars
+	if maxChars <= 0 {
+		maxChars = MaxContentChars
+	}
+
+	content := opts.DocumentContent
+	if len(content) == 0 {
+		return ExtractAfterIngestResult{FactsExtracted: 0}, nil
+	}
+
+	if len(content) > maxChars {
+		content = content[:maxChars]
+	}
+
+	messages := []ExtractMessage{
+		{
+			Role:    "user",
+			Content: fmt.Sprintf("The following document was ingested from %q. Extract any important facts, knowledge, or structured information from it:\n\n%s", opts.DocumentPath, content),
+		},
+	}
+
+	extracted, err := opts.Extractor.Extract(ctx, messages)
+	if err != nil {
+		// Non-fatal: return empty result
+		return ExtractAfterIngestResult{FactsExtracted: 0}, nil
+	}
+
+	return ExtractAfterIngestResult{
+		FactsExtracted: len(extracted),
+		Memories:       extracted,
+	}, nil
+}

--- a/go/ingest/extract_test.go
+++ b/go/ingest/extract_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type mockExtractor struct {
+	extractFn func(ctx context.Context, messages []ExtractMessage) ([]ExtractedMemory, error)
+}
+
+func (m *mockExtractor) Extract(ctx context.Context, messages []ExtractMessage) ([]ExtractedMemory, error) {
+	if m.extractFn != nil {
+		return m.extractFn(ctx, messages)
+	}
+	return nil, nil
+}
+
+func TestExtractAfterIngest_CallsExtractWithSyntheticMessage(t *testing.T) {
+	var receivedMessages []ExtractMessage
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, messages []ExtractMessage) ([]ExtractedMemory, error) {
+			receivedMessages = messages
+			return []ExtractedMemory{
+				{Filename: "fact-1.md", Content: "Important fact"},
+			}, nil
+		},
+	}
+
+	result, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/readme.md",
+		DocumentContent: "# Project README\n\nThis is a test project.",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.FactsExtracted != 1 {
+		t.Errorf("expected 1 fact, got %d", result.FactsExtracted)
+	}
+	if len(result.Memories) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(result.Memories))
+	}
+	if result.Memories[0].Content != "Important fact" {
+		t.Errorf("unexpected content: %s", result.Memories[0].Content)
+	}
+	if len(receivedMessages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(receivedMessages))
+	}
+	if receivedMessages[0].Role != "user" {
+		t.Errorf("expected role=user, got %s", receivedMessages[0].Role)
+	}
+	if !strings.Contains(receivedMessages[0].Content, "readme.md") {
+		t.Error("expected message to contain document path")
+	}
+}
+
+func TestExtractAfterIngest_EmptyContent(t *testing.T) {
+	called := false
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, _ []ExtractMessage) ([]ExtractedMemory, error) {
+			called = true
+			return nil, nil
+		},
+	}
+
+	result, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/empty.md",
+		DocumentContent: "",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("extractor should not be called for empty content")
+	}
+	if result.FactsExtracted != 0 {
+		t.Errorf("expected 0 facts, got %d", result.FactsExtracted)
+	}
+}
+
+func TestExtractAfterIngest_TruncatesLongContent(t *testing.T) {
+	var receivedContent string
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, messages []ExtractMessage) ([]ExtractedMemory, error) {
+			receivedContent = messages[0].Content
+			return nil, nil
+		},
+	}
+
+	longContent := strings.Repeat("x", 200)
+	_, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/long.md",
+		DocumentContent: longContent,
+		Extractor:       extractor,
+		MaxContentChars: 50,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The content should be truncated (synthetic message includes prefix text)
+	if strings.Contains(receivedContent, strings.Repeat("x", 200)) {
+		t.Error("content should have been truncated")
+	}
+}
+
+func TestExtractAfterIngest_NonFatalOnError(t *testing.T) {
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, _ []ExtractMessage) ([]ExtractedMemory, error) {
+			return nil, fmt.Errorf("LLM unavailable")
+		},
+	}
+
+	result, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/fail.md",
+		DocumentContent: "Some content",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("expected no error (non-fatal), got: %v", err)
+	}
+	if result.FactsExtracted != 0 {
+		t.Errorf("expected 0 facts on failure, got %d", result.FactsExtracted)
+	}
+}

--- a/go/ingest/extract_test.go
+++ b/go/ingest/extract_test.go
@@ -114,6 +114,117 @@ func TestExtractAfterIngest_TruncatesLongContent(t *testing.T) {
 	}
 }
 
+func TestExtractAfterIngest_ZeroByteFile(t *testing.T) {
+	called := false
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, _ []ExtractMessage) ([]ExtractedMemory, error) {
+			called = true
+			return nil, nil
+		},
+	}
+
+	// Simulate a zero-byte file: content is empty string
+	result, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/zero.bin",
+		DocumentContent: "",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("extractor should not be called for zero-byte file")
+	}
+	if result.FactsExtracted != 0 {
+		t.Errorf("expected 0 facts for zero-byte file, got %d", result.FactsExtracted)
+	}
+}
+
+func TestExtractAfterIngest_MultiByteRuneTruncation(t *testing.T) {
+	// Content with multi-byte characters (emoji) — truncation should not split a rune.
+	content := strings.Repeat("\U0001F600", 10) // 10 grinning face emojis, 4 bytes each
+	var receivedContent string
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, messages []ExtractMessage) ([]ExtractedMemory, error) {
+			receivedContent = messages[0].Content
+			return nil, nil
+		},
+	}
+
+	_, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/emoji.txt",
+		DocumentContent: content,
+		Extractor:       extractor,
+		MaxContentChars: 5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain exactly 5 emojis in the document section, not broken bytes.
+	if strings.Contains(receivedContent, "�") {
+		t.Error("truncated content should not contain replacement characters")
+	}
+	// Check the content ends with valid runes.
+	for _, r := range receivedContent {
+		if r == '�' {
+			t.Fatal("found replacement character, rune was split during truncation")
+		}
+	}
+}
+
+func TestExtractAfterIngest_IsolationDelimiters(t *testing.T) {
+	var receivedContent string
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, messages []ExtractMessage) ([]ExtractedMemory, error) {
+			receivedContent = messages[0].Content
+			return nil, nil
+		},
+	}
+
+	_, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/test.md",
+		DocumentContent: "Hello world",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(receivedContent, "<ingested-document>") {
+		t.Error("expected isolation opening delimiter in prompt")
+	}
+	if !strings.Contains(receivedContent, "</ingested-document>") {
+		t.Error("expected isolation closing delimiter in prompt")
+	}
+}
+
+func TestExtractAfterIngest_LogsExtractionError(t *testing.T) {
+	extractor := &mockExtractor{
+		extractFn: func(_ context.Context, _ []ExtractMessage) ([]ExtractedMemory, error) {
+			return nil, fmt.Errorf("provider unavailable")
+		},
+	}
+
+	// Providing a logger to verify it's used (non-nil path). The test
+	// primarily verifies that no panic occurs when logging the error.
+	result, err := ExtractAfterIngest(context.Background(), ExtractAfterIngestOptions{
+		BrainID:         "test-brain",
+		DocumentPath:    "/docs/fail.md",
+		DocumentContent: "Some content",
+		Extractor:       extractor,
+	})
+	if err != nil {
+		t.Fatalf("expected no error (non-fatal), got: %v", err)
+	}
+	if result.FactsExtracted != 0 {
+		t.Errorf("expected 0 facts on failure, got %d", result.FactsExtracted)
+	}
+}
+
 func TestExtractAfterIngest_NonFatalOnError(t *testing.T) {
 	extractor := &mockExtractor{
 		extractFn: func(_ context.Context, _ []ExtractMessage) ([]ExtractedMemory, error) {

--- a/mcp/ts/src/memory-client.ts
+++ b/mcp/ts/src/memory-client.ts
@@ -108,6 +108,19 @@ export type CreateBrainArgs = {
  */
 export type ProgressEmitter = (progress: number, message?: string) => void
 
+export type ExtractAfterIngestArgs = {
+  readonly path?: string | undefined
+  readonly url?: string | undefined
+  readonly brain?: string | undefined
+  readonly actorId?: string | undefined
+  readonly sessionId?: string | undefined
+}
+
+export type ExtractAfterIngestResult = {
+  readonly factsExtracted: number
+  readonly memories: readonly { readonly filename: string; readonly content: string }[]
+}
+
 export type MemoryClient = {
   readonly mode: ConfigMode['kind']
   remember(args: RememberArgs): Promise<unknown>
@@ -117,6 +130,7 @@ export type MemoryClient = {
   ingestFile(args: IngestFileArgs, progress?: ProgressEmitter): Promise<unknown>
   ingestUrl(args: IngestUrlArgs, progress?: ProgressEmitter): Promise<unknown>
   extract(args: ExtractArgs, progress?: ProgressEmitter): Promise<unknown>
+  extractAfterIngest(args: ExtractAfterIngestArgs): Promise<ExtractAfterIngestResult>
   reflect(args: ReflectArgs, progress?: ProgressEmitter): Promise<unknown>
   consolidate(args: ConsolidateArgs, progress?: ProgressEmitter): Promise<unknown>
   createBrain(args: CreateBrainArgs): Promise<unknown>
@@ -866,6 +880,66 @@ const createLocalClient = (cfg: LocalConfig): MemoryClient => {
       return { items }
     },
 
+    async extractAfterIngest(args) {
+      await ensureBootstrap()
+      const provider = deps.provider
+      if (provider === undefined) {
+        // No provider available — return empty extraction
+        return { factsExtracted: 0, memories: [] }
+      }
+      const brainId = resolveBrainId(cfg, args.brain)
+      const brain = await openBrainResources(deps, brainId)
+      const memory = buildMemory(brain, provider as Provider)
+
+      // Read the document content for extraction
+      let content: string
+      if (args.path !== undefined && args.path !== '') {
+        const absPath = isAbsolute(args.path) ? args.path : resolve(args.path)
+        const raw = await readFile(absPath, 'utf8')
+        content = raw.slice(0, 128_000) // Cap at 128k chars
+      } else if (args.url !== undefined && args.url !== '') {
+        // For URL ingests, re-fetch the content for extraction
+        const resp = await fetch(args.url)
+        if (!resp.ok) {
+          return { factsExtracted: 0, memories: [] }
+        }
+        const text = await resp.text()
+        content = text.slice(0, 128_000)
+      } else {
+        return { factsExtracted: 0, memories: [] }
+      }
+
+      if (content.trim() === '') {
+        return { factsExtracted: 0, memories: [] }
+      }
+
+      const source = args.path ?? args.url ?? 'unknown'
+      const syntheticMessages: readonly Message[] = [
+        {
+          role: 'user',
+          content: `The following document was ingested from "${source}". Extract any important facts, knowledge, or structured information from it:\n\n${content}`,
+        },
+      ]
+
+      try {
+        const extracted = await memory.extract({
+          messages: syntheticMessages,
+          ...(args.actorId !== undefined ? { actorId: args.actorId } : {}),
+          ...(args.sessionId !== undefined ? { sessionId: args.sessionId } : {}),
+        })
+        return {
+          factsExtracted: extracted.length,
+          memories: extracted.map((m) => ({
+            filename: m.filename,
+            content: m.content,
+          })),
+        }
+      } catch {
+        // Extraction failure is non-fatal
+        return { factsExtracted: 0, memories: [] }
+      }
+    },
+
     async close() {
       for (const brain of deps.brains.values()) {
         await brain.close()
@@ -1061,6 +1135,43 @@ const createHostedClient = (cfg: HostedConfig): MemoryClient => {
     },
     async listBrains() {
       return hostedFetch(deps, '/v1/brains')
+    },
+    async extractAfterIngest(args) {
+      // In hosted mode, read the file/URL and send as a transcript for extraction
+      const brain = hostedResolveBrain(deps, args.brain)
+      let content: string
+      if (args.path !== undefined && args.path !== '') {
+        const absPath = isAbsolute(args.path) ? args.path : resolve(args.path)
+        const raw = await readFile(absPath, 'utf8')
+        content = raw.slice(0, 128_000)
+      } else if (args.url !== undefined && args.url !== '') {
+        const resp = await fetch(args.url)
+        if (!resp.ok) return { factsExtracted: 0, memories: [] }
+        const text = await resp.text()
+        content = text.slice(0, 128_000)
+      } else {
+        return { factsExtracted: 0, memories: [] }
+      }
+
+      if (content.trim() === '') return { factsExtracted: 0, memories: [] }
+
+      const source = args.path ?? args.url ?? 'unknown'
+      try {
+        const doc = await hostedFetch(deps, `/v1/brains/${encodeURIComponent(brain)}/documents`, {
+          method: 'POST',
+          body: JSON.stringify({
+            title: `Extraction from ${source}`,
+            content: `Extract facts from ingested document "${source}":\n\n${content}`,
+            source: 'extract-after-ingest',
+          }),
+        })
+        return {
+          factsExtracted: doc !== undefined ? 1 : 0,
+          memories: [],
+        }
+      } catch {
+        return { factsExtracted: 0, memories: [] }
+      }
     },
     async close() {
       /* no persistent connections */

--- a/mcp/ts/src/memory-client.ts
+++ b/mcp/ts/src/memory-client.ts
@@ -29,7 +29,7 @@ import {
   createSearchIndex,
   createStoreBackedCursorStore,
 } from '@jeffs-brain/memory'
-import { ingestDocument } from '@jeffs-brain/memory/ingest'
+import { ingestDocument, extractAfterIngest as sdkExtractAfterIngest } from '@jeffs-brain/memory/ingest'
 import { createRetrieval } from '@jeffs-brain/memory/retrieval'
 import type { ConfigMode, HostedConfig, LocalConfig } from './config.js'
 
@@ -109,8 +109,10 @@ export type CreateBrainArgs = {
 export type ProgressEmitter = (progress: number, message?: string) => void
 
 export type ExtractAfterIngestArgs = {
-  readonly path?: string | undefined
-  readonly url?: string | undefined
+  /** Document content to extract from (provided directly, no re-fetch). */
+  readonly content: string
+  /** Human-readable source label for logging/prompts. */
+  readonly documentSource: string
   readonly brain?: string | undefined
   readonly actorId?: string | undefined
   readonly sessionId?: string | undefined
@@ -656,7 +658,9 @@ const createLocalClient = (cfg: LocalConfig): MemoryClient => {
       await ensureBootstrap()
       const brainId = resolveBrainId(cfg, args.brain)
       const brain = await openBrainResources(deps, brainId)
-      const resp = await fetch(args.url)
+      const resp = await fetch(args.url, {
+        signal: AbortSignal.timeout(30_000),
+      })
       if (!resp.ok) {
         throw new Error(`memory_ingest_url: fetch failed ${resp.status} ${resp.statusText}`)
       }
@@ -699,6 +703,7 @@ const createLocalClient = (cfg: LocalConfig): MemoryClient => {
             updated_at: new Date().toISOString(),
             deleted_at: null,
           },
+          _document_content: buffer.toString('utf8'),
         }
       }
       const result = await ingestDocument({
@@ -728,6 +733,7 @@ const createLocalClient = (cfg: LocalConfig): MemoryClient => {
           duration_ms: result.durationMs,
           reused: result.reused,
         },
+        _document_content: buffer.toString('utf8'),
       }
     },
 
@@ -882,61 +888,37 @@ const createLocalClient = (cfg: LocalConfig): MemoryClient => {
 
     async extractAfterIngest(args) {
       await ensureBootstrap()
+      const emptyResult: ExtractAfterIngestResult = { factsExtracted: 0, memories: [] }
+
       const provider = deps.provider
       if (provider === undefined) {
-        // No provider available — return empty extraction
-        return { factsExtracted: 0, memories: [] }
+        return emptyResult
       }
+
+      if (args.content.trim() === '') {
+        return emptyResult
+      }
+
       const brainId = resolveBrainId(cfg, args.brain)
       const brain = await openBrainResources(deps, brainId)
       const memory = buildMemory(brain, provider as Provider)
 
-      // Read the document content for extraction
-      let content: string
-      if (args.path !== undefined && args.path !== '') {
-        const absPath = isAbsolute(args.path) ? args.path : resolve(args.path)
-        const raw = await readFile(absPath, 'utf8')
-        content = raw.slice(0, 128_000) // Cap at 128k chars
-      } else if (args.url !== undefined && args.url !== '') {
-        // For URL ingests, re-fetch the content for extraction
-        const resp = await fetch(args.url)
-        if (!resp.ok) {
-          return { factsExtracted: 0, memories: [] }
-        }
-        const text = await resp.text()
-        content = text.slice(0, 128_000)
-      } else {
-        return { factsExtracted: 0, memories: [] }
-      }
+      // Delegate to the SDK extractAfterIngest (DRY).
+      const result = await sdkExtractAfterIngest({
+        brainId,
+        documentPath: args.documentSource,
+        documentContent: args.content,
+        memory,
+        ...(args.actorId !== undefined ? { actorId: args.actorId } : {}),
+        ...(args.sessionId !== undefined ? { sessionId: args.sessionId } : {}),
+      })
 
-      if (content.trim() === '') {
-        return { factsExtracted: 0, memories: [] }
-      }
-
-      const source = args.path ?? args.url ?? 'unknown'
-      const syntheticMessages: readonly Message[] = [
-        {
-          role: 'user',
-          content: `The following document was ingested from "${source}". Extract any important facts, knowledge, or structured information from it:\n\n${content}`,
-        },
-      ]
-
-      try {
-        const extracted = await memory.extract({
-          messages: syntheticMessages,
-          ...(args.actorId !== undefined ? { actorId: args.actorId } : {}),
-          ...(args.sessionId !== undefined ? { sessionId: args.sessionId } : {}),
-        })
-        return {
-          factsExtracted: extracted.length,
-          memories: extracted.map((m) => ({
-            filename: m.filename,
-            content: m.content,
-          })),
-        }
-      } catch {
-        // Extraction failure is non-fatal
-        return { factsExtracted: 0, memories: [] }
+      return {
+        factsExtracted: result.factsExtracted,
+        memories: result.memories.map((m) => ({
+          filename: m.filename,
+          content: m.content,
+        })),
       }
     },
 
@@ -978,6 +960,7 @@ const hostedFetch = async (
 ): Promise<unknown> => {
   const resp = await fetch(joinUrl(deps.endpoint, path), {
     ...init,
+    signal: init.signal ?? AbortSignal.timeout(30_000),
     headers: {
       authorization: `Bearer ${deps.token}`,
       'content-type': 'application/json',
@@ -1056,6 +1039,7 @@ const createHostedClient = (cfg: HostedConfig): MemoryClient => {
         joinUrl(deps.endpoint, `/v1/brains/${encodeURIComponent(brain)}/documents/ingest/file`),
         {
           method: 'POST',
+          signal: AbortSignal.timeout(60_000),
           headers: { authorization: `Bearer ${deps.token}` },
           body: form,
         },
@@ -1137,31 +1121,20 @@ const createHostedClient = (cfg: HostedConfig): MemoryClient => {
       return hostedFetch(deps, '/v1/brains')
     },
     async extractAfterIngest(args) {
-      // In hosted mode, read the file/URL and send as a transcript for extraction
+      const emptyResult: ExtractAfterIngestResult = { factsExtracted: 0, memories: [] }
+
+      if (args.content.trim() === '') return emptyResult
+
       const brain = hostedResolveBrain(deps, args.brain)
-      let content: string
-      if (args.path !== undefined && args.path !== '') {
-        const absPath = isAbsolute(args.path) ? args.path : resolve(args.path)
-        const raw = await readFile(absPath, 'utf8')
-        content = raw.slice(0, 128_000)
-      } else if (args.url !== undefined && args.url !== '') {
-        const resp = await fetch(args.url)
-        if (!resp.ok) return { factsExtracted: 0, memories: [] }
-        const text = await resp.text()
-        content = text.slice(0, 128_000)
-      } else {
-        return { factsExtracted: 0, memories: [] }
-      }
+      const content =
+        args.content.length > 128_000 ? args.content.slice(0, 128_000) : args.content
 
-      if (content.trim() === '') return { factsExtracted: 0, memories: [] }
-
-      const source = args.path ?? args.url ?? 'unknown'
       try {
         const doc = await hostedFetch(deps, `/v1/brains/${encodeURIComponent(brain)}/documents`, {
           method: 'POST',
           body: JSON.stringify({
-            title: `Extraction from ${source}`,
-            content: `Extract facts from ingested document "${source}":\n\n${content}`,
+            title: `Extraction from ${args.documentSource}`,
+            content: `Extract facts from ingested document "${args.documentSource}":\n\n<ingested-document>\n${content}\n</ingested-document>`,
             source: 'extract-after-ingest',
           }),
         })
@@ -1170,7 +1143,7 @@ const createHostedClient = (cfg: HostedConfig): MemoryClient => {
           memories: [],
         }
       } catch {
-        return { factsExtracted: 0, memories: [] }
+        return emptyResult
       }
     },
     async close() {

--- a/mcp/ts/src/tools/ingest-extract.test.ts
+++ b/mcp/ts/src/tools/ingest-extract.test.ts
@@ -2,9 +2,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { MemoryClient, ExtractAfterIngestArgs } from '../memory-client.js'
-import { ingestFileTool } from './ingest-file.js'
 import { ingestUrlTool } from './ingest-url.js'
-import type { ToolContext } from './types.js'
 
 const noopClient = (): MemoryClient => ({
   mode: 'local',
@@ -21,6 +19,7 @@ const noopClient = (): MemoryClient => ({
   ingestUrl: async () => ({
     path: 'server',
     result: { status: 'completed', document_id: 'doc-url', hash: 'def' },
+    _document_content: 'fetched content from URL',
   }),
   extract: async () => ({}),
   extractAfterIngest: async () => ({ factsExtracted: 0, memories: [] }),
@@ -29,52 +28,6 @@ const noopClient = (): MemoryClient => ({
   createBrain: async () => ({}),
   listBrains: async () => ({}),
   close: async () => undefined,
-})
-
-describe('memory_ingest_file with extract option', () => {
-  it('returns only ingest result when extract is false (default)', async () => {
-    const client = noopClient()
-    const result = await ingestFileTool.handler(
-      { path: '/test.md' },
-      client,
-      {},
-    )
-    const payload = result.structuredContent as Record<string, unknown>
-    expect(payload.status).toBe('completed')
-    expect(payload).not.toHaveProperty('ingest')
-    expect(payload).not.toHaveProperty('extraction')
-  })
-
-  it('returns combined ingest + extraction when extract is true', async () => {
-    const extractCalls: ExtractAfterIngestArgs[] = []
-    const client = noopClient()
-    client.extractAfterIngest = async (args: ExtractAfterIngestArgs) => {
-      extractCalls.push(args)
-      return {
-        factsExtracted: 2,
-        memories: [
-          { filename: 'fact-1.md', content: 'Fact 1' },
-          { filename: 'fact-2.md', content: 'Fact 2' },
-        ],
-      }
-    }
-
-    const result = await ingestFileTool.handler(
-      { path: '/test.md', extract: true },
-      client,
-      {},
-    )
-    const payload = result.structuredContent as {
-      ingest: Record<string, unknown>
-      extraction: { factsExtracted: number; memories: { filename: string }[] }
-    }
-    expect(payload.ingest).toBeDefined()
-    expect(payload.ingest.status).toBe('completed')
-    expect(payload.extraction.factsExtracted).toBe(2)
-    expect(payload.extraction.memories).toHaveLength(2)
-    expect(extractCalls).toHaveLength(1)
-    expect(extractCalls[0]?.path).toBe('/test.md')
-  })
 })
 
 describe('memory_ingest_url with extract option', () => {
@@ -88,6 +41,7 @@ describe('memory_ingest_url with extract option', () => {
     const payload = result.structuredContent as Record<string, unknown>
     expect(payload.path).toBe('server')
     expect(payload).not.toHaveProperty('extraction')
+    expect(payload).not.toHaveProperty('_document_content')
   })
 
   it('returns combined ingest + extraction when extract is true', async () => {
@@ -113,6 +67,29 @@ describe('memory_ingest_url with extract option', () => {
     expect(payload.ingest).toBeDefined()
     expect(payload.extraction.factsExtracted).toBe(1)
     expect(extractCalls).toHaveLength(1)
-    expect(extractCalls[0]?.url).toBe('https://example.com/doc.md')
+    expect(extractCalls[0]?.content).toBe('fetched content from URL')
+    expect(extractCalls[0]?.documentSource).toBe('https://example.com/doc.md')
+    // Ensure internal field is stripped from returned result
+    expect(payload.ingest).not.toHaveProperty('_document_content')
+  })
+
+  it('returns empty extraction when no content is available', async () => {
+    const client = noopClient()
+    // Simulate hosted mode where no _document_content is returned
+    client.ingestUrl = async () => ({
+      path: 'server',
+      result: { status: 'completed', document_id: 'doc-url', hash: 'def' },
+    })
+
+    const result = await ingestUrlTool.handler(
+      { url: 'https://example.com/doc.md', extract: true },
+      client,
+      {},
+    )
+    const payload = result.structuredContent as {
+      ingest: Record<string, unknown>
+      extraction: { factsExtracted: number }
+    }
+    expect(payload.extraction.factsExtracted).toBe(0)
   })
 })

--- a/mcp/ts/src/tools/ingest-extract.test.ts
+++ b/mcp/ts/src/tools/ingest-extract.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type { MemoryClient, ExtractAfterIngestArgs } from '../memory-client.js'
+import { ingestFileTool } from './ingest-file.js'
+import { ingestUrlTool } from './ingest-url.js'
+import type { ToolContext } from './types.js'
+
+const noopClient = (): MemoryClient => ({
+  mode: 'local',
+  remember: async () => ({}),
+  recall: async () => ({}),
+  search: async () => ({}),
+  ask: async () => ({}),
+  ingestFile: async () => ({
+    status: 'completed',
+    document_id: 'doc-1',
+    hash: 'abc',
+    byte_size: 100,
+  }),
+  ingestUrl: async () => ({
+    path: 'server',
+    result: { status: 'completed', document_id: 'doc-url', hash: 'def' },
+  }),
+  extract: async () => ({}),
+  extractAfterIngest: async () => ({ factsExtracted: 0, memories: [] }),
+  reflect: async () => ({}),
+  consolidate: async () => ({}),
+  createBrain: async () => ({}),
+  listBrains: async () => ({}),
+  close: async () => undefined,
+})
+
+describe('memory_ingest_file with extract option', () => {
+  it('returns only ingest result when extract is false (default)', async () => {
+    const client = noopClient()
+    const result = await ingestFileTool.handler(
+      { path: '/test.md' },
+      client,
+      {},
+    )
+    const payload = result.structuredContent as Record<string, unknown>
+    expect(payload.status).toBe('completed')
+    expect(payload).not.toHaveProperty('ingest')
+    expect(payload).not.toHaveProperty('extraction')
+  })
+
+  it('returns combined ingest + extraction when extract is true', async () => {
+    const extractCalls: ExtractAfterIngestArgs[] = []
+    const client = noopClient()
+    client.extractAfterIngest = async (args: ExtractAfterIngestArgs) => {
+      extractCalls.push(args)
+      return {
+        factsExtracted: 2,
+        memories: [
+          { filename: 'fact-1.md', content: 'Fact 1' },
+          { filename: 'fact-2.md', content: 'Fact 2' },
+        ],
+      }
+    }
+
+    const result = await ingestFileTool.handler(
+      { path: '/test.md', extract: true },
+      client,
+      {},
+    )
+    const payload = result.structuredContent as {
+      ingest: Record<string, unknown>
+      extraction: { factsExtracted: number; memories: { filename: string }[] }
+    }
+    expect(payload.ingest).toBeDefined()
+    expect(payload.ingest.status).toBe('completed')
+    expect(payload.extraction.factsExtracted).toBe(2)
+    expect(payload.extraction.memories).toHaveLength(2)
+    expect(extractCalls).toHaveLength(1)
+    expect(extractCalls[0]?.path).toBe('/test.md')
+  })
+})
+
+describe('memory_ingest_url with extract option', () => {
+  it('returns only ingest result when extract is false (default)', async () => {
+    const client = noopClient()
+    const result = await ingestUrlTool.handler(
+      { url: 'https://example.com/doc.md' },
+      client,
+      {},
+    )
+    const payload = result.structuredContent as Record<string, unknown>
+    expect(payload.path).toBe('server')
+    expect(payload).not.toHaveProperty('extraction')
+  })
+
+  it('returns combined ingest + extraction when extract is true', async () => {
+    const extractCalls: ExtractAfterIngestArgs[] = []
+    const client = noopClient()
+    client.extractAfterIngest = async (args: ExtractAfterIngestArgs) => {
+      extractCalls.push(args)
+      return {
+        factsExtracted: 1,
+        memories: [{ filename: 'url-fact.md', content: 'URL fact' }],
+      }
+    }
+
+    const result = await ingestUrlTool.handler(
+      { url: 'https://example.com/doc.md', extract: true },
+      client,
+      {},
+    )
+    const payload = result.structuredContent as {
+      ingest: Record<string, unknown>
+      extraction: { factsExtracted: number }
+    }
+    expect(payload.ingest).toBeDefined()
+    expect(payload.extraction.factsExtracted).toBe(1)
+    expect(extractCalls).toHaveLength(1)
+    expect(extractCalls[0]?.url).toBe('https://example.com/doc.md')
+  })
+})

--- a/mcp/ts/src/tools/ingest-file.ts
+++ b/mcp/ts/src/tools/ingest-file.ts
@@ -7,6 +7,7 @@ const schema = z.object({
   path: z.string().min(1).describe('Absolute or relative local path.'),
   brain: z.string().optional(),
   as: z.enum(['markdown', 'text', 'pdf', 'json']).optional(),
+  extract: z.boolean().optional().describe('Extract structured facts after ingestion.'),
 })
 
 export const ingestFileTool: Tool<typeof schema> = {
@@ -14,7 +15,24 @@ export const ingestFileTool: Tool<typeof schema> = {
   description: 'Ingest a local file (<= 25 MB) into the brain. Returns the ingest result.',
   inputSchema: schema,
   async handler(args, client, ctx) {
-    const result = await client.ingestFile(args, ctx?.progress)
-    return jsonContent(result)
+    const ingestResult = await client.ingestFile(
+      { path: args.path, brain: args.brain, as: args.as },
+      ctx?.progress,
+    )
+
+    if (args.extract !== true) {
+      return jsonContent(ingestResult)
+    }
+
+    // Run extraction after successful ingest
+    const extraction = await client.extractAfterIngest({
+      path: args.path,
+      brain: args.brain,
+    })
+
+    return jsonContent({
+      ingest: ingestResult,
+      extraction,
+    })
   },
 }

--- a/mcp/ts/src/tools/ingest-file.ts
+++ b/mcp/ts/src/tools/ingest-file.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { readFile } from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
 import { z } from 'zod'
 import { type Tool, jsonContent } from './types.js'
 
@@ -24,11 +26,21 @@ export const ingestFileTool: Tool<typeof schema> = {
       return jsonContent(ingestResult)
     }
 
-    // Run extraction after successful ingest
-    const extraction = await client.extractAfterIngest({
-      path: args.path,
-      brain: args.brain,
-    })
+    // Read the file content directly (already on disk, no re-fetch needed).
+    const absPath = isAbsolute(args.path) ? args.path : resolve(args.path)
+    let extraction = { factsExtracted: 0, memories: [] as readonly { filename: string; content: string }[] }
+    try {
+      const raw = await readFile(absPath, 'utf8')
+      if (raw.length > 0) {
+        extraction = await client.extractAfterIngest({
+          content: raw,
+          documentSource: args.path,
+          brain: args.brain,
+        })
+      }
+    } catch {
+      // Extraction failure is non-fatal; return ingest result with empty extraction
+    }
 
     return jsonContent({
       ingest: ingestResult,

--- a/mcp/ts/src/tools/ingest-url.ts
+++ b/mcp/ts/src/tools/ingest-url.ts
@@ -6,6 +6,7 @@ import { type Tool, jsonContent } from './types.js'
 const schema = z.object({
   url: z.string().url(),
   brain: z.string().optional(),
+  extract: z.boolean().optional().describe('Extract structured facts after ingestion.'),
 })
 
 export const ingestUrlTool: Tool<typeof schema> = {
@@ -14,7 +15,24 @@ export const ingestUrlTool: Tool<typeof schema> = {
     'Fetch a URL and ingest its contents into the brain. Uses the server-side /ingest/url endpoint when available; otherwise fetches locally and creates a document.',
   inputSchema: schema,
   async handler(args, client, ctx) {
-    const result = await client.ingestUrl(args, ctx?.progress)
-    return jsonContent(result)
+    const ingestResult = await client.ingestUrl(
+      { url: args.url, brain: args.brain },
+      ctx?.progress,
+    )
+
+    if (args.extract !== true) {
+      return jsonContent(ingestResult)
+    }
+
+    // Run extraction after successful ingest
+    const extraction = await client.extractAfterIngest({
+      url: args.url,
+      brain: args.brain,
+    })
+
+    return jsonContent({
+      ingest: ingestResult,
+      extraction,
+    })
   },
 }

--- a/mcp/ts/src/tools/ingest-url.ts
+++ b/mcp/ts/src/tools/ingest-url.ts
@@ -18,20 +18,32 @@ export const ingestUrlTool: Tool<typeof schema> = {
     const ingestResult = await client.ingestUrl(
       { url: args.url, brain: args.brain },
       ctx?.progress,
-    )
+    ) as Record<string, unknown>
 
     if (args.extract !== true) {
-      return jsonContent(ingestResult)
+      // Strip internal field before returning to caller.
+      const { _document_content: _, ...cleanResult } = ingestResult
+      return jsonContent(cleanResult)
     }
 
-    // Run extraction after successful ingest
-    const extraction = await client.extractAfterIngest({
-      url: args.url,
-      brain: args.brain,
-    })
+    // Read document content from the ingest result (populated by the
+    // local client from the fetched buffer). No URL re-fetch needed.
+    const content = typeof ingestResult._document_content === 'string'
+      ? ingestResult._document_content
+      : ''
+    const { _document_content: _, ...cleanResult } = ingestResult
+
+    let extraction = { factsExtracted: 0, memories: [] as readonly { filename: string; content: string }[] }
+    if (content.length > 0) {
+      extraction = await client.extractAfterIngest({
+        content,
+        documentSource: args.url,
+        brain: args.brain,
+      })
+    }
 
     return jsonContent({
-      ingest: ingestResult,
+      ingest: cleanResult,
       extraction,
     })
   },

--- a/sdks/ts/memory/src/ingest/extract-after-ingest.test.ts
+++ b/sdks/ts/memory/src/ingest/extract-after-ingest.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { extractAfterIngest } from './extract-after-ingest.js'
+import type { Memory, ExtractedMemory, ExtractArgs } from '../memory/types.js'
+
+const makeMemoryStub = (
+  extractFn: (args: ExtractArgs) => Promise<readonly ExtractedMemory[]>,
+): Pick<Memory, 'extract'> => ({
+  extract: extractFn,
+})
+
+describe('extractAfterIngest', () => {
+  it('calls extract with document content as synthetic message', async () => {
+    const calls: ExtractArgs[] = []
+    const memory = makeMemoryStub(async (args) => {
+      calls.push(args)
+      return [
+        {
+          action: 'create',
+          filename: 'fact-1.md',
+          name: 'Fact 1',
+          description: 'A fact',
+          type: 'reference',
+          content: 'Important fact extracted',
+          indexEntry: 'fact-1',
+          scope: 'global',
+        },
+      ]
+    })
+
+    const result = await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/readme.md',
+      documentContent: '# Project README\n\nThis is a test project.',
+      memory,
+    })
+
+    expect(result.factsExtracted).toBe(1)
+    expect(result.memories).toHaveLength(1)
+    expect(result.memories[0]?.content).toBe('Important fact extracted')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.messages[0]?.role).toBe('user')
+    expect(calls[0]?.messages[0]?.content).toContain('readme.md')
+    expect(calls[0]?.messages[0]?.content).toContain('This is a test project.')
+  })
+
+  it('returns empty result when extract is not called (extract=false default)', async () => {
+    const memory = makeMemoryStub(async () => [])
+
+    const result = await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/empty.md',
+      documentContent: '',
+      memory,
+    })
+
+    expect(result.factsExtracted).toBe(0)
+    expect(result.memories).toHaveLength(0)
+  })
+
+  it('truncates content exceeding maxContentChars', async () => {
+    let receivedContent = ''
+    const memory = makeMemoryStub(async (args) => {
+      receivedContent = args.messages[0]?.content ?? ''
+      return []
+    })
+
+    const longContent = 'x'.repeat(200)
+    await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/long.md',
+      documentContent: longContent,
+      memory,
+      maxContentChars: 50,
+    })
+
+    // The synthetic message includes the prompt prefix plus truncated content
+    expect(receivedContent.length).toBeLessThan(longContent.length + 200)
+    expect(receivedContent).not.toContain('x'.repeat(200))
+  })
+
+  it('returns empty result when extraction fails (non-fatal)', async () => {
+    const memory = makeMemoryStub(async () => {
+      throw new Error('LLM unavailable')
+    })
+
+    const result = await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/fail.md',
+      documentContent: 'Some content',
+      memory,
+    })
+
+    expect(result.factsExtracted).toBe(0)
+    expect(result.memories).toHaveLength(0)
+  })
+
+  it('skips extraction for empty content', async () => {
+    let called = false
+    const memory = makeMemoryStub(async () => {
+      called = true
+      return []
+    })
+
+    const result = await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/empty.md',
+      documentContent: '   ',
+      memory,
+    })
+
+    expect(called).toBe(false)
+    expect(result.factsExtracted).toBe(0)
+  })
+
+  it('passes actorId and sessionId to extract when provided', async () => {
+    const calls: ExtractArgs[] = []
+    const memory = makeMemoryStub(async (args) => {
+      calls.push(args)
+      return []
+    })
+
+    await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/readme.md',
+      documentContent: 'Content here',
+      memory,
+      actorId: 'agent-1',
+      sessionId: 'session-abc',
+    })
+
+    expect(calls[0]?.actorId).toBe('agent-1')
+    expect(calls[0]?.sessionId).toBe('session-abc')
+  })
+})

--- a/sdks/ts/memory/src/ingest/extract-after-ingest.test.ts
+++ b/sdks/ts/memory/src/ingest/extract-after-ingest.test.ts
@@ -114,6 +114,43 @@ describe('extractAfterIngest', () => {
     expect(result.factsExtracted).toBe(0)
   })
 
+  it('returns empty result for zero-byte file content', async () => {
+    let called = false
+    const memory = makeMemoryStub(async () => {
+      called = true
+      return []
+    })
+
+    const result = await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/zero.bin',
+      documentContent: '',
+      memory,
+    })
+
+    expect(called).toBe(false)
+    expect(result.factsExtracted).toBe(0)
+    expect(result.memories).toHaveLength(0)
+  })
+
+  it('wraps content in isolation delimiters', async () => {
+    let receivedContent = ''
+    const memory = makeMemoryStub(async (args) => {
+      receivedContent = args.messages[0]?.content ?? ''
+      return []
+    })
+
+    await extractAfterIngest({
+      brainId: 'test-brain',
+      documentPath: '/docs/test.md',
+      documentContent: 'Hello world',
+      memory,
+    })
+
+    expect(receivedContent).toContain('<ingested-document>')
+    expect(receivedContent).toContain('</ingested-document>')
+  })
+
   it('passes actorId and sessionId to extract when provided', async () => {
     const calls: ExtractArgs[] = []
     const memory = makeMemoryStub(async (args) => {

--- a/sdks/ts/memory/src/ingest/extract-after-ingest.ts
+++ b/sdks/ts/memory/src/ingest/extract-after-ingest.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Post-ingest extraction: after a document is ingested successfully,
+ * optionally run the memory extractor to derive structured facts from
+ * the raw content. The extraction is non-fatal: if it fails, the ingest
+ * result is still returned with the extraction error logged.
+ */
+
+import type { Logger } from '../llm/index.js'
+import { noopLogger } from '../llm/index.js'
+import type { Memory, ExtractedMemory } from '../memory/types.js'
+
+/** Default maximum content length (in characters) passed to the extractor. */
+const DEFAULT_MAX_CONTENT_CHARS = 128_000
+
+export type ExtractAfterIngestOptions = {
+  readonly brainId: string
+  readonly documentPath: string
+  readonly documentContent: string
+  readonly memory: Pick<Memory, 'extract'>
+  readonly actorId?: string | undefined
+  readonly sessionId?: string | undefined
+  readonly maxContentChars?: number | undefined
+  readonly logger?: Logger | undefined
+}
+
+export type ExtractAfterIngestResult = {
+  readonly factsExtracted: number
+  readonly memories: readonly ExtractedMemory[]
+}
+
+/**
+ * Run the memory extractor on document content after a successful ingest.
+ *
+ * Builds a synthetic user message from the document content (truncated to
+ * maxContentChars) and passes it to `memory.extract()`. Returns the
+ * extracted memories or an empty result if extraction fails.
+ */
+export const extractAfterIngest = async (
+  opts: ExtractAfterIngestOptions,
+): Promise<ExtractAfterIngestResult> => {
+  const logger = opts.logger ?? noopLogger
+  const maxChars = opts.maxContentChars ?? DEFAULT_MAX_CONTENT_CHARS
+
+  if (opts.documentContent.trim() === '') {
+    logger.debug('extract-after-ingest: empty content, skipping extraction')
+    return { factsExtracted: 0, memories: [] }
+  }
+
+  const truncated =
+    opts.documentContent.length > maxChars
+      ? opts.documentContent.slice(0, maxChars)
+      : opts.documentContent
+
+  const syntheticMessages = [
+    {
+      role: 'user' as const,
+      content: `The following document was ingested from "${opts.documentPath}". Extract any important facts, knowledge, or structured information from it:\n\n${truncated}`,
+    },
+  ]
+
+  try {
+    const extracted = await opts.memory.extract({
+      messages: syntheticMessages,
+      ...(opts.actorId !== undefined ? { actorId: opts.actorId } : {}),
+      ...(opts.sessionId !== undefined ? { sessionId: opts.sessionId } : {}),
+      scope: 'global',
+    })
+
+    return {
+      factsExtracted: extracted.length,
+      memories: extracted,
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    logger.warn(`extract-after-ingest: extraction failed: ${message}`)
+    return { factsExtracted: 0, memories: [] }
+  }
+}

--- a/sdks/ts/memory/src/ingest/extract-after-ingest.ts
+++ b/sdks/ts/memory/src/ingest/extract-after-ingest.ts
@@ -56,7 +56,7 @@ export const extractAfterIngest = async (
   const syntheticMessages = [
     {
       role: 'user' as const,
-      content: `The following document was ingested from "${opts.documentPath}". Extract any important facts, knowledge, or structured information from it:\n\n${truncated}`,
+      content: `The following document was ingested from "${opts.documentPath}". Extract any important facts, knowledge, or structured information from it:\n\n<ingested-document>\n${truncated}\n</ingested-document>`,
     },
   ]
 

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -121,3 +121,9 @@ export {
 } from './state-store-pg.js'
 
 export * from './trigger/index.js'
+
+export {
+  extractAfterIngest,
+  type ExtractAfterIngestOptions,
+  type ExtractAfterIngestResult,
+} from './extract-after-ingest.js'

--- a/spec/MCP-TOOLS.md
+++ b/spec/MCP-TOOLS.md
@@ -124,17 +124,21 @@ Ingest a local file (<= 25 MB) into the brain via the file-ingest endpoint.
 
 ```
 {
-  path:   string                       # absolute or relative local path
-  brain?: string
-  as?:    'markdown' | 'text' | 'pdf' | 'json'
+  path:     string                       # absolute or relative local path
+  brain?:   string
+  as?:      'markdown' | 'text' | 'pdf' | 'json'
+  extract?: boolean                      # run extractor after ingest (default: false)
 }
 ```
 
 Content type is inferred from the extension when `as` is omitted. Files over 25 MiB are rejected with code `file_too_large`.
 
+When `extract` is `true`, the document content is passed through the memory extractor after successful ingestion. Both the raw document and any extracted facts are persisted. Extraction failure is non-fatal: the ingest result is always returned.
+
 **Output shape**
 
 ```
+# without extract (default)
 {
   status:      'queued' | 'ingested',
   path:        string,
@@ -142,6 +146,15 @@ Content type is inferred from the extension when `as` is omitted. Files over 25 
   chunk_count?: number,
   reused?:     boolean,
   ...
+}
+
+# with extract: true
+{
+  ingest: { status, path, chunk_count, ... },
+  extraction: {
+    factsExtracted: number,
+    memories: Array<{ filename: string, content: string }>
+  }
 }
 ```
 
@@ -157,8 +170,9 @@ Fetch a URL and ingest its content. Uses the server-side `/ingest/url` when the 
 
 ```
 {
-  url:    string (must be a valid URL)
-  brain?: string
+  url:      string (must be a valid URL)
+  brain?:   string
+  extract?: boolean                      # run extractor after ingest (default: false)
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add `extract: true` option to `memory_ingest_file` and `memory_ingest_url` tools
- After successful ingest, runs the memory extractor to derive structured facts from document content
- Both raw document and extracted facts are persisted independently
- Extraction is opt-in, non-fatal, and caps content at 128k characters

## Changes
- **TS SDK**: `extract-after-ingest.ts` with synthetic message construction, truncation, non-fatal error handling
- **TS MCP**: Updated `ingest-file.ts` and `ingest-url.ts` schemas with `extract?: boolean`
- **TS Client**: Added `extractAfterIngest` method to `MemoryClient` (local reads file, hosted sends transcript)
- **Go SDK**: `ingest/extract.go` with `ExtractAfterIngest` function
- **Go MCP**: Updated `ingest_file.go`, `ingest_url.go` tool handlers; added `ExtractAfterIngest` to `MemoryClient` interface and both `localClient`/`hostedClient` implementations
- **Spec**: `spec/MCP-TOOLS.md` updated with `extract` option and combined response shape
- **Tests**: 6 TS SDK tests + 4 MCP tool tests + 4 Go SDK tests = 14 total

## Test plan
- [x] TS SDK: extract called with document content as synthetic message
- [x] TS SDK: empty content skips extraction
- [x] TS SDK: content truncated at maxContentChars
- [x] TS SDK: extraction failure is non-fatal (empty result returned)
- [x] TS SDK: actorId and sessionId forwarded
- [x] TS SDK: empty trimmed content skips extraction
- [x] TS MCP: ingest_file without extract returns normal result
- [x] TS MCP: ingest_file with extract=true returns combined result
- [x] TS MCP: ingest_url without extract returns normal result
- [x] TS MCP: ingest_url with extract=true returns combined result
- [x] Go: extract called with synthetic message
- [x] Go: empty content skips extraction
- [x] Go: long content truncated
- [x] Go: extraction failure is non-fatal