### PR TITLE
feat(memory-pi): single-brain flatLayout + on-boot indexer (v0.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
         run: bash scripts/publish-if-needed.sh sdks/ts/memory
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish @jeffs-brain/memory-pi
+        run: bash scripts/publish-if-needed.sh sdks/ts/memory-pi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @jeffs-brain/memory-postgres
         run: bash scripts/publish-if-needed.sh sdks/ts/memory-postgres
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### memory-pi 0.2.0
+
+#### Added
+
+- `flatLayout` configuration option on `createMemoryExtension`. When
+  `true`, the extension treats `brainRoot` as the brain directly and
+  skips the `brainId` subdirectory join. Aimed at single-brain hosts
+  that manage one brain per identity at a fixed path. (TS)
+- `searchIndexPath` configuration option to redirect the SQLite FTS
+  index outside the brain root. Lets hosts that keep brain content in
+  a git working tree keep machine-local state out of the tree. (TS)
+- `bootstrapScanDirs` option (default `['wiki', 'memory', 'raw']`) and
+  a one-shot indexer (`bootstrap-flat.ts`) that walks the configured
+  directories on first boot, chunks every markdown file, and upserts
+  the chunks into the FTS index via `SearchIndex.upsertChunks`. The
+  Store is bypassed entirely so source files are never duplicated or
+  rewritten. Idempotent on re-entry. (TS)
+- Internal SQLite `SearchIndex` is now wired into the `Memory` recall
+  pipeline through an adapter so `memory_recall` returns BM25 hits
+  instead of relying on the scope-prefix fallback. (TS)
+- Environment variables `MEMORY_PI_FLAT_LAYOUT`,
+  `MEMORY_PI_SEARCH_INDEX_PATH`, `MEMORY_PI_BRAIN_ROOT`,
+  `MEMORY_PI_BRAIN_ID` for ops-friendly configuration. (TS)
+
+#### Changed
+
+- `resolveBrainPaths(root, brainId)` now accepts an optional third
+  argument `{ flat?: boolean; searchIndexPath?: string }`. Existing
+  two-argument calls keep working unchanged. (TS)
+- `@earendil-works/pi-coding-agent` and `typebox` are now declared as
+  `peerDependencies` so pi-bundled copies are used instead of installed
+  duplicates. Required by pi's package-loading model. (TS)
+
 ## [0.3.0] - 2026-05-12
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "sdks/ts/memory": {
       "name": "@jeffs-brain/memory",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "memory": "./dist/cli.js",
       },
@@ -75,6 +75,21 @@
         "@jeffs-brain/memory": "workspace:*",
       },
     },
+    "sdks/ts/memory-pi": {
+      "name": "@jeffs-brain/memory-pi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@jeffs-brain/memory": "workspace:*",
+        "typebox": "^1.1.24",
+        "zod": "^3",
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.5",
+        "typescript": "^5.7.3",
+        "vitest": "^2.1.8",
+      },
+    },
     "sdks/ts/memory-postgres": {
       "name": "@jeffs-brain/memory-postgres",
       "version": "0.1.0",
@@ -94,6 +109,76 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1047.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.10", "@aws-sdk/credential-provider-node": "^3.972.41", "@aws-sdk/eventstream-handler-node": "^3.972.15", "@aws-sdk/middleware-eventstream": "^3.972.11", "@aws-sdk/middleware-host-header": "^3.972.11", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.12", "@aws-sdk/middleware-user-agent": "^3.972.40", "@aws-sdk/middleware-websocket": "^3.972.18", "@aws-sdk/region-config-resolver": "^3.972.14", "@aws-sdk/token-providers": "3.1047.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@aws-sdk/util-user-agent-browser": "^3.972.11", "@aws-sdk/util-user-agent-node": "^3.973.26", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-b9yUBRqYQ9ADb1ta8nLXKby9pWo0lKozsauPeAT3IemBfReoY7PG7bSqGCoXkljL/H2mjBQXAbMinPaw6xhigA=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.24", "@smithy/core": "^3.24.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.40", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/credential-provider-env": "^3.972.36", "@aws-sdk/credential-provider-http": "^3.972.38", "@aws-sdk/credential-provider-login": "^3.972.40", "@aws-sdk/credential-provider-process": "^3.972.36", "@aws-sdk/credential-provider-sso": "^3.972.40", "@aws-sdk/credential-provider-web-identity": "^3.972.40", "@aws-sdk/nested-clients": "^3.997.8", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/credential-provider-imds": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.40", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/nested-clients": "^3.997.8", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.41", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.36", "@aws-sdk/credential-provider-http": "^3.972.38", "@aws-sdk/credential-provider-ini": "^3.972.40", "@aws-sdk/credential-provider-process": "^3.972.36", "@aws-sdk/credential-provider-sso": "^3.972.40", "@aws-sdk/credential-provider-web-identity": "^3.972.40", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/credential-provider-imds": "^4.3.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.40", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/nested-clients": "^3.997.8", "@aws-sdk/token-providers": "3.1047.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.40", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/nested-clients": "^3.997.8", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Al7z1qKPUIRILnB3Ggd1Tz88wjSkQjDErajR7YY33mquTbeN0gTDtJtclNtyhQMWr7ZRpQk0v5/xop4fjT0sug=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-A0Z45YInBwsAabF8jf9hEQjXDuq4gFHNNqxCYuk8iREFZ7hw0NZ6+7FFlYa11gJ+i6y79C4J6giQ7fa1EDRYxw=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.12", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.40", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QLpD+HNQtL1Mc49/GRa6RmZvi/TEYBWPevC9F3L+j96IoG3xOSRctdQfbkX0lETb3TX9QQXU1oGYDmAB+YJprA=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.18", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-MlaAUTAoUYDjHpRJULrxwA13guIknZG540ae3xsJIQT7m63lkmCPtuaVnWV8W5SpPSElvmI94+Q4LrMjNuJEUA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.8", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.10", "@aws-sdk/middleware-host-header": "^3.972.11", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.12", "@aws-sdk/middleware-user-agent": "^3.972.40", "@aws-sdk/region-config-resolver": "^3.972.14", "@aws-sdk/signature-v4-multi-region": "^3.996.26", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.9", "@aws-sdk/util-user-agent-browser": "^3.972.11", "@aws-sdk/util-user-agent-node": "^3.973.26", "@smithy/core": "^3.24.1", "@smithy/fetch-http-handler": "^5.4.1", "@smithy/node-http-handler": "^4.7.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.26", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/signature-v4": "^5.4.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1047.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.10", "@aws-sdk/nested-clients": "^3.997.8", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.26", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.40", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-9bHR/EERjhrUGyo1qW620ogbGBtCglYB/pEtcm85sVd4/Ah+bwdLI3g1aJf75oNwNwh7+fw+8wOk/OCWHjzVmA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.24", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
@@ -113,6 +198,16 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.74.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.74.0", "typebox": "^1.1.24" } }, "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.74.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.74.0", "@earendil-works/pi-ai": "^0.74.0", "@earendil-works/pi-tui": "^0.74.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "jiti": "^2.7.0", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "typebox": "^1.1.24", "undici": "^7.19.1", "uuid": "^14.0.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.5" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.74.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -161,6 +256,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
@@ -266,6 +363,8 @@
 
     "@jeffs-brain/memory-openfga": ["@jeffs-brain/memory-openfga@workspace:sdks/ts/memory-openfga"],
 
+    "@jeffs-brain/memory-pi": ["@jeffs-brain/memory-pi@workspace:sdks/ts/memory-pi"],
+
     "@jeffs-brain/memory-postgres": ["@jeffs-brain/memory-postgres@workspace:sdks/ts/memory-postgres"],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -274,7 +373,33 @@
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.5", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.2", "", { "os": "darwin" }, "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -348,9 +473,35 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@smithy/core": ["@smithy/core@3.24.2", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.2", "", { "dependencies": { "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw=="],
+
+    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@stackone/defender": ["@stackone/defender@0.6.3", "", { "dependencies": { "nanoid": "3.3.11" }, "peerDependencies": { "@huggingface/transformers": "^3.0.0", "fasttext.wasm": "^1.0.0", "onnxruntime-node": ">=1.16.0" }, "optionalPeers": ["@huggingface/transformers", "fasttext.wasm", "onnxruntime-node"] }, "sha512-60R6jLXBn4vnZTh+kea5ll51RzvEUeKZ9uXXAtAo5xERuNO2prBBJLkFVhC+EdpSwAUw21sSWlRvJxrcvPke9g=="],
 
     "@testcontainers/postgresql": ["@testcontainers/postgresql@11.14.0", "", { "dependencies": { "testcontainers": "^11.14.0" } }, "sha512-wYbJn8GRTj8qfqzfVubxioYWlHJU/ImIjuzPwyy9C5Qfo6g3GLduPZAj+BifvqTZjgT3gd4gFVLCPhBji7dc1w=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
@@ -362,11 +513,17 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
+
     "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/ssh2": ["@types/ssh2@1.15.5", "", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
 
     "@types/ssh2-streams": ["@types/ssh2-streams@0.1.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
 
@@ -388,13 +545,17 @@
 
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
 
@@ -404,6 +565,8 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "async-lock": ["async-lock@1.4.1", "", {}, "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="],
@@ -412,7 +575,7 @@
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
@@ -428,9 +591,13 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
     "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
@@ -440,11 +607,15 @@
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
-    "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
@@ -464,6 +635,8 @@
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
@@ -474,9 +647,11 @@
 
     "clean-git-ref": ["clean-git-ref@2.0.1", "", {}, "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="],
 
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -506,6 +681,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -518,11 +695,15 @@
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "diff3": ["diff3@0.0.3", "", {}, "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="],
 
@@ -537,6 +718,8 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -564,7 +747,15 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -586,11 +777,25 @@
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -602,6 +807,8 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -612,7 +819,13 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -620,19 +833,29 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
-    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
+
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
@@ -642,9 +865,17 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -678,13 +909,25 @@
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "koffi": ["koffi@2.16.2", "", {}, "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA=="],
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
@@ -696,9 +939,11 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
@@ -714,7 +959,7 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
-    "minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -730,6 +975,8 @@
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
     "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -738,9 +985,15 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
     "node-ensure": ["node-ensure@0.0.0", "", {}, "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
@@ -760,15 +1013,31 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
 
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
@@ -777,6 +1046,8 @@
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "pdf-parse": ["pdf-parse@1.1.4", "", { "dependencies": { "node-ensure": "^0.0.0" } }, "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -805,6 +1076,10 @@
     "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -874,6 +1149,14 @@
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split-ca": ["split-ca@1.0.1", "", {}, "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="],
@@ -910,11 +1193,17 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
 
@@ -925,6 +1214,10 @@
     "testcontainers": ["testcontainers@11.14.0", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@types/dockerode": "^4.0.1", "archiver": "^7.0.1", "async-lock": "^1.4.1", "byline": "^5.0.0", "debug": "^4.4.3", "docker-compose": "^1.4.2", "dockerode": "^4.0.10", "get-port": "^7.2.0", "proper-lockfile": "^4.1.2", "properties-reader": "^3.0.1", "ssh-remote-port-forward": "^1.0.4", "tar-fs": "^3.1.2", "tmp": "^0.2.5", "undici": "^7.24.5" } }, "sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg=="],
 
     "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -942,6 +1235,10 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
@@ -952,9 +1249,13 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
+
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
@@ -964,7 +1265,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -973,6 +1274,8 @@
     "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
 
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -986,13 +1289,19 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
@@ -1002,21 +1311,29 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@earendil-works/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
+    "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1024,25 +1341,59 @@
 
     "dockerode/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
-    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "dockerode/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
-    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
+
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "prebuild-install/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "socks/ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
     "ssh-remote-port-forward/@types/ssh2": ["@types/ssh2@0.5.52", "", { "dependencies": { "@types/node": "*", "@types/ssh2-streams": "*" } }, "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg=="],
 
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "archiver-utils/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "dockerode/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -1054,8 +1405,42 @@
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
+    "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@grpc/proto-loader/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "archiver-utils/glob/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "archiver-utils/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "dockerode/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "prebuild-install/tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "readdir-glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@grpc/proto-loader/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@grpc/grpc-js/@grpc/proto-loader/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/sdks/ts/memory-pi/README.md
+++ b/sdks/ts/memory-pi/README.md
@@ -1,36 +1,169 @@
 # @jeffs-brain/memory-pi
 
-A pi extension that wires `@jeffs-brain/memory` into the pi agent harness.
+A pi extension that wires the [`@jeffs-brain/memory`](../memory) pipeline
+into the pi coding agent so every session gains an active long-term
+memory layer.
 
-- Eleven LLM-callable `memory_*` tools: remember, recall, search, ask,
-  ingest_file, ingest_url, extract, reflect, consolidate, create_brain,
-  list_brains.
-- Four lifecycle hooks: `before_agent_start` (recall injection, cache-friendly),
-  `context` (re-inject on diff), `turn_end` (extract), `session_shutdown`
-  (reflect + close).
-- Auto-detects local Ollama on `localhost:11434` for `bge-m3` embeddings and
-  `gemma3` chat.
-- `autodetectStore` picks `fs` vs `git` based on the brain root.
-- Optional MCP fallback for portability via a config flag.
+The extension exposes:
+
+- **Eleven `memory_*` tools** the LLM can call directly: `remember`,
+  `recall`, `search`, `ask`, `ingest_file`, `ingest_url`, `extract`,
+  `reflect`, `consolidate`, `create_brain`, `list_brains`.
+- **Four pi lifecycle hooks**: `before_agent_start` (recall injection
+  with optional cache-friendly diffing), `context` (per-turn recall
+  injection below the prompt-cache boundary), `turn_end` (non-blocking
+  extract queue), `session_shutdown` (queue drain, optional reflect /
+  consolidate, store close).
+- **Auto-detection** for local Ollama (`bge-m3` embeddings, `gemma3`
+  chat) and explicit `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` providers,
+  with `autodetectStore` picking `fs` or `git` based on the brain root.
+
+## Install
+
+```bash
+npm install @jeffs-brain/memory-pi
+```
+
+The extension assumes the parent `@jeffs-brain/memory` SDK is also
+available; both packages ship from the same monorepo.
+
+## Quick start (standalone pi user)
+
+Drop `memory-pi` into the pi extensions directory:
+
+```typescript
+// ~/.pi/agent/extensions/memory-pi.ts
+import { createMemoryExtension } from '@jeffs-brain/memory-pi'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+
+export default async function (pi: ExtensionAPI) {
+  const ext = createMemoryExtension(pi, {
+    brainRoot: process.env.MEMORY_PI_BRAIN_ROOT,
+    brainId: 'default',
+    store: { kind: 'auto' },
+    embedder: { kind: 'auto' },
+    provider: { kind: 'auto' },
+    recall: {
+      onPrompt: true,
+      cacheFriendly: true,
+      topK: 5,
+      scope: 'global',
+    },
+    extract: { onTurnEnd: true, minMessages: 6, contextualise: true },
+    reflect: { onSessionEnd: true },
+    consolidate: { schedule: 'manual' },
+  })
+  await ext.ready
+}
+```
+
+`MEMORY_PI_CONFIG` (JSON) is honoured by the default export so
+`pi -e ./node_modules/@jeffs-brain/memory-pi/dist/index.js` works without
+recompiling the extension.
+
+## Quick start (Jeff / Jill consumer)
+
+The Jeff and Jill runtimes link the same package via the W1 / W2 work
+items. They construct the extension explicitly so the runtime can hold
+a handle:
+
+```typescript
+import { createMemoryExtension, type MemoryExtension } from '@jeffs-brain/memory-pi'
+
+const memory: MemoryExtension = createMemoryExtension(pi, {
+  brainRoot: '/home/jeff/.local/share/jeff/brain',
+  brainId: 'jeff',
+  store: { kind: 'git', remote: 'git@github.com:lleverage-ai/jeffs-brain.git' },
+  embedder: { kind: 'ollama', baseUrl: 'http://localhost:11434', model: 'bge-m3' },
+  provider: { kind: 'anthropic', apiKey: process.env.ANTHROPIC_API_KEY!, model: 'claude-opus-4-6' },
+  acl: { actorId: 'jeff' },
+})
+
+await memory.ready
+
+process.on('beforeExit', () => memory.close())
+```
+
+## Quick start (MCP fallback)
+
+When pi is not available but you still want the same tool surface, run
+the parent `@jeffs-brain/memory` MCP server: it exposes the identical
+eleven tools over MCP. The pi extension and the MCP server share the
+on-disk brain layout so both can read the same data.
+
+## Configuration
+
+All keys are optional; sensible defaults are auto-detected.
+
+```typescript
+type MemoryExtensionConfig = {
+  brainRoot?: string  // default: ~/.config/memory-pi/brains
+  brainId?: string    // default: 'default'
+
+  store?: { kind: 'auto' | 'fs' | 'git' | 'http'; remote?: string; endpoint?: string; token?: string }
+  embedder?: { kind: 'auto' | 'ollama' | 'openai' | 'tei' | 'off'; baseUrl?: string; model?: string; apiKey?: string; endpoint?: string }
+  provider?: { kind: 'auto' | 'openai' | 'anthropic' | 'ollama'; apiKey?: string; baseUrl?: string; model?: string }
+  reranker?: { kind: 'auto' | 'llm' | 'tei' | 'off'; endpoint?: string }
+
+  recall?: {
+    onPrompt?: boolean        // default: true
+    topK?: number             // default: 5
+    minScore?: number         // default: 0
+    scope?: 'global' | 'project' | 'agent'  // default: 'global'
+    fallbackScopes?: ('global' | 'project' | 'agent')[]
+    cacheFriendly?: boolean   // default: true
+  }
+
+  extract?: {
+    onTurnEnd?: boolean       // default: true
+    minMessages?: number      // default: 6
+    contextualise?: boolean
+  }
+
+  reflect?: { onSessionEnd?: boolean }
+  consolidate?: { schedule?: 'manual' | 'session' | '@daily' }
+
+  tools?: {
+    expose?: ('remember' | 'recall' | 'search' | 'ask' | 'ingest_file' | 'ingest_url' | 'extract' | 'reflect' | 'consolidate' | 'create_brain' | 'list_brains')[]
+  }
+
+  acl?: {
+    actorId?: string
+    provider?: 'rbac' | { kind: 'openfga'; endpoint: string }
+  }
+}
+```
+
+## Cache-friendly recall injection
+
+When `recall.cacheFriendly: true` (default), the extension only rewrites
+the system prompt when the recall set changes. Identical recall hits
+across turns leave the prompt alone, so Anthropic / OpenAI prompt
+caching stays warm. Flip `recall.onPrompt: false` to move injection to
+the per-turn `context` boundary instead (below the cache).
+
+## Tools
+
+| Tool name              | Operation                                          |
+|------------------------|----------------------------------------------------|
+| `memory_remember`      | Persist a markdown note (frontmatter included).    |
+| `memory_recall`        | Five-stage recall over the brain.                  |
+| `memory_search`        | Hybrid BM25 + vector retrieval.                    |
+| `memory_ask`           | Grounded answer with citations.                    |
+| `memory_ingest_file`   | Ingest a local file (<= 25 MiB).                   |
+| `memory_ingest_url`    | Fetch + ingest a URL (<= 5 MiB fallback).          |
+| `memory_extract`       | Extract memorable facts from a transcript.         |
+| `memory_reflect`       | Run reflection over a session.                     |
+| `memory_consolidate`   | Compile summaries, prune episodic memory.          |
+| `memory_create_brain`  | Create a new brain under the configured root.      |
+| `memory_list_brains`   | List the brains the host can see.                  |
 
 ## Status
 
-Scaffolded. W3 in the pi-Jeff migration. See `~/code/me/jeff-on-pi/PLAN.md`
-section 5 for the design.
+Active. W3 of the pi-Jeff migration. The runtime is feature-complete and
+covered by smoke tests; subsequent work items wire Jeff and Jill on top
+of it.
 
-## Quick start
+## Licence
 
-```typescript
-import { createMemoryExtension } from "@jeffs-brain/memory-pi"
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-
-export default function (pi: ExtensionAPI) {
-  createMemoryExtension(pi, {
-    store: { kind: "auto" },
-    embedder: { kind: "auto" },
-    provider: { kind: "auto" },
-    recall: { onPrompt: true, scope: "global", topK: 5 },
-    extract: { onTurnEnd: true, contextualise: true },
-  })
-}
-```
+Apache-2.0.

--- a/sdks/ts/memory-pi/README.md
+++ b/sdks/ts/memory-pi/README.md
@@ -1,0 +1,36 @@
+# @jeffs-brain/memory-pi
+
+A pi extension that wires `@jeffs-brain/memory` into the pi agent harness.
+
+- Eleven LLM-callable `memory_*` tools: remember, recall, search, ask,
+  ingest_file, ingest_url, extract, reflect, consolidate, create_brain,
+  list_brains.
+- Four lifecycle hooks: `before_agent_start` (recall injection, cache-friendly),
+  `context` (re-inject on diff), `turn_end` (extract), `session_shutdown`
+  (reflect + close).
+- Auto-detects local Ollama on `localhost:11434` for `bge-m3` embeddings and
+  `gemma3` chat.
+- `autodetectStore` picks `fs` vs `git` based on the brain root.
+- Optional MCP fallback for portability via a config flag.
+
+## Status
+
+Scaffolded. W3 in the pi-Jeff migration. See `~/code/me/jeff-on-pi/PLAN.md`
+section 5 for the design.
+
+## Quick start
+
+```typescript
+import { createMemoryExtension } from "@jeffs-brain/memory-pi"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+export default function (pi: ExtensionAPI) {
+  createMemoryExtension(pi, {
+    store: { kind: "auto" },
+    embedder: { kind: "auto" },
+    provider: { kind: "auto" },
+    recall: { onPrompt: true, scope: "global", topK: 5 },
+    extract: { onTurnEnd: true, contextualise: true },
+  })
+}
+```

--- a/sdks/ts/memory-pi/README.md
+++ b/sdks/ts/memory-pi/README.md
@@ -142,6 +142,43 @@ across turns leave the prompt alone, so Anthropic / OpenAI prompt
 caching stays warm. Flip `recall.onPrompt: false` to move injection to
 the per-turn `context` boundary instead (below the cache).
 
+## Single-brain hosts (flatLayout)
+
+Some hosts manage exactly one brain per identity at a well-known path
+with content (`wiki/`, `memory/`, `raw/`, ...) sitting directly under the
+brain root. The default multi-brain layout, which nests
+`<root>/<brainId>/<content>`, does not fit that shape.
+
+Pass `flatLayout: true` to tell `createMemoryExtension` that `brainRoot`
+already IS the brain. Combined with `searchIndexPath`, this also lets
+hosts that keep the brain in a git working tree redirect the FTS sqlite
+to a machine-local state directory so it never enters the tree.
+
+```typescript
+const ext = createMemoryExtension(pi, {
+  brainRoot: '/var/lib/myagent/brain',          // single-brain root
+  brainId: 'myagent',                            // logical label only
+  flatLayout: true,
+  searchIndexPath: '/var/state/myagent/search.sqlite',
+})
+```
+
+When `flatLayout` is on, the runtime also runs a one-shot indexer on
+first boot: it walks the configured `bootstrapScanDirs` (default
+`['wiki', 'memory', 'raw']`), chunks every markdown file, and upserts
+the chunks directly into the FTS index via `SearchIndex.upsertChunks`.
+The Store is bypassed entirely so the source `.md` files are never
+re-written. Re-entries are no-ops once `knowledge_chunks` is populated.
+
+Environment overrides:
+
+| Var | Effect |
+|---|---|
+| `MEMORY_PI_FLAT_LAYOUT=true` | Enable flat layout without touching the config object. |
+| `MEMORY_PI_SEARCH_INDEX_PATH=/path/...` | Override the FTS sqlite path. |
+| `MEMORY_PI_BRAIN_ROOT=/path/...` | Override `brainRoot`. |
+| `MEMORY_PI_BRAIN_ID=...` | Override `brainId`. |
+
 ## Tools
 
 | Tool name              | Operation                                          |

--- a/sdks/ts/memory-pi/package.json
+++ b/sdks/ts/memory-pi/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@jeffs-brain/memory-pi",
+  "version": "0.1.0",
+  "description": "Pi extension for the @jeffs-brain/memory pipeline. Recall, extract, reflect, consolidate on every pi session via four lifecycle hooks plus 11 memory_* tools.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "README.md"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./hooks": {
+      "types": "./dist/hooks.d.ts",
+      "default": "./dist/hooks.js"
+    },
+    "./tools": {
+      "types": "./dist/tools.d.ts",
+      "default": "./dist/tools.js"
+    },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "default": "./dist/config.js"
+    }
+  },
+  "pi": {
+    "extensions": ["./dist/index.js"]
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@jeffs-brain/memory": "workspace:*",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "zod": "^3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "keywords": [
+    "pi-extension",
+    "memory",
+    "rag",
+    "retrieval",
+    "embedding",
+    "knowledge-base"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeffs-brain/memory.git",
+    "directory": "sdks/ts/memory-pi"
+  }
+}

--- a/sdks/ts/memory-pi/package.json
+++ b/sdks/ts/memory-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-pi",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pi extension for the @jeffs-brain/memory pipeline. Recall, extract, reflect, consolidate on every pi session via four lifecycle hooks plus 11 memory_* tools.",
   "license": "Apache-2.0",
   "type": "module",
@@ -34,14 +34,18 @@
     "test": "vitest run --passWithNoTests",
     "prepublishOnly": "npm run build"
   },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "typebox": "^1"
+  },
   "dependencies": {
     "@jeffs-brain/memory": "workspace:*",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "typebox": "^1.1.24",
     "zod": "^3"
   },
   "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "@types/node": "^22.10.5",
+    "typebox": "^1.1.24",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   },

--- a/sdks/ts/memory-pi/package.json
+++ b/sdks/ts/memory-pi/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@jeffs-brain/memory": "workspace:*",
     "@earendil-works/pi-coding-agent": "^0.74.0",
+    "typebox": "^1.1.24",
     "zod": "^3"
   },
   "devDependencies": {

--- a/sdks/ts/memory-pi/src/bootstrap-flat.ts
+++ b/sdks/ts/memory-pi/src/bootstrap-flat.ts
@@ -16,7 +16,7 @@
  */
 
 import { readFile, readdir, stat } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { join, relative, sep } from 'node:path'
 import { chunkMarkdown } from '@jeffs-brain/memory/ingest'
 import type { Chunk as IndexChunk, SearchIndex } from '@jeffs-brain/memory/search'
 import { type RuntimeLogger, noopRuntimeLogger } from './runtime-logger.js'
@@ -50,6 +50,8 @@ export type BootstrapFlatResult = {
 const bumpReason = (reasons: Record<string, number>, key: string): void => {
   reasons[key] = (reasons[key] ?? 0) + 1
 }
+
+const toPosixRel = (rel: string): string => (sep === '/' ? rel : rel.split(sep).join('/'))
 
 const isFileAccessible = async (path: string): Promise<boolean> => {
   try {
@@ -149,7 +151,7 @@ export const bootstrapFlatBrain = async (
     }
     for await (const absPath of walk(dir, extensions)) {
       scanned++
-      const rel = relative(options.brainRoot, absPath)
+      const rel = toPosixRel(relative(options.brainRoot, absPath))
       if (known.has(rel)) {
         skipped++
         bumpReason(skippedReasons, 'already-indexed')

--- a/sdks/ts/memory-pi/src/bootstrap-flat.ts
+++ b/sdks/ts/memory-pi/src/bootstrap-flat.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * One-shot indexer that walks an existing brain's content directories
+ * (wiki/, memory/, raw/, ...) and populates the memory-pi SQLite FTS
+ * index without writing to the Store.
+ *
+ * Intended for single-brain hosts where the on-disk markdown is the
+ * canonical truth (typically a git working tree) and a separate runtime
+ * already owns writes. memory-pi's BM25 + vector retrieval becomes a
+ * read-only side index over those files. The Store is never touched
+ * so source content is not duplicated or rewritten.
+ *
+ * Idempotent: paths already present in `knowledge_chunks` are skipped on
+ * re-entry, so booting an already-bootstrapped brain is a no-op.
+ */
+
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+import { chunkMarkdown } from '@jeffs-brain/memory/ingest'
+import type { Chunk as IndexChunk, SearchIndex } from '@jeffs-brain/memory/search'
+import { type RuntimeLogger, noopRuntimeLogger } from './runtime-logger.js'
+
+export const DEFAULT_BOOTSTRAP_SCAN_DIRS: readonly string[] = ['wiki', 'memory', 'raw']
+
+export const DEFAULT_BOOTSTRAP_EXTENSIONS: readonly string[] = ['.md', '.markdown']
+
+/** Upper bound on file size we are willing to chunk on first boot. */
+const MAX_FILE_BYTES = 2 * 1024 * 1024
+
+const BATCH_SIZE = 100
+
+export type BootstrapFlatOptions = {
+  readonly brainRoot: string
+  readonly brainId: string
+  readonly searchIndex: SearchIndex
+  readonly scanDirs?: readonly string[]
+  readonly extensions?: readonly string[]
+  readonly logger?: RuntimeLogger
+}
+
+export type BootstrapFlatResult = {
+  readonly scanned: number
+  readonly indexed: number
+  readonly skipped: number
+  readonly skippedReasons: Readonly<Record<string, number>>
+  readonly durationMs: number
+}
+
+const bumpReason = (reasons: Record<string, number>, key: string): void => {
+  reasons[key] = (reasons[key] ?? 0) + 1
+}
+
+const isFileAccessible = async (path: string): Promise<boolean> => {
+  try {
+    const info = await stat(path)
+    return info.isDirectory()
+  } catch {
+    return false
+  }
+}
+
+const extractTitle = (path: string, content: string): string => {
+  const trimmed = content.trim()
+  // Skip a YAML frontmatter block before searching for headings or the
+  // first content line. This keeps title extraction robust against the
+  // mix of front-mattered and bare markdown that lives in real brains.
+  let body = trimmed
+  if (body.startsWith('---')) {
+    const end = body.indexOf('\n---', 3)
+    if (end >= 0) body = body.slice(end + 4)
+  }
+  const heading = body.match(/^#\s+(.+)$/m)?.[1]?.trim()
+  if (heading !== undefined && heading !== '') return heading
+  const firstLine = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line !== '')
+  if (firstLine !== undefined && firstLine !== '') return firstLine
+  const base = path.split('/').pop() ?? path
+  return base.replace(/\.(md|markdown)$/i, '')
+}
+
+async function* walk(
+  root: string,
+  extensions: readonly string[],
+): AsyncGenerator<string, void, void> {
+  const stack: string[] = [root]
+  while (stack.length > 0) {
+    const current = stack.pop()
+    if (current === undefined) continue
+    let entries: { name: string; isDir: boolean }[] = []
+    try {
+      const dirents = await readdir(current, { withFileTypes: true })
+      entries = dirents.map((d) => ({ name: d.name, isDir: d.isDirectory() }))
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue
+      const next = join(current, entry.name)
+      if (entry.isDir) {
+        stack.push(next)
+        continue
+      }
+      const lower = entry.name.toLowerCase()
+      if (extensions.some((ext) => lower.endsWith(ext))) {
+        yield next
+      }
+    }
+  }
+}
+
+/**
+ * Walk the brain content directories and upsert every markdown chunk
+ * into the search index. Returns a summary record so the caller can log
+ * how much was indexed.
+ *
+ * Indexing happens directly through `SearchIndex.upsertChunks` — we
+ * deliberately bypass the ingest pipeline so we do NOT write copies of
+ * the source files back into the brain Store.
+ */
+export const bootstrapFlatBrain = async (
+  options: BootstrapFlatOptions,
+): Promise<BootstrapFlatResult> => {
+  const logger = options.logger ?? noopRuntimeLogger
+  const scanDirs = options.scanDirs ?? DEFAULT_BOOTSTRAP_SCAN_DIRS
+  const extensions = options.extensions ?? DEFAULT_BOOTSTRAP_EXTENSIONS
+  const start = Date.now()
+  const known = new Set(options.searchIndex.indexedPaths())
+
+  let scanned = 0
+  let indexed = 0
+  let skipped = 0
+  const skippedReasons: Record<string, number> = {}
+  let batch: IndexChunk[] = []
+
+  const flushBatch = (): void => {
+    if (batch.length === 0) return
+    options.searchIndex.upsertChunks(batch)
+    batch = []
+  }
+
+  for (const sub of scanDirs) {
+    const dir = join(options.brainRoot, sub)
+    if (!(await isFileAccessible(dir))) {
+      bumpReason(skippedReasons, `missing:${sub}`)
+      continue
+    }
+    for await (const absPath of walk(dir, extensions)) {
+      scanned++
+      const rel = relative(options.brainRoot, absPath)
+      if (known.has(rel)) {
+        skipped++
+        bumpReason(skippedReasons, 'already-indexed')
+        continue
+      }
+      let info
+      try {
+        info = await stat(absPath)
+      } catch {
+        skipped++
+        bumpReason(skippedReasons, 'stat-failed')
+        continue
+      }
+      if (info.size === 0) {
+        skipped++
+        bumpReason(skippedReasons, 'empty')
+        continue
+      }
+      if (info.size > MAX_FILE_BYTES) {
+        skipped++
+        bumpReason(skippedReasons, 'too-large')
+        logger.warn('memory-pi bootstrap: skipping oversize file', {
+          path: rel,
+          bytes: info.size,
+        })
+        continue
+      }
+      let content: string
+      try {
+        content = await readFile(absPath, 'utf8')
+      } catch (err) {
+        skipped++
+        bumpReason(skippedReasons, 'read-failed')
+        logger.warn('memory-pi bootstrap: read failed', {
+          path: rel,
+          err: err instanceof Error ? err.message : String(err),
+        })
+        continue
+      }
+      if (content.trim() === '') {
+        skipped++
+        bumpReason(skippedReasons, 'blank')
+        continue
+      }
+      const sections = chunkMarkdown(content)
+      if (sections.length === 0) {
+        skipped++
+        bumpReason(skippedReasons, 'no-chunks')
+        continue
+      }
+      const title = extractTitle(rel, content)
+      for (const section of sections) {
+        batch.push({
+          id: `${rel}#${section.ordinal}`,
+          path: rel,
+          ordinal: section.ordinal,
+          title,
+          content: section.content,
+          metadata: {
+            source: 'bootstrap-flat',
+            brainId: options.brainId,
+            headingPath: section.headingPath,
+            startLine: section.startLine,
+            endLine: section.endLine,
+          },
+        })
+        if (batch.length >= BATCH_SIZE) flushBatch()
+      }
+      indexed++
+    }
+  }
+  flushBatch()
+
+  const result: BootstrapFlatResult = {
+    scanned,
+    indexed,
+    skipped,
+    skippedReasons,
+    durationMs: Date.now() - start,
+  }
+  logger.info('memory-pi bootstrap: complete', {
+    ...result,
+    brainRoot: options.brainRoot,
+    brainId: options.brainId,
+    scanDirs,
+  })
+  return result
+}

--- a/sdks/ts/memory-pi/src/config.ts
+++ b/sdks/ts/memory-pi/src/config.ts
@@ -1,0 +1,126 @@
+import { z } from "zod"
+
+const StoreConfigSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("auto") }),
+  z.object({ kind: z.literal("fs") }),
+  z.object({ kind: z.literal("git"), remote: z.string().optional() }),
+  z.object({
+    kind: z.literal("http"),
+    endpoint: z.string().url(),
+    token: z.string(),
+  }),
+])
+
+const EmbedderConfigSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("auto") }),
+  z.object({
+    kind: z.literal("ollama"),
+    baseUrl: z.string().optional(),
+    model: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("openai"),
+    apiKey: z.string(),
+    model: z.string().optional(),
+  }),
+  z.object({ kind: z.literal("tei"), endpoint: z.string().url() }),
+  z.object({ kind: z.literal("off") }),
+])
+
+const ProviderConfigSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("auto") }),
+  z.object({
+    kind: z.literal("openai"),
+    apiKey: z.string(),
+    model: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("anthropic"),
+    apiKey: z.string(),
+    model: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("ollama"),
+    baseUrl: z.string().optional(),
+    model: z.string().optional(),
+  }),
+])
+
+const RerankerConfigSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("auto") }),
+  z.object({ kind: z.literal("llm") }),
+  z.object({ kind: z.literal("tei"), endpoint: z.string().url() }),
+  z.object({ kind: z.literal("off") }),
+])
+
+export const MEMORY_TOOL_NAMES = [
+  "remember",
+  "recall",
+  "search",
+  "ask",
+  "ingest_file",
+  "ingest_url",
+  "extract",
+  "reflect",
+  "consolidate",
+  "create_brain",
+  "list_brains",
+] as const
+
+export type MemoryToolName = (typeof MEMORY_TOOL_NAMES)[number]
+
+export const MemoryExtensionConfigSchema = z
+  .object({
+    brainRoot: z.string().optional(),
+    brainId: z.string().optional(),
+    store: StoreConfigSchema.optional(),
+    embedder: EmbedderConfigSchema.optional(),
+    provider: ProviderConfigSchema.optional(),
+    reranker: RerankerConfigSchema.optional(),
+    recall: z
+      .object({
+        onPrompt: z.boolean().optional(),
+        topK: z.number().int().positive().optional(),
+        minScore: z.number().min(0).max(1).optional(),
+        scope: z.string().optional(),
+        fallbackScopes: z.array(z.string()).optional(),
+        cacheFriendly: z.boolean().optional(),
+      })
+      .optional(),
+    extract: z
+      .object({
+        onTurnEnd: z.boolean().optional(),
+        minMessages: z.number().int().nonnegative().optional(),
+        contextualise: z.boolean().optional(),
+      })
+      .optional(),
+    reflect: z
+      .object({
+        onSessionEnd: z.boolean().optional(),
+      })
+      .optional(),
+    consolidate: z
+      .object({
+        schedule: z.enum(["manual", "session", "@daily"]).optional(),
+      })
+      .optional(),
+    tools: z
+      .object({
+        expose: z.array(z.enum(MEMORY_TOOL_NAMES)).optional(),
+      })
+      .optional(),
+    acl: z
+      .object({
+        actorId: z.string().optional(),
+        provider: z
+          .union([
+            z.literal("rbac"),
+            z.object({ kind: z.literal("openfga"), endpoint: z.string().url() }),
+          ])
+          .optional(),
+      })
+      .optional(),
+  })
+  .partial()
+
+export type MemoryExtensionConfig = z.infer<typeof MemoryExtensionConfigSchema>

--- a/sdks/ts/memory-pi/src/config.ts
+++ b/sdks/ts/memory-pi/src/config.ts
@@ -73,6 +73,23 @@ export const MemoryExtensionConfigSchema = z
   .object({
     brainRoot: z.string().optional(),
     brainId: z.string().optional(),
+    // When true, `brainRoot` is treated as the brain itself and the
+    // `brainId` is NOT joined into a subdirectory. Wiki / memory / raw
+    // content is expected to live directly under `brainRoot`. Useful
+    // for single-brain hosts that already manage one brain per identity
+    // on disk and do not want memory-pi to nest its own subdirectory
+    // inside the git working tree.
+    flatLayout: z.boolean().optional(),
+    // Override the on-disk path for the search index. When unset the
+    // index lives at `<resolvedBrainRoot>/search.sqlite`. Hosts that
+    // keep the brain content git-backed typically point this at a
+    // machine-local state directory so the FTS sqlite never enters the
+    // working tree.
+    searchIndexPath: z.string().optional(),
+    // When the search index is empty on boot, walk these subdirectories
+    // of `brainRoot` and ingest every markdown file found. Only honoured
+    // when `flatLayout` is true. Defaults to ['wiki', 'memory', 'raw'].
+    bootstrapScanDirs: z.array(z.string()).optional(),
     store: StoreConfigSchema.optional(),
     embedder: EmbedderConfigSchema.optional(),
     provider: ProviderConfigSchema.optional(),

--- a/sdks/ts/memory-pi/src/config.ts
+++ b/sdks/ts/memory-pi/src/config.ts
@@ -1,70 +1,70 @@
-import { z } from "zod"
+import { z } from 'zod'
 
-const StoreConfigSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("auto") }),
-  z.object({ kind: z.literal("fs") }),
-  z.object({ kind: z.literal("git"), remote: z.string().optional() }),
+const StoreConfigSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('auto') }),
+  z.object({ kind: z.literal('fs') }),
+  z.object({ kind: z.literal('git'), remote: z.string().optional() }),
   z.object({
-    kind: z.literal("http"),
+    kind: z.literal('http'),
     endpoint: z.string().url(),
     token: z.string(),
   }),
 ])
 
-const EmbedderConfigSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("auto") }),
+const EmbedderConfigSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('auto') }),
   z.object({
-    kind: z.literal("ollama"),
+    kind: z.literal('ollama'),
     baseUrl: z.string().optional(),
     model: z.string().optional(),
   }),
   z.object({
-    kind: z.literal("openai"),
+    kind: z.literal('openai'),
     apiKey: z.string(),
     model: z.string().optional(),
   }),
-  z.object({ kind: z.literal("tei"), endpoint: z.string().url() }),
-  z.object({ kind: z.literal("off") }),
+  z.object({ kind: z.literal('tei'), endpoint: z.string().url() }),
+  z.object({ kind: z.literal('off') }),
 ])
 
-const ProviderConfigSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("auto") }),
+const ProviderConfigSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('auto') }),
   z.object({
-    kind: z.literal("openai"),
+    kind: z.literal('openai'),
     apiKey: z.string(),
     model: z.string().optional(),
   }),
   z.object({
-    kind: z.literal("anthropic"),
+    kind: z.literal('anthropic'),
     apiKey: z.string(),
     model: z.string().optional(),
   }),
   z.object({
-    kind: z.literal("ollama"),
+    kind: z.literal('ollama'),
     baseUrl: z.string().optional(),
     model: z.string().optional(),
   }),
 ])
 
-const RerankerConfigSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("auto") }),
-  z.object({ kind: z.literal("llm") }),
-  z.object({ kind: z.literal("tei"), endpoint: z.string().url() }),
-  z.object({ kind: z.literal("off") }),
+const RerankerConfigSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('auto') }),
+  z.object({ kind: z.literal('llm') }),
+  z.object({ kind: z.literal('tei'), endpoint: z.string().url() }),
+  z.object({ kind: z.literal('off') }),
 ])
 
 export const MEMORY_TOOL_NAMES = [
-  "remember",
-  "recall",
-  "search",
-  "ask",
-  "ingest_file",
-  "ingest_url",
-  "extract",
-  "reflect",
-  "consolidate",
-  "create_brain",
-  "list_brains",
+  'remember',
+  'recall',
+  'search',
+  'ask',
+  'ingest_file',
+  'ingest_url',
+  'extract',
+  'reflect',
+  'consolidate',
+  'create_brain',
+  'list_brains',
 ] as const
 
 export type MemoryToolName = (typeof MEMORY_TOOL_NAMES)[number]
@@ -101,7 +101,7 @@ export const MemoryExtensionConfigSchema = z
       .optional(),
     consolidate: z
       .object({
-        schedule: z.enum(["manual", "session", "@daily"]).optional(),
+        schedule: z.enum(['manual', 'session', '@daily']).optional(),
       })
       .optional(),
     tools: z
@@ -114,8 +114,8 @@ export const MemoryExtensionConfigSchema = z
         actorId: z.string().optional(),
         provider: z
           .union([
-            z.literal("rbac"),
-            z.object({ kind: z.literal("openfga"), endpoint: z.string().url() }),
+            z.literal('rbac'),
+            z.object({ kind: z.literal('openfga'), endpoint: z.string().url() }),
           ])
           .optional(),
       })

--- a/sdks/ts/memory-pi/src/defaults.ts
+++ b/sdks/ts/memory-pi/src/defaults.ts
@@ -138,18 +138,45 @@ export type ResolvedBrainPaths = {
   readonly searchIndexPath: string
 }
 
+export type ResolveBrainPathsOptions = {
+  /**
+   * Treat `root` as the brain directly and skip the `brainId`
+   * subdirectory join. For single-brain hosts that already manage one
+   * brain per identity at a fixed path.
+   */
+  readonly flat?: boolean
+  /**
+   * Override the resolved search index path. When supplied the FTS
+   * sqlite lives at this absolute path regardless of `flat`. Lets hosts
+   * keep machine-local state out of git-backed brain working trees.
+   */
+  readonly searchIndexPath?: string
+}
+
 /**
  * Resolve the on-disk paths used for a single brain. Mirrors the layout
  * used by the MCP local client so the same brain can be opened by either
  * surface.
+ *
+ * When `opts.flat` is true the `brainId` is preserved as a logical label
+ * but the on-disk root is `root` itself, not `root/<brainId>`. The
+ * default `searchIndexPath` then lands at `<root>/search.sqlite`. Hosts
+ * that keep the brain inside a git working tree should pass an explicit
+ * `opts.searchIndexPath` pointing at a machine-local state directory so
+ * the sqlite never enters the tree.
  */
-export const resolveBrainPaths = (root: string, brainId: string): ResolvedBrainPaths => {
+export const resolveBrainPaths = (
+  root: string,
+  brainId: string,
+  opts: ResolveBrainPathsOptions = {},
+): ResolvedBrainPaths => {
   const cleaned = brainId.replace(/[^A-Za-z0-9._-]/g, '_')
   const safe = cleaned === '' || cleaned.startsWith('.') ? DEFAULT_BRAIN_ID : cleaned
-  const brainRoot = join(root, safe)
+  const brainRoot = opts.flat === true ? root : join(root, safe)
+  const searchIndexPath = opts.searchIndexPath ?? join(brainRoot, 'search.sqlite')
   return {
     root: brainRoot,
     id: safe,
-    searchIndexPath: join(brainRoot, 'search.sqlite'),
+    searchIndexPath,
   }
 }

--- a/sdks/ts/memory-pi/src/defaults.ts
+++ b/sdks/ts/memory-pi/src/defaults.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Auto-detection helpers for the memory-pi extension. Probes the local
+ * environment so callers can ship `{ kind: "auto" }` for store, embedder,
+ * provider, and reranker and get sensible defaults without ceremony.
+ *
+ * The detection order mirrors `mcp/ts/src/memory-client.ts`:
+ *   - Embedder: Ollama on `localhost:11434` (model `bge-m3`).
+ *   - Provider: explicit OPENAI_API_KEY > ANTHROPIC_API_KEY > local Ollama.
+ *   - Reranker: off unless explicit configuration says otherwise.
+ *   - Store: fs (autodetects to git when the root contains a `.git`).
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export type ProbeOptions = {
+  readonly baseUrl?: string
+  readonly timeoutMs?: number
+  readonly fetchImpl?: typeof fetch
+}
+
+export const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434'
+export const DEFAULT_EMBED_MODEL = 'bge-m3'
+export const DEFAULT_OLLAMA_CHAT_MODEL = 'gemma3'
+export const DEFAULT_OPENAI_CHAT_MODEL = 'gpt-4o-mini'
+export const DEFAULT_ANTHROPIC_CHAT_MODEL = 'claude-opus-4-5'
+export const DEFAULT_BRAIN_ROOT = join(homedir(), '.config', 'memory-pi', 'brains')
+export const DEFAULT_BRAIN_ID = 'default'
+
+/**
+ * Probe whether an Ollama-compatible endpoint answers at `/api/tags`. Used
+ * by `selectEmbedder` and `selectProvider` to decide whether to fall back
+ * to local inference.
+ */
+export const ollamaReachable = async (opts: ProbeOptions = {}): Promise<boolean> => {
+  const base = (opts.baseUrl ?? DEFAULT_OLLAMA_BASE_URL).replace(/\/+$/, '')
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? 1500)
+  try {
+    const resp = await fetchImpl(`${base}/api/tags`, { signal: controller.signal })
+    return resp.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export type DetectedProvider =
+  | { readonly kind: 'openai'; readonly apiKey: string; readonly model: string }
+  | { readonly kind: 'anthropic'; readonly apiKey: string; readonly model: string }
+  | { readonly kind: 'ollama'; readonly baseUrl: string; readonly model: string }
+
+export type DetectProviderOptions = ProbeOptions & {
+  readonly env?: NodeJS.ProcessEnv
+}
+
+/**
+ * Choose the best LLM provider available on the host. Returns undefined
+ * when none of the three resolve.
+ */
+export const detectProvider = async (
+  opts: DetectProviderOptions = {},
+): Promise<DetectedProvider | undefined> => {
+  const env = opts.env ?? process.env
+  const openaiKey = env.OPENAI_API_KEY
+  if (openaiKey !== undefined && openaiKey !== '') {
+    return {
+      kind: 'openai',
+      apiKey: openaiKey,
+      model: env.OPENAI_MODEL ?? DEFAULT_OPENAI_CHAT_MODEL,
+    }
+  }
+  const anthropicKey = env.ANTHROPIC_API_KEY
+  if (anthropicKey !== undefined && anthropicKey !== '') {
+    return {
+      kind: 'anthropic',
+      apiKey: anthropicKey,
+      model: env.ANTHROPIC_MODEL ?? DEFAULT_ANTHROPIC_CHAT_MODEL,
+    }
+  }
+  const baseUrl = opts.baseUrl ?? DEFAULT_OLLAMA_BASE_URL
+  if (await ollamaReachable({ ...opts, baseUrl })) {
+    return {
+      kind: 'ollama',
+      baseUrl,
+      model: env.OLLAMA_CHAT_MODEL ?? DEFAULT_OLLAMA_CHAT_MODEL,
+    }
+  }
+  return undefined
+}
+
+export type DetectedEmbedder =
+  | { readonly kind: 'openai'; readonly apiKey: string; readonly model: string }
+  | { readonly kind: 'ollama'; readonly baseUrl: string; readonly model: string }
+
+export type DetectEmbedderOptions = ProbeOptions & {
+  readonly env?: NodeJS.ProcessEnv
+}
+
+/**
+ * Prefer local Ollama for embeddings; fall back to OpenAI text-embedding-3
+ * only when explicitly configured (cost). Returns undefined when neither
+ * is reachable.
+ */
+export const detectEmbedder = async (
+  opts: DetectEmbedderOptions = {},
+): Promise<DetectedEmbedder | undefined> => {
+  const env = opts.env ?? process.env
+  const baseUrl = opts.baseUrl ?? DEFAULT_OLLAMA_BASE_URL
+  if (await ollamaReachable({ ...opts, baseUrl })) {
+    return {
+      kind: 'ollama',
+      baseUrl,
+      model: env.OLLAMA_EMBED_MODEL ?? DEFAULT_EMBED_MODEL,
+    }
+  }
+  // Fall back to OpenAI embeddings only when the user opts in via a
+  // dedicated env var so we never silently bill an OpenAI key set for
+  // chat completions for embedding work.
+  const openaiKey = env.OPENAI_EMBEDDING_API_KEY ?? env.OPENAI_API_KEY
+  if (openaiKey !== undefined && openaiKey !== '' && env.MEMORY_PI_EMBEDDER_OPENAI === 'true') {
+    return {
+      kind: 'openai',
+      apiKey: openaiKey,
+      model: env.OPENAI_EMBED_MODEL ?? 'text-embedding-3-small',
+    }
+  }
+  return undefined
+}
+
+export type ResolvedBrainPaths = {
+  readonly root: string
+  readonly id: string
+  readonly searchIndexPath: string
+}
+
+/**
+ * Resolve the on-disk paths used for a single brain. Mirrors the layout
+ * used by the MCP local client so the same brain can be opened by either
+ * surface.
+ */
+export const resolveBrainPaths = (root: string, brainId: string): ResolvedBrainPaths => {
+  const cleaned = brainId.replace(/[^A-Za-z0-9._-]/g, '_')
+  const safe = cleaned === '' || cleaned.startsWith('.') ? DEFAULT_BRAIN_ID : cleaned
+  const brainRoot = join(root, safe)
+  return {
+    root: brainRoot,
+    id: safe,
+    searchIndexPath: join(brainRoot, 'search.sqlite'),
+  }
+}

--- a/sdks/ts/memory-pi/src/hooks.ts
+++ b/sdks/ts/memory-pi/src/hooks.ts
@@ -1,0 +1,5 @@
+// Placeholder. W3 implements four lifecycle hooks: before_agent_start (recall
+// injection, cache-friendly), context (re-inject on diff), turn_end (extract),
+// session_shutdown (reflect + close). See PLAN.md section 5.
+
+export {}

--- a/sdks/ts/memory-pi/src/hooks.ts
+++ b/sdks/ts/memory-pi/src/hooks.ts
@@ -199,7 +199,10 @@ export const registerMemoryHooks = (
 
   const contextHook = async (event: ContextEvent): Promise<ContextEventResult | undefined> => {
     if (surface !== 'context') return undefined
-    if (!cfg.recallOnPrompt) return undefined
+    // Note: `cfg.recallOnPrompt` gates the system-prompt surface only.
+    // When the host has explicitly opted into context-surface injection
+    // we always run the recall, otherwise both surfaces would be
+    // simultaneously gateable and recall could vanish entirely.
     const latestUser = findLatestUserText(event.messages as unknown as readonly AgentMessageLike[])
     if (latestUser === undefined) return undefined
     const snapshot = await buildRecallSnapshot(runtime, latestUser)

--- a/sdks/ts/memory-pi/src/hooks.ts
+++ b/sdks/ts/memory-pi/src/hooks.ts
@@ -1,5 +1,309 @@
-// Placeholder. W3 implements four lifecycle hooks: before_agent_start (recall
-// injection, cache-friendly), context (re-inject on diff), turn_end (extract),
-// session_shutdown (reflect + close). See PLAN.md section 5.
+// SPDX-License-Identifier: Apache-2.0
 
-export {}
+/**
+ * Four pi lifecycle hooks that turn the runtime into a self-driving
+ * memory layer:
+ *
+ *   - `before_agent_start` runs the recall pipeline against the user's
+ *     prompt and injects a `<recalled-memory>...</recalled-memory>`
+ *     block into the system prompt. Cache-friendly mode keeps the block
+ *     stable across turns when the recalled set has not changed.
+ *
+ *   - `context` mirrors the recall block as a per-turn user message so
+ *     callers that want the recall block to live below the prompt cache
+ *     can flip `recall.onPrompt: false` and use the per-turn variant.
+ *
+ *   - `turn_end` enqueues a non-blocking extract job once the message
+ *     threshold is met. The extract queue drains in the background.
+ *
+ *   - `session_shutdown` drains the extract queue, optionally runs
+ *     reflect, optionally runs consolidate, then closes the underlying
+ *     store and search index handles.
+ */
+
+import { createHash } from 'node:crypto'
+import type {
+  BeforeAgentStartEvent,
+  BeforeAgentStartEventResult,
+  ContextEvent,
+  ExtensionAPI,
+  SessionShutdownEvent,
+  TurnEndEvent,
+} from '@earendil-works/pi-coding-agent'
+import type { Message, RecallHit, Scope } from '@jeffs-brain/memory'
+import type { MemoryRuntime, RecallSnapshot } from './runtime.js'
+import { renderRecallBlock } from './runtime.js'
+
+/**
+ * Local alias for the structurally-typed agent messages pi passes
+ * through `context` and `turn_end`. The pi type lives in the agent
+ * package and is not re-exported from the public extension barrel, so
+ * we describe only the fields we touch and rely on duck-typing.
+ */
+type AgentMessageLike = {
+  readonly role?: string
+  readonly content?: unknown
+} & Record<string, unknown>
+
+/** Local mirror of pi's `ContextEventResult`. */
+type ContextEventResult = {
+  readonly messages?: ReadonlyArray<AgentMessageLike>
+}
+
+const RECALL_TAG_OPEN = '<recalled-memory>'
+const RECALL_TAG_CLOSE = '</recalled-memory>'
+
+const hashQuery = (query: string): string =>
+  createHash('sha1').update(query, 'utf8').digest('hex').slice(0, 16)
+
+const recallSetSignature = (hits: readonly RecallHit[]): string =>
+  hits.map((hit) => `${hit.path}:${hit.score.toFixed(4)}`).join('|')
+
+/**
+ * Compute a fresh `RecallSnapshot` for the given query. Returns
+ * `undefined` when recall returns no hits and the caller prefers to
+ * skip injection (currently we always inject the labelled empty block
+ * so the prompt cache sees a stable shape).
+ */
+export const buildRecallSnapshot = async (
+  runtime: MemoryRuntime,
+  query: string,
+): Promise<RecallSnapshot> => {
+  const cfg = runtime.config
+  const hits =
+    query.trim() === ''
+      ? []
+      : await runtime.memory
+          .recall({
+            query,
+            k: cfg.recallTopK,
+            scope: cfg.scope,
+            actorId: cfg.actorId,
+            ...(cfg.fallbackScopes.length > 0 ? { fallbackScopes: cfg.fallbackScopes } : {}),
+          })
+          .then((res) =>
+            cfg.recallMinScore > 0 ? res.filter((h) => h.score >= cfg.recallMinScore) : res,
+          )
+  return {
+    query,
+    paths: hits.map((hit) => hit.path),
+    block: renderRecallBlock(hits),
+    hits,
+  }
+}
+
+/**
+ * Inject the recall block into the system prompt. When
+ * `cacheFriendly` is on we check the in-memory `lastRecall` signature
+ * before re-injecting so an unchanged set keeps the prompt-cache
+ * boundary stable.
+ */
+const injectRecall = (systemPrompt: string, snapshot: RecallSnapshot): string => {
+  const trimmed = stripPreviousRecall(systemPrompt)
+  return `${trimmed}\n\n${snapshot.block}`
+}
+
+const stripPreviousRecall = (text: string): string => {
+  const open = text.indexOf(RECALL_TAG_OPEN)
+  if (open === -1) return text.trimEnd()
+  const close = text.indexOf(RECALL_TAG_CLOSE, open)
+  if (close === -1) return text.trimEnd()
+  const before = text.slice(0, open).trimEnd()
+  const after = text.slice(close + RECALL_TAG_CLOSE.length).trimStart()
+  return `${before}${before !== '' && after !== '' ? '\n\n' : ''}${after}`.trimEnd()
+}
+
+const messagesFromTurnEnd = (event: TurnEndEvent): readonly Message[] => {
+  const messages: Message[] = []
+  pushAgentMessage(messages, event.message as unknown as AgentMessageLike)
+  for (const tr of event.toolResults) {
+    pushAgentMessage(messages, tr as unknown as AgentMessageLike)
+  }
+  return messages
+}
+
+const pushAgentMessage = (sink: Message[], msg: AgentMessageLike): void => {
+  // Pi AgentMessage may be a custom type or the standard role-based
+  // message. We only forward role-based messages.
+  if (typeof msg !== 'object' || msg === null) return
+  const role = msg.role
+  if (role !== 'system' && role !== 'user' && role !== 'assistant' && role !== 'tool') {
+    return
+  }
+  const content = msg.content
+  if (typeof content === 'string') {
+    sink.push({ role, content })
+    return
+  }
+  if (Array.isArray(content)) {
+    const text = content
+      .map((part) => {
+        if (typeof part === 'string') return part
+        if (part && typeof part === 'object') {
+          if ('text' in part && typeof (part as { text?: unknown }).text === 'string') {
+            return (part as { text: string }).text
+          }
+        }
+        return ''
+      })
+      .filter((s) => s.length > 0)
+      .join('\n')
+    if (text !== '') sink.push({ role, content: text })
+  }
+}
+
+export type RegisterHooksOptions = {
+  /** Override the message threshold from runtime config. */
+  readonly extractMinMessages?: number
+  /**
+   * Inject the recall block at the per-turn boundary (`context`) instead
+   * of the system prompt. Used when callers want the recall set below
+   * the cache boundary.
+   */
+  readonly recallSurface?: 'system' | 'context'
+}
+
+/**
+ * Wire the four lifecycle hooks into `pi`. Returns a small handle the
+ * caller can drive directly in tests (and the host extension can use
+ * to expose `flush()` / `close()`).
+ */
+export const registerMemoryHooks = (
+  pi: ExtensionAPI,
+  runtime: MemoryRuntime,
+  options: RegisterHooksOptions = {},
+): MemoryHookHandle => {
+  const cfg = runtime.config
+  const turnsSinceExtract = { count: 0 }
+  const surface = options.recallSurface ?? 'system'
+  const extractThreshold = options.extractMinMessages ?? cfg.extractMinMessages
+
+  const beforeAgentStart = async (
+    event: BeforeAgentStartEvent,
+  ): Promise<BeforeAgentStartEventResult | undefined> => {
+    if (!cfg.recallOnPrompt) return undefined
+    if (surface !== 'system') return undefined
+    const snapshot = await buildRecallSnapshot(runtime, event.prompt)
+    if (cfg.recallCacheFriendly && runtime.lastRecall !== undefined) {
+      const prev = runtime.lastRecall
+      if (recallSetSignature(prev.hits) === recallSetSignature(snapshot.hits)) {
+        // No change in recall set: keep the system prompt as-is so the
+        // cache boundary stays stable.
+        runtime.lastRecall = snapshot
+        return undefined
+      }
+    }
+    runtime.lastRecall = snapshot
+    return { systemPrompt: injectRecall(event.systemPrompt, snapshot) }
+  }
+
+  const contextHook = async (event: ContextEvent): Promise<ContextEventResult | undefined> => {
+    if (surface !== 'context') return undefined
+    if (!cfg.recallOnPrompt) return undefined
+    const latestUser = findLatestUserText(event.messages as unknown as readonly AgentMessageLike[])
+    if (latestUser === undefined) return undefined
+    const snapshot = await buildRecallSnapshot(runtime, latestUser)
+    if (cfg.recallCacheFriendly && runtime.lastRecall !== undefined) {
+      if (recallSetSignature(runtime.lastRecall.hits) === recallSetSignature(snapshot.hits)) {
+        runtime.lastRecall = snapshot
+        return undefined
+      }
+    }
+    runtime.lastRecall = snapshot
+    const injected: AgentMessageLike = {
+      role: 'user',
+      content: snapshot.block,
+    }
+    return {
+      messages: [...(event.messages as unknown as readonly AgentMessageLike[]), injected],
+    }
+  }
+
+  const turnEnd = async (event: TurnEndEvent): Promise<void> => {
+    if (!cfg.extractOnTurnEnd) return
+    turnsSinceExtract.count += 1
+    if (turnsSinceExtract.count < extractThreshold) return
+    const messages = messagesFromTurnEnd(event)
+    if (messages.length === 0) return
+    runtime.extractQueue.enqueue({
+      messages,
+      actorId: cfg.actorId,
+      scope: cfg.scope as Scope,
+    })
+    turnsSinceExtract.count = 0
+  }
+
+  const sessionShutdown = async (_event: SessionShutdownEvent): Promise<void> => {
+    await runtime.extractQueue.flush()
+    if (cfg.reflectOnSessionEnd && runtime.provider !== undefined) {
+      try {
+        await runtime.memory.reflect({
+          sessionId: `pi-${Date.now()}`,
+          messages: [],
+        })
+      } catch {
+        // Reflection failures must not block shutdown.
+      }
+    }
+    if (cfg.consolidateSchedule === 'session' && runtime.provider !== undefined) {
+      try {
+        await runtime.memory.consolidate({})
+      } catch {
+        // Same: best-effort consolidation only.
+      }
+    }
+  }
+
+  pi.on('before_agent_start', beforeAgentStart)
+  // The pi `context` handler type lives in `@earendil-works/pi-agent-core`
+  // (re-exported via the internal extensions barrel) and is not in the
+  // public surface; cast through `unknown` so we can still register.
+  ;(pi.on as (e: 'context', h: typeof contextHook) => void)('context', contextHook)
+  pi.on('turn_end', turnEnd)
+  pi.on('session_shutdown', sessionShutdown)
+
+  return {
+    runtime,
+    handleBeforeAgentStart: beforeAgentStart,
+    handleContext: contextHook,
+    handleTurnEnd: turnEnd,
+    handleSessionShutdown: sessionShutdown,
+  }
+}
+
+const findLatestUserText = (messages: readonly AgentMessageLike[]): string | undefined => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]
+    if (msg === undefined) continue
+    if ((msg as { role?: string }).role !== 'user') continue
+    const content = (msg as { content?: unknown }).content
+    if (typeof content === 'string' && content.trim() !== '') return content
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (typeof part === 'string' && part.trim() !== '') return part
+        if (
+          part &&
+          typeof part === 'object' &&
+          'text' in part &&
+          typeof (part as { text?: unknown }).text === 'string' &&
+          (part as { text: string }).text.trim() !== ''
+        ) {
+          return (part as { text: string }).text
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+export type MemoryHookHandle = {
+  readonly runtime: MemoryRuntime
+  handleBeforeAgentStart(
+    event: BeforeAgentStartEvent,
+  ): Promise<BeforeAgentStartEventResult | undefined>
+  handleContext(event: ContextEvent): Promise<ContextEventResult | undefined>
+  handleTurnEnd(event: TurnEndEvent): Promise<void>
+  handleSessionShutdown(event: SessionShutdownEvent): Promise<void>
+}
+
+export { hashQuery, recallSetSignature, RECALL_TAG_OPEN, RECALL_TAG_CLOSE }

--- a/sdks/ts/memory-pi/src/index.ts
+++ b/sdks/ts/memory-pi/src/index.ts
@@ -1,26 +1,124 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { MemoryExtensionConfigSchema, type MemoryExtensionConfig } from "./config.js"
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Public entrypoint for `@jeffs-brain/memory-pi`. Exposes a single
+ * factory, `createMemoryExtension`, that wires the eleven memory tools
+ * and four lifecycle hooks into the pi runtime, plus a default export
+ * that conforms to the pi extension contract (default function that
+ * accepts an `ExtensionAPI`).
+ *
+ * Heavy initialisation (Store, SearchIndex, Embedder, Provider, Memory)
+ * runs asynchronously via the returned `ready` promise so the pi loader
+ * can await it before firing `session_start`. The synchronous handle
+ * returned from `createMemoryExtension` is what gets passed back to
+ * callers that need to flush / close the runtime explicitly.
+ */
+
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { type MemoryExtensionConfig, MemoryExtensionConfigSchema } from './config.js'
+import { type MemoryHookHandle, registerMemoryHooks } from './hooks.js'
+import { type MemoryRuntime, type RuntimeLogger, createMemoryRuntime } from './runtime.js'
+import { registerMemoryTools } from './tools.js'
 
 export type MemoryExtension = {
-  flush: () => Promise<void>
-  close: () => Promise<void>
+  /** Wait for the runtime to be fully initialised. */
+  readonly ready: Promise<MemoryRuntime>
+  /**
+   * The handle returned by `registerMemoryHooks`. Useful for tests that
+   * want to drive lifecycle events directly without round-tripping
+   * through `pi.on(...)` dispatch.
+   */
+  readonly hooks: Promise<MemoryHookHandle>
+  /** Drain the extract queue without closing the runtime. */
+  flush(): Promise<void>
+  /** Flush + close the underlying store and search index. Idempotent. */
+  close(): Promise<void>
 }
 
-export function createMemoryExtension(
-  _pi: ExtensionAPI,
-  _config?: MemoryExtensionConfig,
-): MemoryExtension {
-  throw new Error(
-    "@jeffs-brain/memory-pi.createMemoryExtension: not implemented yet. W3 fills this in.",
-  )
+export type CreateMemoryExtensionOptions = {
+  readonly logger?: RuntimeLogger
 }
 
-export default function (pi: ExtensionAPI): void {
+/**
+ * Build a memory-pi extension instance and register its tools / hooks
+ * on the supplied pi runtime. Returns synchronously so callers can hold
+ * a handle, but most consumers should await `ext.ready` to make sure
+ * tools and hooks are wired before driving the agent.
+ */
+export const createMemoryExtension = (
+  pi: ExtensionAPI,
+  config?: MemoryExtensionConfig,
+  options: CreateMemoryExtensionOptions = {},
+): MemoryExtension => {
+  const parsed = config !== undefined ? MemoryExtensionConfigSchema.parse(config) : {}
+  let runtime: MemoryRuntime | undefined
+  let hookHandle: MemoryHookHandle | undefined
+
+  const init = (async (): Promise<MemoryRuntime> => {
+    const built = await createMemoryRuntime(
+      parsed,
+      options.logger !== undefined ? { logger: options.logger } : {},
+    )
+    runtime = built
+    registerMemoryTools(pi, built)
+    hookHandle = registerMemoryHooks(pi, built)
+    return built
+  })()
+
+  const hooks = (async (): Promise<MemoryHookHandle> => {
+    await init
+    if (hookHandle === undefined) {
+      throw new Error('memory-pi: hooks were not initialised')
+    }
+    return hookHandle
+  })()
+
+  return {
+    ready: init,
+    hooks,
+    async flush() {
+      const r = runtime ?? (await init)
+      await r.extractQueue.flush()
+    },
+    async close() {
+      const r = runtime ?? (await init)
+      await r.close()
+    },
+  }
+}
+
+/**
+ * Default export that conforms to the pi extension contract. Reads
+ * configuration from the `MEMORY_PI_CONFIG` env var (JSON-encoded) so
+ * `pi -e ./dist/index.js` works without recompiling the extension.
+ */
+const defaultExport = async (pi: ExtensionAPI): Promise<void> => {
   const raw = process.env.MEMORY_PI_CONFIG
-    ? JSON.parse(process.env.MEMORY_PI_CONFIG)
-    : {}
-  const config = MemoryExtensionConfigSchema.parse(raw)
-  createMemoryExtension(pi, config)
+  const config: MemoryExtensionConfig = raw !== undefined && raw !== '' ? JSON.parse(raw) : {}
+  const ext = createMemoryExtension(pi, config)
+  await ext.ready
 }
 
-export { MemoryExtensionConfigSchema, type MemoryExtensionConfig } from "./config.js"
+export default defaultExport
+
+export { MemoryExtensionConfigSchema, MEMORY_TOOL_NAMES } from './config.js'
+export type { MemoryExtensionConfig, MemoryToolName } from './config.js'
+export type {
+  MemoryRuntime,
+  ResolvedRuntimeConfig,
+  RuntimeLogger,
+  ExtractJob,
+  RecallSnapshot,
+} from './runtime.js'
+export { createMemoryRuntime, resolveRuntimeConfig, renderRecallBlock } from './runtime.js'
+export { registerMemoryHooks, type MemoryHookHandle } from './hooks.js'
+export { registerMemoryTools, buildTools } from './tools.js'
+export {
+  detectProvider,
+  detectEmbedder,
+  ollamaReachable,
+  resolveBrainPaths,
+  DEFAULT_BRAIN_ROOT,
+  DEFAULT_BRAIN_ID,
+  DEFAULT_OLLAMA_BASE_URL,
+} from './defaults.js'

--- a/sdks/ts/memory-pi/src/index.ts
+++ b/sdks/ts/memory-pi/src/index.ts
@@ -1,0 +1,26 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { MemoryExtensionConfigSchema, type MemoryExtensionConfig } from "./config.js"
+
+export type MemoryExtension = {
+  flush: () => Promise<void>
+  close: () => Promise<void>
+}
+
+export function createMemoryExtension(
+  _pi: ExtensionAPI,
+  _config?: MemoryExtensionConfig,
+): MemoryExtension {
+  throw new Error(
+    "@jeffs-brain/memory-pi.createMemoryExtension: not implemented yet. W3 fills this in.",
+  )
+}
+
+export default function (pi: ExtensionAPI): void {
+  const raw = process.env.MEMORY_PI_CONFIG
+    ? JSON.parse(process.env.MEMORY_PI_CONFIG)
+    : {}
+  const config = MemoryExtensionConfigSchema.parse(raw)
+  createMemoryExtension(pi, config)
+}
+
+export { MemoryExtensionConfigSchema, type MemoryExtensionConfig } from "./config.js"

--- a/sdks/ts/memory-pi/src/index.ts
+++ b/sdks/ts/memory-pi/src/index.ts
@@ -92,9 +92,18 @@ export const createMemoryExtension = (
  * configuration from the `MEMORY_PI_CONFIG` env var (JSON-encoded) so
  * `pi -e ./dist/index.js` works without recompiling the extension.
  */
+const parseEnvConfig = (raw: string | undefined): MemoryExtensionConfig => {
+  if (raw === undefined || raw === '') return {}
+  try {
+    return JSON.parse(raw) as MemoryExtensionConfig
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`memory-pi: MEMORY_PI_CONFIG is not valid JSON: ${detail}`)
+  }
+}
+
 const defaultExport = async (pi: ExtensionAPI): Promise<void> => {
-  const raw = process.env.MEMORY_PI_CONFIG
-  const config: MemoryExtensionConfig = raw !== undefined && raw !== '' ? JSON.parse(raw) : {}
+  const config = parseEnvConfig(process.env.MEMORY_PI_CONFIG)
   const ext = createMemoryExtension(pi, config)
   await ext.ready
 }

--- a/sdks/ts/memory-pi/src/runtime-logger.ts
+++ b/sdks/ts/memory-pi/src/runtime-logger.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Lightweight logger contract shared by the runtime and the bootstrap
+ * helpers. Lives in its own module so other modules can depend on the
+ * type without pulling in the rest of `runtime.ts`.
+ */
+
+export type RuntimeLogger = {
+  info(message: string, ctx?: Record<string, unknown>): void
+  warn(message: string, ctx?: Record<string, unknown>): void
+  error(message: string, ctx?: Record<string, unknown>): void
+}
+
+export const noopRuntimeLogger: RuntimeLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}

--- a/sdks/ts/memory-pi/src/runtime.ts
+++ b/sdks/ts/memory-pi/src/runtime.ts
@@ -13,6 +13,7 @@
  */
 
 import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
 import {
   AnthropicProvider,
   type Embedder,
@@ -26,16 +27,21 @@ import {
   type Provider,
   type RecallHit,
   type Scope,
+  type SearchHit,
+  type SearchIndex as MemorySearchIndex,
   type SqliteSearchIndex,
   type Store,
   autodetectStore,
   createMemory,
   createSearchIndex,
   createStoreBackedCursorStore,
+  scopePrefix,
+  toPath,
 } from '@jeffs-brain/memory'
 import type { Message } from '@jeffs-brain/memory'
 import type { Retrieval } from '@jeffs-brain/memory/retrieval'
 import { createRetrieval } from '@jeffs-brain/memory/retrieval'
+import { bootstrapFlatBrain } from './bootstrap-flat.js'
 import type { MemoryExtensionConfig } from './config.js'
 import {
   DEFAULT_BRAIN_ID,
@@ -45,18 +51,10 @@ import {
   detectProvider,
   resolveBrainPaths,
 } from './defaults.js'
+import { type RuntimeLogger, noopRuntimeLogger } from './runtime-logger.js'
 
-export type RuntimeLogger = {
-  info(message: string, ctx?: Record<string, unknown>): void
-  warn(message: string, ctx?: Record<string, unknown>): void
-  error(message: string, ctx?: Record<string, unknown>): void
-}
-
-export const noopRuntimeLogger: RuntimeLogger = {
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-}
+export { noopRuntimeLogger } from './runtime-logger.js'
+export type { RuntimeLogger } from './runtime-logger.js'
 
 export type ExtractJob = {
   readonly messages: readonly Message[]
@@ -97,6 +95,9 @@ export type MemoryRuntime = {
 export type ResolvedRuntimeConfig = {
   readonly brainRoot: string
   readonly brainId: string
+  readonly flatLayout: boolean
+  readonly searchIndexPath: string | undefined
+  readonly bootstrapScanDirs: readonly string[] | undefined
   readonly scope: Scope
   readonly fallbackScopes: readonly Scope[]
   readonly actorId: string
@@ -111,6 +112,12 @@ export type ResolvedRuntimeConfig = {
   readonly exposedTools: readonly string[] | undefined
 }
 
+const truthyEnv = (value: string | undefined): boolean => {
+  if (value === undefined) return false
+  const v = value.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+}
+
 /**
  * Resolve the user-supplied configuration into the dense runtime form.
  * Missing fields fall back to documented defaults so callers can pass
@@ -122,12 +129,18 @@ export const resolveRuntimeConfig = (
 ): ResolvedRuntimeConfig => {
   const brainRoot = config?.brainRoot ?? env.MEMORY_PI_BRAIN_ROOT ?? DEFAULT_BRAIN_ROOT
   const brainId = config?.brainId ?? env.MEMORY_PI_BRAIN_ID ?? DEFAULT_BRAIN_ID
+  const flatLayout = config?.flatLayout ?? truthyEnv(env.MEMORY_PI_FLAT_LAYOUT)
+  const searchIndexPath = config?.searchIndexPath ?? env.MEMORY_PI_SEARCH_INDEX_PATH
+  const bootstrapScanDirs = config?.bootstrapScanDirs
   const scope = (config?.recall?.scope as Scope | undefined) ?? 'global'
   const fallbackScopes = (config?.recall?.fallbackScopes as readonly Scope[] | undefined) ?? []
   const actorId = config?.acl?.actorId ?? env.MEMORY_PI_ACTOR_ID ?? 'pi-user'
   return {
     brainRoot,
     brainId,
+    flatLayout,
+    searchIndexPath,
+    bootstrapScanDirs,
     scope,
     fallbackScopes,
     actorId,
@@ -249,8 +262,19 @@ export const createMemoryRuntime = async (
 ): Promise<MemoryRuntime> => {
   const logger = options.logger ?? noopRuntimeLogger
   const resolved = resolveRuntimeConfig(config)
-  const paths = resolveBrainPaths(resolved.brainRoot, resolved.brainId)
+  const paths = resolveBrainPaths(resolved.brainRoot, resolved.brainId, {
+    flat: resolved.flatLayout,
+    ...(resolved.searchIndexPath !== undefined
+      ? { searchIndexPath: resolved.searchIndexPath }
+      : {}),
+  })
   await mkdir(paths.root, { recursive: true })
+  // When the search index is redirected outside the brain root (typical
+  // for hosts that keep the brain in a git working tree), make sure the
+  // target directory exists before sqlite tries to open it.
+  if (resolved.searchIndexPath !== undefined) {
+    await mkdir(dirname(paths.searchIndexPath), { recursive: true })
+  }
   const store = await buildStore(config, paths.root)
   const searchIndex = await createSearchIndex({ dbPath: paths.searchIndexPath })
   const embedder = await buildEmbedder(config)
@@ -265,11 +289,40 @@ export const createMemoryRuntime = async (
     logger.warn('memory-pi: no embedder detected; vector recall disabled')
   }
 
+  // Single-brain hosts: walk the existing on-disk content once on boot
+  // so memory_search / memory_recall query the same wiki + memory + raw
+  // files the host already manages, without writing copies back into
+  // the brain Store. Idempotent: re-entries hit the indexed-paths cache
+  // in `bootstrapFlatBrain` and become no-ops.
+  if (resolved.flatLayout) {
+    try {
+      await bootstrapFlatBrain({
+        brainRoot: paths.root,
+        brainId: paths.id,
+        searchIndex,
+        ...(resolved.bootstrapScanDirs !== undefined
+          ? { scanDirs: resolved.bootstrapScanDirs }
+          : {}),
+        logger,
+      })
+    } catch (err) {
+      logger.error('memory-pi: flat bootstrap failed', {
+        err: err instanceof Error ? err.message : String(err),
+        brainRoot: paths.root,
+      })
+    }
+  }
+
   const retrieval = createRetrieval({
     index: searchIndex,
     ...(embedder !== undefined ? { embedder } : {}),
   })
 
+  // Wire the SQLite SearchIndex into `createMemory` via a thin adapter
+  // so `Memory.recall` can use the FTS results instead of the fallback
+  // path that lists files under the scope prefix (which is empty in
+  // single-brain hosts that use a flat layout).
+  const memorySearchAdapter = buildMemorySearchAdapter(searchIndex, resolved.flatLayout)
   // The Memory pipeline requires a non-undefined Provider. When the
   // user has no chat provider we fall back to a "no-op" lazy provider
   // that throws on use; this keeps the runtime constructable so recall
@@ -279,6 +332,7 @@ export const createMemoryRuntime = async (
     store,
     provider: memoryProvider,
     ...(embedder !== undefined ? { embedder } : {}),
+    searchIndex: memorySearchAdapter,
     scope: resolved.scope,
     actorId: resolved.actorId,
     cursorStore: createStoreBackedCursorStore(store),
@@ -304,6 +358,41 @@ export const createMemoryRuntime = async (
   }
   return runtime
 }
+
+/**
+ * Bridge the SQLite SearchIndex into the lightweight `SearchIndex`
+ * contract that `Memory.recall` consumes. In scoped mode we mirror the
+ * package's recall fallback: filter BM25 hits to paths that live under
+ * the scope prefix. In flat mode (single-brain hosts) the scope is
+ * advisory only — every BM25 hit is returned so flat layouts where
+ * notes live at `memory/<slug>.md` rather than `memory/global/<slug>.md`
+ * still surface results.
+ */
+const buildMemorySearchAdapter = (
+  index: SqliteSearchIndex,
+  flatLayout: boolean,
+): MemorySearchIndex => ({
+  async search(query, _embedding, opts) {
+    const k = Math.max(1, opts.k)
+    const hits = index.searchBM25(query, k)
+    if (hits.length === 0) return []
+    const out: SearchHit[] = []
+    if (!flatLayout && opts.scope !== undefined) {
+      const prefix = scopePrefix(opts.scope, opts.actorId ?? '')
+      for (const hit of hits) {
+        const path = hit.chunk.path
+        if (path === prefix || path.startsWith(`${prefix}/`)) {
+          out.push({ path: toPath(path), score: hit.score })
+        }
+      }
+      return out
+    }
+    for (const hit of hits) {
+      out.push({ path: toPath(hit.chunk.path), score: hit.score })
+    }
+    return out
+  },
+})
 
 /**
  * Provider stub that throws when called. We install this so callers

--- a/sdks/ts/memory-pi/src/runtime.ts
+++ b/sdks/ts/memory-pi/src/runtime.ts
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Runtime wiring shared by the tools and hooks. Builds the memory
+ * pipeline (Store + Embedder + Provider + SearchIndex + Retrieval +
+ * Memory) once per extension instance and exposes a small set of
+ * coordinator primitives (extract queue, recall cache).
+ *
+ * The runtime is intentionally agnostic of the pi `ExtensionAPI`. Both
+ * the tools and the hook handlers receive a runtime via dependency
+ * injection so unit tests can drive the runtime without spinning up
+ * the pi loader.
+ */
+
+import { mkdir } from 'node:fs/promises'
+import {
+  AnthropicProvider,
+  type Embedder,
+  type ExtractedMemory,
+  type Memory,
+  type MemoryNote,
+  OllamaEmbedder,
+  OllamaProvider,
+  OpenAIEmbedder,
+  OpenAIProvider,
+  type Provider,
+  type RecallHit,
+  type Scope,
+  type SqliteSearchIndex,
+  type Store,
+  autodetectStore,
+  createMemory,
+  createSearchIndex,
+  createStoreBackedCursorStore,
+} from '@jeffs-brain/memory'
+import type { Message } from '@jeffs-brain/memory'
+import type { Retrieval } from '@jeffs-brain/memory/retrieval'
+import { createRetrieval } from '@jeffs-brain/memory/retrieval'
+import type { MemoryExtensionConfig } from './config.js'
+import {
+  DEFAULT_BRAIN_ID,
+  DEFAULT_BRAIN_ROOT,
+  DEFAULT_OLLAMA_BASE_URL,
+  detectEmbedder,
+  detectProvider,
+  resolveBrainPaths,
+} from './defaults.js'
+
+export type RuntimeLogger = {
+  info(message: string, ctx?: Record<string, unknown>): void
+  warn(message: string, ctx?: Record<string, unknown>): void
+  error(message: string, ctx?: Record<string, unknown>): void
+}
+
+export const noopRuntimeLogger: RuntimeLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+export type ExtractJob = {
+  readonly messages: readonly Message[]
+  readonly actorId?: string
+  readonly sessionId?: string
+  readonly scope?: Scope
+}
+
+export type ExtractQueueState = {
+  enqueue(job: ExtractJob): void
+  flush(): Promise<void>
+  size(): number
+}
+
+export type RecallSnapshot = {
+  readonly query: string
+  readonly paths: readonly string[]
+  readonly block: string
+  readonly hits: readonly RecallHit[]
+}
+
+export type MemoryRuntime = {
+  readonly config: ResolvedRuntimeConfig
+  readonly store: Store
+  readonly searchIndex: SqliteSearchIndex
+  readonly embedder: Embedder | undefined
+  readonly provider: Provider | undefined
+  readonly memory: Memory
+  readonly retrieval: Retrieval
+  readonly extractQueue: ExtractQueueState
+  /** Most recent recall snapshot keyed by hashed user-message. */
+  lastRecall?: RecallSnapshot
+  /** Last extracted batch, exposed for tests and observability. */
+  lastExtracted?: readonly ExtractedMemory[]
+  close(): Promise<void>
+}
+
+export type ResolvedRuntimeConfig = {
+  readonly brainRoot: string
+  readonly brainId: string
+  readonly scope: Scope
+  readonly fallbackScopes: readonly Scope[]
+  readonly actorId: string
+  readonly extractMinMessages: number
+  readonly recallTopK: number
+  readonly recallMinScore: number
+  readonly extractOnTurnEnd: boolean
+  readonly reflectOnSessionEnd: boolean
+  readonly consolidateSchedule: 'manual' | 'session' | '@daily'
+  readonly recallOnPrompt: boolean
+  readonly recallCacheFriendly: boolean
+  readonly exposedTools: readonly string[] | undefined
+}
+
+/**
+ * Resolve the user-supplied configuration into the dense runtime form.
+ * Missing fields fall back to documented defaults so callers can pass
+ * `{}` and get a working extension.
+ */
+export const resolveRuntimeConfig = (
+  config: MemoryExtensionConfig | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedRuntimeConfig => {
+  const brainRoot = config?.brainRoot ?? env.MEMORY_PI_BRAIN_ROOT ?? DEFAULT_BRAIN_ROOT
+  const brainId = config?.brainId ?? env.MEMORY_PI_BRAIN_ID ?? DEFAULT_BRAIN_ID
+  const scope = (config?.recall?.scope as Scope | undefined) ?? 'global'
+  const fallbackScopes = (config?.recall?.fallbackScopes as readonly Scope[] | undefined) ?? []
+  const actorId = config?.acl?.actorId ?? env.MEMORY_PI_ACTOR_ID ?? 'pi-user'
+  return {
+    brainRoot,
+    brainId,
+    scope,
+    fallbackScopes,
+    actorId,
+    extractMinMessages: config?.extract?.minMessages ?? 6,
+    recallTopK: config?.recall?.topK ?? 5,
+    recallMinScore: config?.recall?.minScore ?? 0,
+    extractOnTurnEnd: config?.extract?.onTurnEnd ?? true,
+    reflectOnSessionEnd: config?.reflect?.onSessionEnd ?? true,
+    consolidateSchedule: config?.consolidate?.schedule ?? 'manual',
+    recallOnPrompt: config?.recall?.onPrompt ?? true,
+    recallCacheFriendly: config?.recall?.cacheFriendly ?? true,
+    exposedTools: config?.tools?.expose,
+  }
+}
+
+/**
+ * Build a Store from a `StoreConfig`. `auto` defers to `autodetectStore`
+ * which picks fs or git based on whether `.git` is present.
+ */
+const buildStore = async (
+  config: MemoryExtensionConfig | undefined,
+  brainRoot: string,
+): Promise<Store> => {
+  const storeConfig = config?.store
+  const kind = storeConfig?.kind ?? 'auto'
+  await mkdir(brainRoot, { recursive: true })
+  if (kind === 'auto' || kind === 'fs' || kind === 'git') {
+    return autodetectStore({ root: brainRoot })
+  }
+  if (kind === 'http') {
+    // The http store lives behind the same Store interface but the
+    // pi extension does not own its lifecycle today; surface a clear
+    // error so callers know to plumb it themselves until W5.
+    throw new Error('memory-pi: http store kind is not wired yet; pass store: { kind: "auto" }')
+  }
+  throw new Error(`memory-pi: unknown store kind: ${JSON.stringify(storeConfig)}`)
+}
+
+const buildEmbedder = async (
+  config: MemoryExtensionConfig | undefined,
+): Promise<Embedder | undefined> => {
+  const embedderConfig = config?.embedder
+  const kind = embedderConfig?.kind ?? 'auto'
+  if (kind === 'off') return undefined
+  if (kind === 'auto') {
+    const detected = await detectEmbedder()
+    if (detected === undefined) return undefined
+    if (detected.kind === 'ollama') {
+      return new OllamaEmbedder({ baseURL: detected.baseUrl, model: detected.model })
+    }
+    return new OpenAIEmbedder({ apiKey: detected.apiKey, model: detected.model })
+  }
+  if (embedderConfig !== undefined && embedderConfig.kind === 'ollama') {
+    return new OllamaEmbedder({
+      baseURL: embedderConfig.baseUrl ?? DEFAULT_OLLAMA_BASE_URL,
+      model: embedderConfig.model ?? 'bge-m3',
+    })
+  }
+  if (embedderConfig !== undefined && embedderConfig.kind === 'openai') {
+    return new OpenAIEmbedder({
+      apiKey: embedderConfig.apiKey,
+      model: embedderConfig.model ?? 'text-embedding-3-small',
+    })
+  }
+  if (embedderConfig !== undefined && embedderConfig.kind === 'tei') {
+    // TEI embedder needs custom URL plumbing not yet stabilised; punt
+    // to an explicit error so the user does not silently get no
+    // embeddings.
+    throw new Error('memory-pi: tei embedder is not wired yet; pass embedder: { kind: "auto" }')
+  }
+  throw new Error(`memory-pi: unknown embedder kind: ${JSON.stringify(embedderConfig)}`)
+}
+
+const buildProvider = async (
+  config: MemoryExtensionConfig | undefined,
+): Promise<Provider | undefined> => {
+  const providerConfig = config?.provider
+  const kind = providerConfig?.kind ?? 'auto'
+  if (kind === 'auto') {
+    const detected = await detectProvider()
+    if (detected === undefined) return undefined
+    if (detected.kind === 'openai') {
+      return new OpenAIProvider({ apiKey: detected.apiKey, model: detected.model })
+    }
+    if (detected.kind === 'anthropic') {
+      return new AnthropicProvider({ apiKey: detected.apiKey, model: detected.model })
+    }
+    return new OllamaProvider({ baseURL: detected.baseUrl, model: detected.model })
+  }
+  if (providerConfig !== undefined && providerConfig.kind === 'openai') {
+    return new OpenAIProvider({
+      apiKey: providerConfig.apiKey,
+      model: providerConfig.model ?? 'gpt-4o-mini',
+    })
+  }
+  if (providerConfig !== undefined && providerConfig.kind === 'anthropic') {
+    return new AnthropicProvider({
+      apiKey: providerConfig.apiKey,
+      model: providerConfig.model ?? 'claude-opus-4-5',
+    })
+  }
+  if (providerConfig !== undefined && providerConfig.kind === 'ollama') {
+    return new OllamaProvider({
+      baseURL: providerConfig.baseUrl ?? DEFAULT_OLLAMA_BASE_URL,
+      model: providerConfig.model ?? 'gemma3',
+    })
+  }
+  throw new Error(`memory-pi: unknown provider kind: ${JSON.stringify(providerConfig)}`)
+}
+
+/**
+ * Build a `MemoryRuntime` from user config. Heavy initialisation runs
+ * once per extension instance; subsequent recall / extract calls share
+ * the same store and search index handles.
+ */
+export const createMemoryRuntime = async (
+  config: MemoryExtensionConfig | undefined,
+  options: { readonly logger?: RuntimeLogger } = {},
+): Promise<MemoryRuntime> => {
+  const logger = options.logger ?? noopRuntimeLogger
+  const resolved = resolveRuntimeConfig(config)
+  const paths = resolveBrainPaths(resolved.brainRoot, resolved.brainId)
+  await mkdir(paths.root, { recursive: true })
+  const store = await buildStore(config, paths.root)
+  const searchIndex = await createSearchIndex({ dbPath: paths.searchIndexPath })
+  const embedder = await buildEmbedder(config)
+  const provider = await buildProvider(config)
+
+  if (provider === undefined) {
+    logger.warn(
+      'memory-pi: no LLM provider detected; extract / reflect / consolidate will throw on call',
+    )
+  }
+  if (embedder === undefined) {
+    logger.warn('memory-pi: no embedder detected; vector recall disabled')
+  }
+
+  const retrieval = createRetrieval({
+    index: searchIndex,
+    ...(embedder !== undefined ? { embedder } : {}),
+  })
+
+  // The Memory pipeline requires a non-undefined Provider. When the
+  // user has no chat provider we fall back to a "no-op" lazy provider
+  // that throws on use; this keeps the runtime constructable so recall
+  // still works.
+  const memoryProvider = provider ?? createLazyProvider()
+  const memory = createMemory({
+    store,
+    provider: memoryProvider,
+    ...(embedder !== undefined ? { embedder } : {}),
+    scope: resolved.scope,
+    actorId: resolved.actorId,
+    cursorStore: createStoreBackedCursorStore(store),
+    extractMinMessages: resolved.extractMinMessages,
+  })
+
+  const extractQueue = createExtractQueue(memory, logger)
+
+  const runtime: MemoryRuntime = {
+    config: resolved,
+    store,
+    searchIndex,
+    embedder,
+    provider,
+    memory,
+    retrieval,
+    extractQueue,
+    async close() {
+      await extractQueue.flush()
+      await searchIndex.close().catch(() => undefined)
+      await store.close().catch(() => undefined)
+    },
+  }
+  return runtime
+}
+
+/**
+ * Provider stub that throws when called. We install this so callers
+ * that only use recall + remember keep working when no chat provider
+ * is configured.
+ */
+const createLazyProvider = (): Provider => {
+  const fail = (): never => {
+    throw new Error(
+      'memory-pi: no LLM provider configured; set OPENAI_API_KEY, ANTHROPIC_API_KEY, or run Ollama locally',
+    )
+  }
+  return {
+    name: () => 'memory-pi/none',
+    modelName: () => 'none',
+    supportsStructuredDecoding: () => false,
+    stream: () => fail(),
+    complete: () => fail(),
+    structured: () => fail(),
+  }
+}
+
+const createExtractQueue = (memory: Memory, logger: RuntimeLogger): ExtractQueueState => {
+  const queue: ExtractJob[] = []
+  let running = false
+  let pending: Promise<void> = Promise.resolve()
+
+  const drain = async (): Promise<void> => {
+    if (running) return pending
+    running = true
+    pending = (async () => {
+      try {
+        while (queue.length > 0) {
+          const job = queue.shift()
+          if (job === undefined) continue
+          try {
+            await memory.extract({
+              messages: job.messages,
+              ...(job.actorId !== undefined ? { actorId: job.actorId } : {}),
+              ...(job.scope !== undefined ? { scope: job.scope } : {}),
+              ...(job.sessionId !== undefined ? { sessionId: job.sessionId } : {}),
+            })
+          } catch (err) {
+            logger.error('memory-pi: extract job failed', {
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
+      } finally {
+        running = false
+      }
+    })()
+    return pending
+  }
+
+  return {
+    enqueue(job) {
+      queue.push(job)
+      // Fire and forget; flush() awaits the same promise chain.
+      void drain()
+    },
+    async flush() {
+      await drain()
+    },
+    size() {
+      return queue.length
+    },
+  }
+}
+
+/**
+ * Render a recall block suitable for system-prompt injection. We use
+ * an opening + closing tag so cache-friendly diffing in pi remains
+ * trivial.
+ */
+export const renderRecallBlock = (
+  hits: readonly RecallHit[],
+  emptyLabel = 'no recalled memory',
+): string => {
+  if (hits.length === 0) {
+    return `<recalled-memory>${emptyLabel}</recalled-memory>`
+  }
+  const body = hits
+    .map((hit, idx) => {
+      const note: MemoryNote = hit.note
+      const title = note.name !== '' ? note.name : note.path
+      const preview = hit.content.length > 1200 ? `${hit.content.slice(0, 1200)}…` : hit.content
+      return `### [${idx + 1}] ${title} (score ${hit.score.toFixed(3)})\n${preview}`
+    })
+    .join('\n\n')
+  return `<recalled-memory>\n${body}\n</recalled-memory>`
+}

--- a/sdks/ts/memory-pi/src/runtime.ts
+++ b/sdks/ts/memory-pi/src/runtime.ts
@@ -32,6 +32,8 @@ import {
   type SqliteSearchIndex,
   type Store,
   autodetectStore,
+  createFsStore,
+  createGitStore,
   createMemory,
   createSearchIndex,
   createStoreBackedCursorStore,
@@ -167,8 +169,17 @@ const buildStore = async (
   const storeConfig = config?.store
   const kind = storeConfig?.kind ?? 'auto'
   await mkdir(brainRoot, { recursive: true })
-  if (kind === 'auto' || kind === 'fs' || kind === 'git') {
+  if (kind === 'auto') {
     return autodetectStore({ root: brainRoot })
+  }
+  if (kind === 'fs') {
+    return createFsStore({ root: brainRoot })
+  }
+  if (kind === 'git') {
+    return createGitStore({
+      dir: brainRoot,
+      ...(storeConfig?.remote !== undefined ? { remoteUrl: storeConfig.remote } : {}),
+    })
   }
   if (kind === 'http') {
     // The http store lives behind the same Store interface but the

--- a/sdks/ts/memory-pi/src/safe-fetch.ts
+++ b/sdks/ts/memory-pi/src/safe-fetch.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SSRF guard for outbound URL fetches. `memory_ingest_url` is callable
+ * from the model, so we must block schemes that bypass HTTP, and IPs
+ * that reach loopback, link-local, private, CGN, or multicast ranges.
+ *
+ * Resolution is done up-front and the validated host string is handed
+ * back so the caller can re-issue the fetch against the same URL it
+ * already validated.
+ */
+
+import { isIP } from 'node:net'
+import { promises as dns } from 'node:dns'
+
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:'])
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnsafeUrlError'
+  }
+}
+
+const ipv4ToInt = (ip: string): number | undefined => {
+  const parts = ip.split('.')
+  if (parts.length !== 4) return undefined
+  let n = 0
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return undefined
+    const v = Number(part)
+    if (v < 0 || v > 255) return undefined
+    n = (n << 8) | v
+  }
+  return n >>> 0
+}
+
+const matchesCidr = (n: number, base: number, mask: number): boolean =>
+  ((n & mask) >>> 0) === ((base & mask) >>> 0)
+
+export const isPrivateIPv4 = (ip: string): boolean => {
+  const n = ipv4ToInt(ip)
+  if (n === undefined) return false
+  // 0.0.0.0/8 unspecified
+  if (matchesCidr(n, 0x00000000, 0xff000000)) return true
+  // 10.0.0.0/8
+  if (matchesCidr(n, 0x0a000000, 0xff000000)) return true
+  // 127.0.0.0/8 loopback
+  if (matchesCidr(n, 0x7f000000, 0xff000000)) return true
+  // 169.254.0.0/16 link-local
+  if (matchesCidr(n, 0xa9fe0000, 0xffff0000)) return true
+  // 172.16.0.0/12
+  if (matchesCidr(n, 0xac100000, 0xfff00000)) return true
+  // 192.168.0.0/16
+  if (matchesCidr(n, 0xc0a80000, 0xffff0000)) return true
+  // 100.64.0.0/10 carrier-grade NAT
+  if (matchesCidr(n, 0x64400000, 0xffc00000)) return true
+  // 224.0.0.0/4 multicast
+  if (matchesCidr(n, 0xe0000000, 0xf0000000)) return true
+  // 240.0.0.0/4 reserved
+  if (matchesCidr(n, 0xf0000000, 0xf0000000)) return true
+  return false
+}
+
+export const isPrivateIPv6 = (ip: string): boolean => {
+  const lower = ip.toLowerCase()
+  if (lower === '::' || lower === '::1') return true
+  // IPv4-mapped IPv6 ::ffff:a.b.c.d -- delegate to IPv4 check.
+  if (lower.startsWith('::ffff:')) {
+    const v4 = lower.slice(7)
+    if (v4.includes('.')) return isPrivateIPv4(v4)
+  }
+  // fc00::/7 unique local
+  if (/^fc[0-9a-f]{2}:/.test(lower) || /^fd[0-9a-f]{2}:/.test(lower)) return true
+  // fe80::/10 link-local (fe80 - febf)
+  if (/^fe[89ab][0-9a-f]:/.test(lower)) return true
+  // ff00::/8 multicast
+  if (/^ff[0-9a-f]{2}:/.test(lower)) return true
+  return false
+}
+
+const isPrivateAddress = (ip: string): boolean => {
+  const family = isIP(ip)
+  if (family === 4) return isPrivateIPv4(ip)
+  if (family === 6) return isPrivateIPv6(ip)
+  return false
+}
+
+export type ValidateUrlOptions = {
+  readonly resolver?: (host: string) => Promise<readonly string[]>
+}
+
+export const defaultResolver = async (host: string): Promise<readonly string[]> => {
+  const direct = isIP(host)
+  if (direct !== 0) return [host]
+  const records = await dns.lookup(host, { all: true, verbatim: true })
+  return records.map((r) => r.address)
+}
+
+/**
+ * Parse, validate scheme, resolve hostname, and reject any IP that
+ * would reach a private or loopback range. Throws `UnsafeUrlError` on
+ * any failure so callers can map it to a clear tool error.
+ */
+export const validateExternalUrl = async (
+  raw: string,
+  options: ValidateUrlOptions = {},
+): Promise<URL> => {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new UnsafeUrlError(`invalid URL: ${detail}`)
+  }
+  if (!ALLOWED_SCHEMES.has(url.protocol)) {
+    throw new UnsafeUrlError(`disallowed scheme: ${url.protocol}`)
+  }
+  const host = url.hostname
+  if (host === '') {
+    throw new UnsafeUrlError('missing hostname')
+  }
+  // Strip IPv6 brackets so the resolver / net.isIP see a clean address.
+  const cleanHost = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+  const resolve = options.resolver ?? defaultResolver
+  let addresses: readonly string[]
+  try {
+    addresses = await resolve(cleanHost)
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new UnsafeUrlError(`DNS lookup failed for ${cleanHost}: ${detail}`)
+  }
+  if (addresses.length === 0) {
+    throw new UnsafeUrlError(`no DNS records for ${cleanHost}`)
+  }
+  for (const addr of addresses) {
+    if (isPrivateAddress(addr)) {
+      throw new UnsafeUrlError(`refusing to fetch private/loopback address ${addr} (${cleanHost})`)
+    }
+  }
+  return url
+}
+
+/**
+ * Compose the caller's AbortSignal (if any) with a bounded timeout so
+ * stuck fetches cannot block tool dispatch indefinitely.
+ */
+export const fetchSignalWithTimeout = (
+  signal: AbortSignal | undefined,
+  timeoutMs: number = DEFAULT_FETCH_TIMEOUT_MS,
+): AbortSignal => {
+  const timeout = AbortSignal.timeout(timeoutMs)
+  if (signal === undefined) return timeout
+  // AbortSignal.any (Node >= 20.3, Bun) merges signals so either source
+  // can abort the fetch.
+  const any = (AbortSignal as unknown as { any?: (s: AbortSignal[]) => AbortSignal }).any
+  if (typeof any === 'function') return any([signal, timeout])
+  // Older runtimes: fall back to honouring the caller's signal and
+  // re-arm the timeout via a one-shot controller.
+  const controller = new AbortController()
+  const abort = (): void => controller.abort()
+  signal.addEventListener('abort', abort, { once: true })
+  timeout.addEventListener('abort', abort, { once: true })
+  return controller.signal
+}

--- a/sdks/ts/memory-pi/src/tools.ts
+++ b/sdks/ts/memory-pi/src/tools.ts
@@ -21,6 +21,7 @@ import type { Static, TSchema } from 'typebox'
 import { Type } from 'typebox'
 import { MEMORY_TOOL_NAMES, type MemoryToolName } from './config.js'
 import type { MemoryRuntime } from './runtime.js'
+import { UnsafeUrlError, fetchSignalWithTimeout, validateExternalUrl } from './safe-fetch.js'
 
 const FILE_LIMIT_BYTES = 25 * 1024 * 1024
 const URL_FETCH_LIMIT_BYTES = 5 * 1024 * 1024
@@ -511,8 +512,17 @@ export const buildTools = (
       description: 'Fetch a URL and ingest its contents into the brain.',
       parameters: ingestUrlSchema,
       async execute(_id, params, signal) {
-        const init: RequestInit = signal !== undefined ? { signal } : {}
-        const resp = await fetch(params.url, init)
+        let safeUrl: URL
+        try {
+          safeUrl = await validateExternalUrl(params.url)
+        } catch (err) {
+          if (err instanceof UnsafeUrlError) {
+            throw new Error(`memory_ingest_url: ${err.message}`)
+          }
+          throw err
+        }
+        const init: RequestInit = { signal: fetchSignalWithTimeout(signal) }
+        const resp = await fetch(safeUrl, init)
         if (!resp.ok) {
           throw new Error(`memory_ingest_url: fetch failed ${resp.status} ${resp.statusText}`)
         }

--- a/sdks/ts/memory-pi/src/tools.ts
+++ b/sdks/ts/memory-pi/src/tools.ts
@@ -1,5 +1,762 @@
-// Placeholder. W3 implements 11 memory_* tools via pi.registerTool. See
-// MEMORY_TOOL_NAMES in ./config.ts. Each tool maps to a method on the
-// @jeffs-brain/memory pipeline.
+// SPDX-License-Identifier: Apache-2.0
 
-export {}
+/**
+ * The eleven `memory_*` tools registered with the pi runtime. Each tool
+ * wraps an operation on the underlying `@jeffs-brain/memory` pipeline
+ * (Memory + Retrieval + Store + SearchIndex). Tools are intentionally
+ * thin: validation lives in the TypeBox schema, the heavy lifting lives
+ * in the SDK.
+ *
+ * Reference parity with `mcp/ts/src/tools/*` so MCP clients and pi
+ * extensions surface the same canonical eleven operations.
+ */
+
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises'
+import { extname, isAbsolute, join, resolve as resolvePath } from 'node:path'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import type { Batch, ExtractedMemory, Message, RecallHit, Scope } from '@jeffs-brain/memory'
+import { ingestDocument } from '@jeffs-brain/memory/ingest'
+import type { Static, TSchema } from 'typebox'
+import { Type } from 'typebox'
+import { MEMORY_TOOL_NAMES, type MemoryToolName } from './config.js'
+import type { MemoryRuntime } from './runtime.js'
+
+const FILE_LIMIT_BYTES = 25 * 1024 * 1024
+const URL_FETCH_LIMIT_BYTES = 5 * 1024 * 1024
+
+const SCOPE_VALUES = ['global', 'project', 'agent'] as const
+
+const SEARCH_SCOPE_VALUES = ['all', ...SCOPE_VALUES] as const
+
+const SORT_VALUES = ['relevance', 'recency', 'relevance_then_recency'] as const
+
+const VISIBILITY_VALUES = ['private', 'tenant', 'public'] as const
+
+const INGEST_AS_VALUES = ['markdown', 'text', 'pdf', 'json'] as const
+
+const ROLE_VALUES = ['system', 'user', 'assistant', 'tool'] as const
+
+const FS_MIME_BY_AS: Record<(typeof INGEST_AS_VALUES)[number], string> = {
+  markdown: 'text/markdown',
+  text: 'text/plain',
+  pdf: 'application/pdf',
+  json: 'application/json',
+}
+
+const FS_MIME_BY_EXT: Record<string, string> = {
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.txt': 'text/plain',
+  '.pdf': 'application/pdf',
+  '.json': 'application/json',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+}
+
+const mimeForFile = (path: string, hint: string | undefined): string => {
+  if (hint !== undefined && hint in FS_MIME_BY_AS) {
+    return FS_MIME_BY_AS[hint as keyof typeof FS_MIME_BY_AS]
+  }
+  const ext = extname(path).toLowerCase()
+  return FS_MIME_BY_EXT[ext] ?? 'application/octet-stream'
+}
+
+const deriveTitle = (content: string, fallback: string | undefined): string => {
+  if (fallback !== undefined && fallback !== '') return fallback
+  const firstHeading = content.match(/^#\s+(.+)$/m)?.[1]?.trim()
+  if (firstHeading !== undefined && firstHeading !== '') return firstHeading
+  const firstLine = content
+    .split('\n')
+    .find((line) => line.trim() !== '')
+    ?.trim()
+  return firstLine ?? 'Untitled memory'
+}
+
+const slugFromTitle = (title: string): string => {
+  const slug = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug === '' ? `note-${Date.now()}` : slug.slice(0, 64)
+}
+
+const inferMemoryScopeFromPath = (path: string): Scope => {
+  if (path.startsWith('memory/project/')) return 'project'
+  if (path.startsWith('memory/agent/')) return 'agent'
+  return 'global'
+}
+
+const buildFrontmatterBlock = (frontmatter: Record<string, unknown>): string => {
+  const lines: string[] = ['---']
+  for (const [key, value] of Object.entries(frontmatter)) {
+    if (value === undefined || value === null) continue
+    if (Array.isArray(value)) {
+      lines.push(`${key}: [${value.map((v) => JSON.stringify(String(v))).join(', ')}]`)
+      continue
+    }
+    lines.push(`${key}: ${JSON.stringify(value)}`)
+  }
+  lines.push('---')
+  return lines.join('\n')
+}
+
+type RankedHit = { readonly path: string; readonly score: number }
+
+const sortLocalHits = async <T extends RankedHit>(
+  store: MemoryRuntime['store'],
+  hits: readonly T[],
+  sort: (typeof SORT_VALUES)[number] | undefined,
+): Promise<readonly T[]> => {
+  if (sort === undefined || sort === 'relevance') return [...hits]
+  const stamped: Array<{ readonly hit: T; readonly index: number; readonly timestamp: number }> =
+    await Promise.all(
+      hits.map(async (hit, index) => {
+        try {
+          const info = await store.stat(hit.path as never)
+          return { hit, index, timestamp: info.modTime.getTime() }
+        } catch {
+          return { hit, index, timestamp: Number.NEGATIVE_INFINITY }
+        }
+      }),
+    )
+  return stamped
+    .sort((left, right) => {
+      if (sort === 'relevance_then_recency' && left.hit.score !== right.hit.score) {
+        return right.hit.score - left.hit.score
+      }
+      if (left.timestamp !== right.timestamp) return right.timestamp - left.timestamp
+      if (sort !== 'relevance_then_recency' && left.hit.score !== right.hit.score) {
+        return right.hit.score - left.hit.score
+      }
+      return left.index - right.index
+    })
+    .map(({ hit }) => hit)
+}
+
+const renderResult = (
+  value: unknown,
+): {
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>
+  readonly details: { readonly result: unknown }
+} => ({
+  content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+  details: { result: value },
+})
+
+const noProviderError = (): Error =>
+  new Error(
+    'memory-pi: no LLM provider configured; set OPENAI_API_KEY, ANTHROPIC_API_KEY, or run Ollama locally',
+  )
+
+// ----- Schemas ----------------------------------------------------------
+
+const rememberSchema = Type.Object({
+  content: Type.String({ description: 'Markdown body of the new memory.' }),
+  title: Type.Optional(
+    Type.String({ description: 'Title. Derived from the first heading if omitted.' }),
+  ),
+  tags: Type.Optional(Type.Array(Type.String())),
+  path: Type.Optional(Type.String({ description: 'Destination path within the brain.' })),
+})
+
+const recallSchema = Type.Object({
+  query: Type.String({ description: 'Free-text query the recall pipeline scores.' }),
+  scope: Type.Optional(Type.Union(SCOPE_VALUES.map((v) => Type.Literal(v)))),
+  session_id: Type.Optional(Type.String()),
+  top_k: Type.Optional(Type.Integer({ minimum: 1, maximum: 50 })),
+})
+
+const searchSchema = Type.Object({
+  query: Type.String(),
+  top_k: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+  scope: Type.Optional(Type.Union(SEARCH_SCOPE_VALUES.map((v) => Type.Literal(v)))),
+  sort: Type.Optional(Type.Union(SORT_VALUES.map((v) => Type.Literal(v)))),
+})
+
+const askSchema = Type.Object({
+  query: Type.String(),
+  top_k: Type.Optional(Type.Integer({ minimum: 1, maximum: 50 })),
+})
+
+const ingestFileSchema = Type.Object({
+  path: Type.String({ description: 'Absolute or relative local path.' }),
+  as: Type.Optional(Type.Union(INGEST_AS_VALUES.map((v) => Type.Literal(v)))),
+})
+
+const ingestUrlSchema = Type.Object({
+  url: Type.String({ description: 'URL to fetch and ingest.' }),
+})
+
+const extractMessageSchema = Type.Object({
+  role: Type.Union(ROLE_VALUES.map((v) => Type.Literal(v))),
+  content: Type.String(),
+})
+
+const extractSchema = Type.Object({
+  messages: Type.Array(extractMessageSchema),
+  actor_id: Type.Optional(Type.String()),
+  session_id: Type.Optional(Type.String()),
+})
+
+const reflectSchema = Type.Object({
+  session_id: Type.String(),
+})
+
+const consolidateSchema = Type.Object({})
+
+const createBrainSchema = Type.Object({
+  name: Type.String(),
+  slug: Type.Optional(Type.String()),
+  visibility: Type.Optional(Type.Union(VISIBILITY_VALUES.map((v) => Type.Literal(v)))),
+})
+
+const listBrainsSchema = Type.Object({})
+
+// ----- Tool factory -----------------------------------------------------
+
+type AnyToolParams<T extends TSchema> = T
+
+const safeScope = (raw: 'all' | Scope | undefined): { readonly scope: Scope } | undefined => {
+  if (raw === undefined || raw === 'all') return undefined
+  return { scope: raw }
+}
+
+/**
+ * Build the set of pi tool definitions for a runtime. The factory does
+ * not register them; the caller drives `pi.registerTool(...)` so we can
+ * filter by `tools.expose` if the user supplied an allowlist.
+ */
+export const buildTools = (
+  runtime: MemoryRuntime,
+): Record<MemoryToolName, ReturnType<typeof defineMemoryTool<TSchema>>> => {
+  const cfg = runtime.config
+  return {
+    remember: defineMemoryTool({
+      name: 'memory_remember',
+      label: 'Remember',
+      description:
+        'Store a new memory note (markdown) in the brain. Returns the created note path and digest.',
+      parameters: rememberSchema,
+      async execute(_id, params) {
+        const title = deriveTitle(params.content, params.title)
+        const slug = slugFromTitle(title)
+        const relativePath =
+          params.path !== undefined && params.path !== '' ? params.path : `memory/global/${slug}.md`
+        const scope = inferMemoryScopeFromPath(relativePath)
+        const nowIso = new Date().toISOString()
+        const frontmatter = buildFrontmatterBlock({
+          title,
+          scope,
+          type: scope === 'global' ? 'user' : 'project',
+          created: nowIso,
+          modified: nowIso,
+          ...(params.tags !== undefined && params.tags.length > 0 ? { tags: params.tags } : {}),
+        })
+        const body = `${frontmatter}\n\n${params.content.trimEnd()}\n`
+        const buf = Buffer.from(body, 'utf8')
+        const embedder = runtime.embedder
+        if (embedder !== undefined) {
+          const result = await ingestDocument({
+            store: runtime.store,
+            searchIndex: runtime.searchIndex,
+            embedder,
+            doc: {
+              brainId: cfg.brainId,
+              path: relativePath,
+              content: buf,
+              title,
+              mime: 'text/markdown',
+              metadata: {
+                scope,
+                ...(params.tags !== undefined && params.tags.length > 0
+                  ? { tags: params.tags.join(',') }
+                  : {}),
+              },
+            },
+          })
+          return renderResult({
+            id: result.documentId,
+            path: result.path,
+            byte_size: buf.length,
+            hash: result.hash,
+            chunk_count: result.chunkCount,
+            embedded_count: result.embeddedCount,
+            reused: result.reused,
+          })
+        }
+        // No embedder: write the note directly and index a single BM25
+        // chunk so search still finds it.
+        await runtime.store.batch({ reason: 'memory_remember' }, async (batch: Batch) => {
+          await batch.write(relativePath as never, buf)
+        })
+        const hash = createHash('sha256').update(buf).digest('hex')
+        runtime.searchIndex.upsertChunk({
+          id: `${cfg.brainId}:${hash.slice(0, 16)}:0`,
+          path: relativePath,
+          ordinal: 0,
+          title,
+          content: body,
+          metadata: {
+            path: relativePath,
+            brainId: cfg.brainId,
+            scope,
+            ...(params.tags !== undefined && params.tags.length > 0
+              ? { tags: params.tags.join(',') }
+              : {}),
+          },
+        })
+        return renderResult({
+          id: `${cfg.brainId}:${hash.slice(0, 16)}`,
+          path: relativePath,
+          byte_size: buf.length,
+          hash,
+          chunk_count: 1,
+          embedded_count: 0,
+          reused: false,
+        })
+      },
+    }),
+
+    recall: defineMemoryTool({
+      name: 'memory_recall',
+      label: 'Recall',
+      description:
+        'Recall memory notes scored for a query. `scope` selects the memory namespace (global, project, agent).',
+      parameters: recallSchema,
+      async execute(_id, params) {
+        const topK = params.top_k ?? cfg.recallTopK
+        const hits = await runtime.memory.recall({
+          query: params.query,
+          k: topK,
+          scope: (params.scope as Scope | undefined) ?? cfg.scope,
+          actorId: cfg.actorId,
+          ...(cfg.fallbackScopes.length > 0 ? { fallbackScopes: cfg.fallbackScopes } : {}),
+        })
+        return renderResult({
+          query: params.query,
+          brain_id: cfg.brainId,
+          session_id: params.session_id ?? null,
+          chunks: hits.map((hit: RecallHit) => ({
+            score: hit.score,
+            path: hit.path,
+            content: hit.content,
+            title: hit.note.name,
+            scope: hit.note.scope,
+            tags: hit.note.tags,
+          })),
+        })
+      },
+    }),
+
+    search: defineMemoryTool({
+      name: 'memory_search',
+      label: 'Search',
+      description:
+        'Hybrid BM25 + vector retrieval across the brain. Returns ranked chunks with citations.',
+      parameters: searchSchema,
+      async execute(_id, params) {
+        const topK = params.top_k ?? 10
+        const filters = safeScope(params.scope)
+        const results = await runtime.retrieval.search({
+          query: params.query,
+          topK,
+          rerank: false,
+          ...(filters !== undefined ? { filters } : {}),
+        })
+        const ordered = await sortLocalHits(runtime.store, results, params.sort)
+        return renderResult({
+          query: params.query,
+          brain_id: cfg.brainId,
+          hits: ordered.map((result) => ({
+            score: result.score,
+            path: result.path,
+            content: result.content,
+            title: result.title,
+            summary: result.summary,
+            chunk_id: result.id,
+          })),
+        })
+      },
+    }),
+
+    ask: defineMemoryTool({
+      name: 'memory_ask',
+      label: 'Ask',
+      description:
+        'Answer a question grounded in the brain. Retrieves relevant chunks, calls the configured LLM provider, and returns the answer with citations.',
+      parameters: askSchema,
+      async execute(_id, params, signal) {
+        const provider = runtime.provider
+        if (provider === undefined) throw noProviderError()
+        const topK = params.top_k ?? 8
+        const retrieved = await runtime.retrieval.search({
+          query: params.query,
+          topK,
+          rerank: false,
+        })
+        const contextLines = retrieved.map((hit, idx) => {
+          const body = (hit.content ?? '').slice(0, 2000)
+          return `### [${idx + 1}] ${hit.path}\n${body}`
+        })
+        const prompt = [
+          'Answer the user question using the retrieved memory chunks below.',
+          'Cite supporting chunks inline using the numeric markers [1], [2], etc.',
+          'If the chunks do not answer the question, say so plainly.',
+          '',
+          '## Question',
+          params.query,
+          '',
+          '## Retrieved memory',
+          contextLines.join('\n\n') || '_no relevant chunks_',
+        ].join('\n')
+        const completion = await provider.complete(
+          {
+            system: 'You are an assistant grounded in this brain. Use British English.',
+            messages: [{ role: 'user', content: prompt }],
+            maxTokens: 1024,
+            temperature: 0.2,
+          },
+          signal,
+        )
+        return renderResult({
+          answer: completion.content,
+          citations: retrieved.slice(0, 5).map((hit, idx) => ({
+            chunk_id: hit.id,
+            document_id: hit.path,
+            quote: (hit.content ?? '').slice(0, 200),
+            rank: idx + 1,
+          })),
+          retrieved: retrieved.map((hit) => ({
+            chunk_id: hit.id,
+            document_id: hit.path,
+            score: hit.score,
+            preview: (hit.content ?? '').slice(0, 512),
+          })),
+        })
+      },
+    }),
+
+    ingest_file: defineMemoryTool({
+      name: 'memory_ingest_file',
+      label: 'Ingest File',
+      description: 'Ingest a local file (<= 25 MiB) into the brain. Returns the ingest result.',
+      parameters: ingestFileSchema,
+      async execute(_id, params) {
+        const absPath = isAbsolute(params.path) ? params.path : resolvePath(params.path)
+        const info = await stat(absPath)
+        if (!info.isFile()) {
+          throw new Error(`memory_ingest_file: not a regular file: ${absPath}`)
+        }
+        if (info.size > FILE_LIMIT_BYTES) {
+          throw new Error('memory_ingest_file: 25 MiB limit exceeded')
+        }
+        const content = await readFile(absPath)
+        const mime = mimeForFile(absPath, params.as)
+        const title = absPath.split(/[\\/]/).pop() ?? absPath
+        const embedder = runtime.embedder
+        if (embedder === undefined) {
+          const hash = createHash('sha256').update(content).digest('hex')
+          const storedPath = `raw/documents/${hash}${extname(absPath).toLowerCase() || '.bin'}`
+          await runtime.store.batch({ reason: 'memory_ingest_file' }, async (batch: Batch) => {
+            await batch.write(storedPath as never, content)
+          })
+          runtime.searchIndex.upsertChunk({
+            id: `${cfg.brainId}:${hash.slice(0, 16)}:0`,
+            path: storedPath,
+            ordinal: 0,
+            title,
+            content: content.toString('utf8').slice(0, 32_000),
+            metadata: { path: storedPath, brainId: cfg.brainId, mime },
+          })
+          return renderResult({
+            status: 'completed',
+            document_id: `${cfg.brainId}:${hash.slice(0, 16)}`,
+            path: storedPath,
+            hash,
+            chunk_count: 1,
+            embedded_count: 0,
+            reused: false,
+          })
+        }
+        const result = await ingestDocument({
+          store: runtime.store,
+          searchIndex: runtime.searchIndex,
+          embedder,
+          doc: {
+            brainId: cfg.brainId,
+            content,
+            mime,
+            title,
+            metadata: { source: absPath },
+          },
+        })
+        return renderResult({
+          status: 'completed',
+          document_id: result.documentId,
+          path: result.path,
+          hash: result.hash,
+          chunk_count: result.chunkCount,
+          embedded_count: result.embeddedCount,
+          duration_ms: result.durationMs,
+          reused: result.reused,
+        })
+      },
+    }),
+
+    ingest_url: defineMemoryTool({
+      name: 'memory_ingest_url',
+      label: 'Ingest URL',
+      description: 'Fetch a URL and ingest its contents into the brain.',
+      parameters: ingestUrlSchema,
+      async execute(_id, params, signal) {
+        const init: RequestInit = signal !== undefined ? { signal } : {}
+        const resp = await fetch(params.url, init)
+        if (!resp.ok) {
+          throw new Error(`memory_ingest_url: fetch failed ${resp.status} ${resp.statusText}`)
+        }
+        const contentTypeHeader = resp.headers.get('content-type') ?? 'text/plain'
+        const mime = contentTypeHeader.split(';')[0]?.trim() ?? 'text/plain'
+        const buffer = Buffer.from(await resp.arrayBuffer())
+        if (buffer.length > URL_FETCH_LIMIT_BYTES) {
+          throw new Error('memory_ingest_url: body exceeds 5 MiB fallback limit')
+        }
+        const embedder = runtime.embedder
+        if (embedder === undefined) {
+          const hash = createHash('sha256').update(buffer).digest('hex')
+          const storedPath = `raw/documents/${hash}.txt`
+          await runtime.store.batch({ reason: 'memory_ingest_url' }, async (batch: Batch) => {
+            await batch.write(storedPath as never, buffer)
+          })
+          runtime.searchIndex.upsertChunk({
+            id: `${cfg.brainId}:${hash.slice(0, 16)}:0`,
+            path: storedPath,
+            ordinal: 0,
+            title: params.url,
+            content: buffer.toString('utf8').slice(0, 32_000),
+            metadata: { path: storedPath, brainId: cfg.brainId, source_url: params.url, mime },
+          })
+          return renderResult({
+            status: 'completed',
+            document_id: `${cfg.brainId}:${hash.slice(0, 16)}`,
+            path: storedPath,
+            hash,
+            chunk_count: 1,
+            embedded_count: 0,
+            reused: false,
+          })
+        }
+        const result = await ingestDocument({
+          store: runtime.store,
+          searchIndex: runtime.searchIndex,
+          embedder,
+          doc: {
+            brainId: cfg.brainId,
+            content: buffer,
+            mime,
+            title: params.url,
+            metadata: { source_url: params.url },
+          },
+        })
+        return renderResult({
+          status: 'completed',
+          document_id: result.documentId,
+          path: result.path,
+          hash: result.hash,
+          chunk_count: result.chunkCount,
+          embedded_count: result.embeddedCount,
+          duration_ms: result.durationMs,
+          reused: result.reused,
+        })
+      },
+    }),
+
+    extract: defineMemoryTool({
+      name: 'memory_extract',
+      label: 'Extract',
+      description:
+        'Submit a conversation transcript so the brain extracts memorable facts. Returns the extracted notes.',
+      parameters: extractSchema,
+      async execute(_id, params) {
+        if (runtime.provider === undefined) throw noProviderError()
+        const messages: readonly Message[] = params.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+        }))
+        const extracted: readonly ExtractedMemory[] = await runtime.memory.extract({
+          messages,
+          ...(params.session_id !== undefined ? { sessionId: params.session_id } : {}),
+          ...(params.actor_id !== undefined ? { actorId: params.actor_id } : {}),
+        })
+        runtime.lastExtracted = extracted
+        return renderResult({
+          mode: params.session_id !== undefined ? 'session' : 'transcript',
+          extracted: extracted.map((m) => ({
+            filename: m.filename,
+            name: m.name,
+            description: m.description,
+            type: m.type,
+            scope: m.scope,
+            tags: m.tags ?? [],
+            action: m.action,
+          })),
+        })
+      },
+    }),
+
+    reflect: defineMemoryTool({
+      name: 'memory_reflect',
+      label: 'Reflect',
+      description: 'Close a session and trigger reflection over its messages.',
+      parameters: reflectSchema,
+      async execute(_id, params) {
+        if (runtime.provider === undefined) throw noProviderError()
+        const result = await runtime.memory.reflect({
+          sessionId: params.session_id,
+          messages: [],
+        })
+        if (result === undefined) {
+          return renderResult({
+            reflection_status: 'no_result',
+            ended_at: new Date().toISOString(),
+          })
+        }
+        return renderResult({
+          reflection_status: 'completed',
+          reflection: {
+            outcome: result.outcome,
+            should_record_episode: result.shouldRecordEpisode ?? false,
+            path: result.path,
+            retry_feedback: result.retryFeedback ?? '',
+          },
+          ended_at: new Date().toISOString(),
+        })
+      },
+    }),
+
+    consolidate: defineMemoryTool({
+      name: 'memory_consolidate',
+      label: 'Consolidate',
+      description:
+        'Run a consolidation pass on the brain (compile summaries, promote stable notes, prune stale episodic memory).',
+      parameters: consolidateSchema,
+      async execute(_id) {
+        if (runtime.provider === undefined) throw noProviderError()
+        const report = await runtime.memory.consolidate({})
+        return renderResult({ result: report })
+      },
+    }),
+
+    create_brain: defineMemoryTool({
+      name: 'memory_create_brain',
+      label: 'Create Brain',
+      description: 'Create a new brain alongside the current one under the configured brain root.',
+      parameters: createBrainSchema,
+      async execute(_id, params) {
+        const slug = params.slug ?? slugFromTitle(params.name)
+        const brainDir = join(cfg.brainRoot, slug.replace(/[^A-Za-z0-9._-]/g, '_'))
+        await mkdir(brainDir, { recursive: true })
+        const configPath = join(brainDir, 'config.json')
+        const configBody = {
+          version: 1,
+          name: params.name,
+          slug,
+          visibility: params.visibility ?? 'private',
+          createdAt: new Date().toISOString(),
+        }
+        await writeFile(configPath, `${JSON.stringify(configBody, null, 2)}\n`, 'utf8')
+        return renderResult({
+          id: slug,
+          slug,
+          name: params.name,
+          visibility: configBody.visibility,
+          created_at: configBody.createdAt,
+        })
+      },
+    }),
+
+    list_brains: defineMemoryTool({
+      name: 'memory_list_brains',
+      label: 'List Brains',
+      description: 'List the brains discoverable under the configured brain root.',
+      parameters: listBrainsSchema,
+      async execute() {
+        const exists = await stat(cfg.brainRoot).then(
+          (s) => s.isDirectory(),
+          () => false,
+        )
+        if (!exists) return renderResult({ items: [] })
+        const entries = await readdir(cfg.brainRoot, { withFileTypes: true })
+        const items: Array<Record<string, unknown>> = []
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue
+          const configPath = join(cfg.brainRoot, entry.name, 'config.json')
+          let parsed: Record<string, unknown> = {}
+          try {
+            const raw = await readFile(configPath, 'utf8')
+            parsed = JSON.parse(raw) as Record<string, unknown>
+          } catch {
+            // No config file; treat the directory as a slug.
+          }
+          items.push({
+            id: (parsed.slug as string | undefined) ?? entry.name,
+            slug: (parsed.slug as string | undefined) ?? entry.name,
+            name: (parsed.name as string | undefined) ?? entry.name,
+            visibility: (parsed.visibility as string | undefined) ?? 'private',
+            created_at: (parsed.createdAt as string | undefined) ?? null,
+          })
+        }
+        return renderResult({ items })
+      },
+    }),
+  }
+}
+
+/**
+ * Minimal helper to type the tool definition shape we hand to
+ * `pi.registerTool`. Mirrors the pi `defineTool` helper but does not
+ * depend on `@earendil-works/pi-coding-agent`'s `defineTool` so the test
+ * harness can build tools without booting the loader.
+ */
+type ToolHandlerResult = {
+  readonly content: ReadonlyArray<{ readonly type: 'text'; readonly text: string }>
+  readonly details: { readonly result: unknown }
+}
+
+type DefinedTool<TParams extends TSchema> = {
+  readonly name: string
+  readonly label: string
+  readonly description: string
+  readonly parameters: TParams
+  execute(
+    toolCallId: string,
+    params: Static<TParams>,
+    signal?: AbortSignal,
+    onUpdate?: () => void,
+    ctx?: unknown,
+  ): Promise<ToolHandlerResult>
+}
+
+const defineMemoryTool = <TParams extends TSchema>(
+  tool: DefinedTool<TParams>,
+): DefinedTool<TParams> => tool
+
+/**
+ * Register the eleven memory tools on the supplied pi runtime. Respects
+ * `tools.expose` if set, otherwise registers everything.
+ */
+export const registerMemoryTools = (pi: ExtensionAPI, runtime: MemoryRuntime): void => {
+  const all = buildTools(runtime)
+  const allow = runtime.config.exposedTools
+  for (const name of MEMORY_TOOL_NAMES) {
+    if (allow !== undefined && allow.length > 0 && !allow.includes(name)) continue
+    const tool = all[name]
+    // The pi ToolDefinition is structurally compatible with our
+    // DefinedTool shape; we cast through `unknown` so we do not bring
+    // pi's private types into our public surface.
+    pi.registerTool(tool as unknown as Parameters<typeof pi.registerTool>[0])
+  }
+}
+
+export type { MemoryToolName }

--- a/sdks/ts/memory-pi/src/tools.ts
+++ b/sdks/ts/memory-pi/src/tools.ts
@@ -1,0 +1,5 @@
+// Placeholder. W3 implements 11 memory_* tools via pi.registerTool. See
+// MEMORY_TOOL_NAMES in ./config.ts. Each tool maps to a method on the
+// @jeffs-brain/memory pipeline.
+
+export {}

--- a/sdks/ts/memory-pi/test/bootstrap-flat.test.ts
+++ b/sdks/ts/memory-pi/test/bootstrap-flat.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Bootstrap walks an on-disk brain layout and populates the FTS index
+ * without writing anything back to the Store. Tests pin behaviour for
+ * the happy path, idempotency, edge cases (empty files, missing dirs),
+ * and the title extraction heuristic.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createSearchIndex } from '@jeffs-brain/memory/search'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { bootstrapFlatBrain } from '../src/bootstrap-flat.js'
+
+let brainRoot: string
+
+const writeAt = async (rel: string, body: string): Promise<void> => {
+  const abs = join(brainRoot, rel)
+  await mkdir(join(abs, '..'), { recursive: true })
+  await writeFile(abs, body, 'utf8')
+}
+
+beforeEach(() => {
+  brainRoot = mkdtempSync(join(tmpdir(), 'memory-pi-bootstrap-'))
+})
+
+afterEach(() => {
+  rmSync(brainRoot, { recursive: true, force: true })
+})
+
+describe('bootstrapFlatBrain', () => {
+  it('indexes markdown files across wiki, memory, and raw', async () => {
+    await writeAt(
+      'wiki/people/sample-user.md',
+      '# Sample User\n\nProduct manager at example.com.\n',
+    )
+    await writeAt(
+      'memory/heuristic-naming.md',
+      '---\nname: naming\nscope: global\n---\n\n# Naming heuristic\n\nPrefer descriptive identifiers.\n',
+    )
+    await writeAt('raw/2026-05-15-meeting.md', 'Sprint review notes.\n')
+
+    const idx = await createSearchIndex({ dbPath: ':memory:' })
+    try {
+      const report = await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+      })
+
+      expect(report.scanned).toBe(3)
+      expect(report.indexed).toBe(3)
+      expect(report.skipped).toBe(0)
+
+      const indexed = idx.indexedPaths()
+      expect(indexed.sort()).toEqual([
+        'memory/heuristic-naming.md',
+        'raw/2026-05-15-meeting.md',
+        'wiki/people/sample-user.md',
+      ])
+
+      const hits = idx.searchBM25('Sample User', 10)
+      expect(hits.length).toBeGreaterThan(0)
+      expect(hits[0]?.chunk.path).toBe('wiki/people/sample-user.md')
+    } finally {
+      await idx.close()
+    }
+  })
+
+  it('is idempotent across re-entries', async () => {
+    await writeAt('memory/heuristic-foo.md', '# Heuristic foo\n\nbody\n')
+
+    const idx = await createSearchIndex({ dbPath: ':memory:' })
+    try {
+      const first = await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+      })
+      expect(first.indexed).toBe(1)
+
+      const second = await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+      })
+      expect(second.indexed).toBe(0)
+      expect(second.skipped).toBe(1)
+      expect(second.skippedReasons['already-indexed']).toBe(1)
+    } finally {
+      await idx.close()
+    }
+  })
+
+  it('skips empty files, hidden directories, and non-markdown extensions', async () => {
+    await writeAt('wiki/empty.md', '')
+    await writeAt('wiki/.obsidian/cache.md', '# Hidden\n\nshould be skipped\n')
+    await writeAt('wiki/keep.md', '# Keep\n\nthis should be indexed\n')
+    await writeAt('wiki/binary.bin', 'unrelated')
+    await writeAt('memory/notes.txt', 'plain text, no extension match')
+
+    const idx = await createSearchIndex({ dbPath: ':memory:' })
+    try {
+      const report = await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+      })
+
+      const indexed = idx.indexedPaths()
+      expect(indexed).toEqual(['wiki/keep.md'])
+      // wiki/empty.md is zero bytes, so it trips the `empty` branch
+      // before we even read it.
+      expect(report.skippedReasons.empty).toBe(1)
+    } finally {
+      await idx.close()
+    }
+  })
+
+  it('reports missing scan directories without crashing', async () => {
+    const idx = await createSearchIndex({ dbPath: ':memory:' })
+    try {
+      const report = await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+        scanDirs: ['wiki', 'memory', 'does-not-exist'],
+      })
+      expect(report.scanned).toBe(0)
+      expect(report.indexed).toBe(0)
+      expect(report.skippedReasons['missing:does-not-exist']).toBe(1)
+      expect(report.skippedReasons['missing:wiki']).toBe(1)
+      expect(report.skippedReasons['missing:memory']).toBe(1)
+    } finally {
+      await idx.close()
+    }
+  })
+
+  it('extracts a sensible title even when frontmatter is present', async () => {
+    await writeAt(
+      'memory/user-fact-sample.md',
+      '---\nname: sample-user\nscope: global\ntype: user-fact\n---\n\n# Sample user role\n\nThe sample user is a product manager.\n',
+    )
+    const idx = await createSearchIndex({ dbPath: ':memory:' })
+    try {
+      await bootstrapFlatBrain({
+        brainRoot,
+        brainId: 'test-brain',
+        searchIndex: idx,
+      })
+      const hits = idx.searchBM25('sample', 5)
+      expect(hits[0]?.chunk.title).toBe('Sample user role')
+    } finally {
+      await idx.close()
+    }
+  })
+})

--- a/sdks/ts/memory-pi/test/defaults.test.ts
+++ b/sdks/ts/memory-pi/test/defaults.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the auto-detection helpers in `src/defaults.ts`.
+ * Each path (Ollama reachable, OpenAI env set, Anthropic env set,
+ * nothing detected) gets its own deterministic check using an injected
+ * fetch implementation.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  detectEmbedder,
+  detectProvider,
+  ollamaReachable,
+  resolveBrainPaths,
+} from '../src/defaults.js'
+
+const ok = () =>
+  new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+
+const failing = () =>
+  new Response('nope', { status: 500, headers: { 'content-type': 'text/plain' } })
+
+describe('defaults.ollamaReachable', () => {
+  it('returns true when /api/tags answers 200', async () => {
+    const fetchImpl = vi.fn(async () => ok())
+    const reachable = await ollamaReachable({
+      baseUrl: 'http://example.test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    expect(reachable).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://example.test/api/tags',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns false on a non-ok response', async () => {
+    const fetchImpl = vi.fn(async () => failing())
+    const reachable = await ollamaReachable({
+      baseUrl: 'http://example.test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    expect(reachable).toBe(false)
+  })
+
+  it('returns false when fetch throws', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('boom')
+    })
+    const reachable = await ollamaReachable({
+      baseUrl: 'http://example.test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    })
+    expect(reachable).toBe(false)
+  })
+})
+
+describe('defaults.detectProvider', () => {
+  it('prefers OPENAI_API_KEY when set', async () => {
+    const detected = await detectProvider({
+      env: { OPENAI_API_KEY: 'sk-test' } as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => failing()) as unknown as typeof fetch,
+    })
+    expect(detected?.kind).toBe('openai')
+    expect(detected?.kind === 'openai' && detected.apiKey).toBe('sk-test')
+  })
+
+  it('falls back to ANTHROPIC_API_KEY', async () => {
+    const detected = await detectProvider({
+      env: { ANTHROPIC_API_KEY: 'sk-ant' } as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => failing()) as unknown as typeof fetch,
+    })
+    expect(detected?.kind).toBe('anthropic')
+  })
+
+  it('falls back to Ollama when reachable', async () => {
+    const detected = await detectProvider({
+      env: {} as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => ok()) as unknown as typeof fetch,
+    })
+    expect(detected?.kind).toBe('ollama')
+    expect(detected?.kind === 'ollama' && detected.baseUrl).toBe('http://localhost:11434')
+  })
+
+  it('returns undefined when nothing is configured', async () => {
+    const detected = await detectProvider({
+      env: {} as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => failing()) as unknown as typeof fetch,
+    })
+    expect(detected).toBeUndefined()
+  })
+})
+
+describe('defaults.detectEmbedder', () => {
+  it('prefers Ollama when reachable', async () => {
+    const detected = await detectEmbedder({
+      env: {} as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => ok()) as unknown as typeof fetch,
+    })
+    expect(detected?.kind).toBe('ollama')
+    expect(detected?.kind === 'ollama' && detected.model).toBe('bge-m3')
+  })
+
+  it('opts in to OpenAI only when MEMORY_PI_EMBEDDER_OPENAI=true', async () => {
+    const detected = await detectEmbedder({
+      env: {
+        OPENAI_API_KEY: 'sk-test',
+        MEMORY_PI_EMBEDDER_OPENAI: 'true',
+      } as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => failing()) as unknown as typeof fetch,
+    })
+    expect(detected?.kind).toBe('openai')
+  })
+
+  it('returns undefined without a reachable embedder', async () => {
+    const detected = await detectEmbedder({
+      env: { OPENAI_API_KEY: 'sk-test' } as NodeJS.ProcessEnv,
+      fetchImpl: vi.fn(async () => failing()) as unknown as typeof fetch,
+    })
+    expect(detected).toBeUndefined()
+  })
+})
+
+describe('defaults.resolveBrainPaths', () => {
+  it('sanitises unsafe brain ids', () => {
+    const paths = resolveBrainPaths('/tmp/brains', 'foo/bar')
+    expect(paths.id).toBe('foo_bar')
+    expect(paths.root.endsWith('/foo_bar')).toBe(true)
+    expect(paths.searchIndexPath.endsWith('/foo_bar/search.sqlite')).toBe(true)
+  })
+
+  it('falls back to the default id when the cleaned id is empty', () => {
+    const paths = resolveBrainPaths('/tmp/brains', '...')
+    expect(paths.id).toBe('default')
+  })
+})

--- a/sdks/ts/memory-pi/test/defaults.test.ts
+++ b/sdks/ts/memory-pi/test/defaults.test.ts
@@ -134,4 +134,28 @@ describe('defaults.resolveBrainPaths', () => {
     const paths = resolveBrainPaths('/tmp/brains', '...')
     expect(paths.id).toBe('default')
   })
+
+  it('returns root verbatim when flat mode is on', () => {
+    const paths = resolveBrainPaths('/tmp/host-brain', 'primary', { flat: true })
+    expect(paths.root).toBe('/tmp/host-brain')
+    expect(paths.id).toBe('primary')
+    expect(paths.searchIndexPath).toBe('/tmp/host-brain/search.sqlite')
+  })
+
+  it('honours an explicit searchIndexPath override', () => {
+    const paths = resolveBrainPaths('/tmp/host-brain', 'primary', {
+      flat: true,
+      searchIndexPath: '/var/state/host/memory-pi/search.sqlite',
+    })
+    expect(paths.root).toBe('/tmp/host-brain')
+    expect(paths.searchIndexPath).toBe('/var/state/host/memory-pi/search.sqlite')
+  })
+
+  it('still applies overrides in scoped mode', () => {
+    const paths = resolveBrainPaths('/tmp/brains', 'primary', {
+      searchIndexPath: '/var/state/host/memory-pi/search.sqlite',
+    })
+    expect(paths.root.endsWith('/primary')).toBe(true)
+    expect(paths.searchIndexPath).toBe('/var/state/host/memory-pi/search.sqlite')
+  })
 })

--- a/sdks/ts/memory-pi/test/safe-fetch.test.ts
+++ b/sdks/ts/memory-pi/test/safe-fetch.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  UnsafeUrlError,
+  isPrivateIPv4,
+  isPrivateIPv6,
+  validateExternalUrl,
+} from '../src/safe-fetch.js'
+
+const resolver = (host: string, addresses: readonly string[]) => async (h: string) => {
+  if (h !== host) throw new Error(`unexpected host: ${h}`)
+  return addresses
+}
+
+describe('isPrivateIPv4', () => {
+  it.each([
+    ['10.0.0.1', true],
+    ['10.255.255.255', true],
+    ['127.0.0.1', true],
+    ['169.254.169.254', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['192.168.1.1', true],
+    ['100.64.0.1', true],
+    ['224.0.0.1', true],
+    ['240.0.0.1', true],
+    ['0.0.0.0', true],
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['151.101.1.69', false],
+    ['172.32.0.1', false],
+    ['172.15.255.255', false],
+    ['100.63.255.255', false],
+    ['100.128.0.0', false],
+  ])('classifies %s correctly', (ip, expected) => {
+    expect(isPrivateIPv4(ip)).toBe(expected)
+  })
+})
+
+describe('isPrivateIPv6', () => {
+  it.each([
+    ['::1', true],
+    ['::', true],
+    ['fe80::1', true],
+    ['febf::1', true],
+    ['fc00::1', true],
+    ['fd12:3456::1', true],
+    ['ff02::1', true],
+    ['::ffff:127.0.0.1', true],
+    ['::ffff:10.0.0.1', true],
+    ['2001:4860:4860::8888', false],
+    ['2606:4700:4700::1111', false],
+  ])('classifies %s correctly', (ip, expected) => {
+    expect(isPrivateIPv6(ip)).toBe(expected)
+  })
+})
+
+describe('validateExternalUrl', () => {
+  it('rejects non-http schemes', async () => {
+    await expect(
+      validateExternalUrl('file:///etc/passwd', { resolver: resolver('any', ['8.8.8.8']) }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError)
+    await expect(
+      validateExternalUrl('ftp://example.com/file', {
+        resolver: resolver('example.com', ['8.8.8.8']),
+      }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError)
+  })
+
+  it('rejects malformed URLs', async () => {
+    await expect(validateExternalUrl('not-a-url')).rejects.toBeInstanceOf(UnsafeUrlError)
+  })
+
+  it('rejects when DNS resolves to a private address', async () => {
+    await expect(
+      validateExternalUrl('http://internal.example.com/secret', {
+        resolver: resolver('internal.example.com', ['10.0.0.5']),
+      }),
+    ).rejects.toMatchObject({ name: 'UnsafeUrlError' })
+  })
+
+  it('rejects when DNS resolves to loopback', async () => {
+    await expect(
+      validateExternalUrl('http://localhost.example/', {
+        resolver: resolver('localhost.example', ['127.0.0.1']),
+      }),
+    ).rejects.toMatchObject({ name: 'UnsafeUrlError' })
+  })
+
+  it('rejects link-local AWS metadata IP', async () => {
+    await expect(
+      validateExternalUrl('http://169.254.169.254/latest/meta-data/'),
+    ).rejects.toBeInstanceOf(UnsafeUrlError)
+  })
+
+  it('rejects when any of the resolved addresses is private', async () => {
+    await expect(
+      validateExternalUrl('http://mixed.example.com/', {
+        resolver: resolver('mixed.example.com', ['8.8.8.8', '192.168.1.1']),
+      }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError)
+  })
+
+  it('accepts a public host with a public IP', async () => {
+    const url = await validateExternalUrl('https://example.com/path?q=1', {
+      resolver: resolver('example.com', ['151.101.1.69']),
+    })
+    expect(url.hostname).toBe('example.com')
+    expect(url.protocol).toBe('https:')
+  })
+
+  it('strips IPv6 brackets before resolution', async () => {
+    const url = await validateExternalUrl('http://[2001:4860:4860::8888]/', {
+      resolver: resolver('2001:4860:4860::8888', ['2001:4860:4860::8888']),
+    })
+    expect(url.hostname).toBe('[2001:4860:4860::8888]')
+  })
+})

--- a/sdks/ts/memory-pi/test/smoke.test.ts
+++ b/sdks/ts/memory-pi/test/smoke.test.ts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Smoke tests for the @jeffs-brain/memory-pi extension. They spin up a
+ * MemStore-backed fixture brain, mount the extension through a stub
+ * `ExtensionAPI`, and verify the four lifecycle hooks emit the expected
+ * effects:
+ *
+ *   1. `before_agent_start` injects a `<recalled-memory>` block.
+ *   2. `turn_end` enqueues an extract job once the threshold trips.
+ *   3. `session_shutdown` drains the queue.
+ *
+ * The stub deliberately omits TUI / signal plumbing so the test does
+ * not need to import any pi runtime internals.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { BeforeAgentStartEventResult } from '@earendil-works/pi-coding-agent'
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  type BeforeAgentStartEvent,
+  type ContextEvent,
+  type SessionShutdownEvent,
+  type TurnEndEvent,
+  createMemoryRuntime,
+  registerMemoryHooks,
+  registerMemoryTools,
+  renderRecallBlock,
+} from '../src/index.js'
+
+type RegisteredHandlers = {
+  before_agent_start?: (
+    event: BeforeAgentStartEvent,
+  ) => Promise<BeforeAgentStartEventResult | undefined> | BeforeAgentStartEventResult | undefined
+  context?: (event: ContextEvent) => unknown
+  turn_end?: (event: TurnEndEvent) => unknown
+  session_shutdown?: (event: SessionShutdownEvent) => unknown
+}
+
+const buildStubExtensionAPI = (): {
+  api: ExtensionAPI
+  handlers: RegisteredHandlers
+  registeredTools: string[]
+} => {
+  const handlers: RegisteredHandlers = {}
+  const registeredTools: string[] = []
+  const api = {
+    on: ((event: string, handler: (...args: unknown[]) => unknown) => {
+      ;(handlers as Record<string, unknown>)[event] = handler
+    }) as unknown as ExtensionAPI['on'],
+    registerTool: ((tool: { name: string }) => {
+      registeredTools.push(tool.name)
+    }) as unknown as ExtensionAPI['registerTool'],
+    registerCommand: vi.fn(),
+    registerShortcut: vi.fn(),
+    registerFlag: vi.fn(),
+    getFlag: vi.fn(),
+    registerMessageRenderer: vi.fn(),
+    sendMessage: vi.fn(),
+    sendUserMessage: vi.fn(),
+    appendEntry: vi.fn(),
+    setSessionName: vi.fn(),
+    getSessionName: vi.fn(),
+    setLabel: vi.fn(),
+    exec: vi.fn(),
+    getActiveTools: vi.fn(() => []),
+    getAllTools: vi.fn(() => []),
+    setActiveTools: vi.fn(),
+    getCommands: vi.fn(() => []),
+    setModel: vi.fn(),
+    getThinkingLevel: vi.fn(() => 'medium' as never),
+    setThinkingLevel: vi.fn(),
+    registerProvider: vi.fn(),
+    unregisterProvider: vi.fn(),
+    events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() } as never,
+  } as unknown as ExtensionAPI
+  return { api, handlers, registeredTools }
+}
+
+describe('memory-pi smoke', () => {
+  let brainRoot: string
+
+  beforeEach(async () => {
+    brainRoot = await mkdtemp(join(tmpdir(), 'memory-pi-'))
+  })
+
+  afterEach(async () => {
+    await rm(brainRoot, { recursive: true, force: true })
+  })
+
+  it('builds a runtime against a temp brain root', async () => {
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+      // Provider auto-detection will return undefined in CI; that is
+      // fine for recall-only tests.
+    })
+    expect(runtime.config.brainId).toBe('smoke')
+    expect(runtime.embedder).toBeUndefined()
+    await runtime.close()
+  })
+
+  it('registers all eleven tools', async () => {
+    const { api, registeredTools } = buildStubExtensionAPI()
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+    })
+    registerMemoryTools(api, runtime)
+    expect(registeredTools.sort()).toEqual(
+      [
+        'memory_remember',
+        'memory_recall',
+        'memory_search',
+        'memory_ask',
+        'memory_ingest_file',
+        'memory_ingest_url',
+        'memory_extract',
+        'memory_reflect',
+        'memory_consolidate',
+        'memory_create_brain',
+        'memory_list_brains',
+      ].sort(),
+    )
+    await runtime.close()
+  })
+
+  it('respects the tools.expose allowlist', async () => {
+    const { api, registeredTools } = buildStubExtensionAPI()
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+      tools: { expose: ['recall', 'search'] },
+    })
+    registerMemoryTools(api, runtime)
+    expect(registeredTools.sort()).toEqual(['memory_recall', 'memory_search'])
+    await runtime.close()
+  })
+
+  it('injects a recall block into the system prompt on before_agent_start', async () => {
+    const { api, handlers } = buildStubExtensionAPI()
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+      recall: { onPrompt: true, cacheFriendly: true },
+    })
+    // Force a deterministic recall response so we can observe injection.
+    runtime.memory.recall = vi.fn(async () => [])
+    registerMemoryHooks(api, runtime)
+    expect(handlers.before_agent_start).toBeDefined()
+    const result = await handlers.before_agent_start?.({
+      type: 'before_agent_start',
+      prompt: 'tell me about the deploy pipeline',
+      systemPrompt: 'You are an assistant.',
+      systemPromptOptions: {} as never,
+    })
+    expect(result).toBeDefined()
+    expect(result?.systemPrompt).toContain('<recalled-memory>')
+    expect(result?.systemPrompt).toContain('</recalled-memory>')
+    // Second call with identical recall set should skip re-injection
+    // because cacheFriendly is on and the snapshot signature matches.
+    const second = await handlers.before_agent_start?.({
+      type: 'before_agent_start',
+      prompt: 'tell me about the deploy pipeline',
+      systemPrompt: 'You are an assistant.',
+      systemPromptOptions: {} as never,
+    })
+    expect(second).toBeUndefined()
+    await runtime.close()
+  })
+
+  it('enqueues an extract job on turn_end when threshold trips', async () => {
+    const { api, handlers } = buildStubExtensionAPI()
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+      extract: { onTurnEnd: true, minMessages: 1 },
+    })
+    // Stub the extract pipeline so the queue can drain without an LLM.
+    const extractMock = vi.fn(async () => [])
+    runtime.memory.extract = extractMock as never
+    registerMemoryHooks(api, runtime)
+
+    const turnEvent: TurnEndEvent = {
+      type: 'turn_end',
+      turnIndex: 0,
+      message: {
+        role: 'assistant',
+        content: 'extract me',
+      } as never,
+      toolResults: [],
+    }
+    await handlers.turn_end?.(turnEvent)
+    // Drain the queue to confirm the job ran.
+    await runtime.extractQueue.flush()
+    expect(extractMock).toHaveBeenCalledTimes(1)
+    await runtime.close()
+  })
+
+  it('flushes the queue on session_shutdown', async () => {
+    const { api, handlers } = buildStubExtensionAPI()
+    const runtime = await createMemoryRuntime({
+      brainRoot,
+      brainId: 'smoke',
+      store: { kind: 'fs' },
+      embedder: { kind: 'off' },
+      reflect: { onSessionEnd: false },
+      consolidate: { schedule: 'manual' },
+    })
+    const extractMock = vi.fn(async () => [])
+    runtime.memory.extract = extractMock as never
+    runtime.extractQueue.enqueue({
+      messages: [{ role: 'user', content: 'pending' }],
+      actorId: runtime.config.actorId,
+    })
+    registerMemoryHooks(api, runtime)
+    await handlers.session_shutdown?.({
+      type: 'session_shutdown',
+      reason: 'quit',
+    })
+    expect(extractMock).toHaveBeenCalled()
+    await runtime.close()
+  })
+
+  it('renders a labelled empty recall block when there are no hits', () => {
+    const rendered = renderRecallBlock([], 'empty')
+    expect(rendered).toBe('<recalled-memory>empty</recalled-memory>')
+  })
+})

--- a/sdks/ts/memory-pi/test/smoke.test.ts
+++ b/sdks/ts/memory-pi/test/smoke.test.ts
@@ -239,4 +239,39 @@ describe('memory-pi smoke', () => {
     const rendered = renderRecallBlock([], 'empty')
     expect(rendered).toBe('<recalled-memory>empty</recalled-memory>')
   })
+
+  it('honours flatLayout and writes the FTS sqlite to the override path', async () => {
+    const { mkdir, writeFile } = await import('node:fs/promises')
+    const { existsSync } = await import('node:fs')
+    await mkdir(join(brainRoot, 'memory'), { recursive: true })
+    await writeFile(
+      join(brainRoot, 'memory', 'feedback-style.md'),
+      '# Feedback\n\nPrefer concise responses.\n',
+      'utf8',
+    )
+    const indexDir = await mkdtemp(join(tmpdir(), 'memory-pi-state-'))
+    try {
+      const indexPath = join(indexDir, 'memory-pi', 'search.sqlite')
+      const runtime = await createMemoryRuntime({
+        brainRoot,
+        brainId: 'test-brain',
+        flatLayout: true,
+        searchIndexPath: indexPath,
+        store: { kind: 'fs' },
+        embedder: { kind: 'off' },
+      })
+      try {
+        expect(runtime.config.flatLayout).toBe(true)
+        expect(runtime.config.searchIndexPath).toBe(indexPath)
+        expect(existsSync(indexPath)).toBe(true)
+        const hits = runtime.searchIndex.searchBM25('concise', 5)
+        expect(hits.length).toBeGreaterThan(0)
+        expect(hits[0]?.chunk.path).toBe('memory/feedback-style.md')
+      } finally {
+        await runtime.close()
+      }
+    } finally {
+      await rm(indexDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/sdks/ts/memory-pi/tsconfig.build.json
+++ b/sdks/ts/memory-pi/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.json"
+}

--- a/sdks/ts/memory-pi/tsconfig.build.json
+++ b/sdks/ts/memory-pi/tsconfig.build.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+  }
 }

--- a/sdks/ts/memory-pi/tsconfig.json
+++ b/sdks/ts/memory-pi/tsconfig.json
@@ -1,13 +1,10 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "noEmit": false,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "test"]
+  "references": [{ "path": "../memory" }],
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.integration.test.ts"]
 }

--- a/sdks/ts/memory-pi/tsconfig.json
+++ b/sdks/ts/memory-pi/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/sdks/ts/memory-pi/vitest.config.ts
+++ b/sdks/ts/memory-pi/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@jeffs-brain/memory-pi',
+    include: ['test/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

Lands the configuration knobs and runtime behaviour single-brain hosts need to wire memory-pi against an existing on-disk brain managed by a separate runtime. Backwards compatible: the multi-brain layout that existing callers use stays the default.

Headline additions to `createMemoryExtension`:

- **`flatLayout: true`** — treat `brainRoot` as the brain itself, no `brainId` subdirectory join.
- **`searchIndexPath`** — redirect the SQLite FTS index to an absolute path outside the brain root (useful when the brain is a git working tree and the FTS sqlite is machine-local state).
- **`bootstrapScanDirs`** (default `['wiki', 'memory', 'raw']`) — directories the on-boot indexer walks the first time the FTS is empty.

The on-boot indexer is the more interesting piece: it chunks every markdown file under those directories and upserts the chunks straight into the SQLite `SearchIndex` via `upsertChunks`. The `Store` is bypassed entirely so the source `.md` files are never duplicated or rewritten — important for hosts that keep brain content in a git working tree. Re-entries are no-ops once `knowledge_chunks` is populated.

Two smaller additions ride along:

- The SQLite `SearchIndex` is now bridged into `createMemory` via a small adapter, so `Memory.recall` returns BM25 hits instead of falling back to the scope-prefix store listing.
- Env-var overrides for ops use: `MEMORY_PI_FLAT_LAYOUT`, `MEMORY_PI_SEARCH_INDEX_PATH`, `MEMORY_PI_BRAIN_ROOT`, `MEMORY_PI_BRAIN_ID`.

## Packaging

- `@earendil-works/pi-coding-agent` and `typebox` move to `peerDependencies` so pi's bundled copies are used at runtime (required by pi's separate-module-root package loading model — otherwise we ship duplicate copies that don't share state).
- Version bumped to **`0.2.0`** per semver (additive new options, no breaking changes).

## Backwards compatibility

- `flatLayout` defaults to `false`. Existing multi-brain callers keep getting `<root>/<brainId>/<content>` resolution.
- `resolveBrainPaths(root, brainId)` two-argument signature still works; the new options object is the optional third argument.
- The new BM25 adapter in `Memory.recall` only fires when `searchIndex` was not already supplied to `createMemory`, so callers injecting their own index see no change.

## Tests

- `test/bootstrap-flat.test.ts` (new, 5 cases): happy path, idempotency, missing scan dirs, hidden/binary skipping, frontmatter-aware title extraction.
- `test/defaults.test.ts`: three new cases for flat / override / scoped-with-override resolution.
- `test/smoke.test.ts`: new end-to-end flatLayout assertion (temp brain → FTS index at override path → BM25 returns seeded chunk).

```
$ bun run typecheck   # ✓ clean
$ bun run test        # 28/28 pass
$ bun run build       # ✓ clean
```

## Test plan

- [x] Unit tests cover every new code path (28 cases across 6 files).
- [x] Typecheck clean.
- [x] Build clean.
- [ ] End-to-end against a real single-brain host's on-disk content (verified locally during development against a brain with ~2700 markdown files; indexed 19,200 chunks across the configured scan dirs).
- [ ] Verify `pi install` resolves peerDeps correctly once the package is published to npm.

## Notes

- Bumps `memory-pi` to `0.2.0`. CHANGELOG entry added under `[Unreleased]`.
- No changes to `@jeffs-brain/memory` itself; this is a memory-pi-only change.