### PR TITLE
feat(ingest): dead letter queue with error history and re-enqueue (P3-3)

### DIFF
--- a/go/ingest/deadletter.go
+++ b/go/ingest/deadletter.go
@@ -1,0 +1,831 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DefaultMaxAttempts is the default number of failed attempts before a job
+// is moved to the dead letter queue.
+const DefaultMaxAttempts = 3
+
+// DefaultRetentionDays is the default number of days dead letter entries
+// are retained before they become eligible for age-based purging.
+const DefaultRetentionDays = 30
+
+// ErrDeadLetterNotFound signals that the requested dead letter entry does
+// not exist.
+var ErrDeadLetterNotFound = errors.New("ingest: dead letter entry not found")
+
+// ErrDeadLetterAlreadyResolved signals that the entry has already been
+// retried or otherwise resolved.
+var ErrDeadLetterAlreadyResolved = errors.New("ingest: dead letter entry already resolved")
+
+// JobPayload holds the serialised job data that was being processed when
+// the job failed permanently. This is the data needed to re-enqueue the
+// job for a retry from the dead letter queue.
+type JobPayload struct {
+	DocumentHash string `json:"documentHash"`
+	BrainID      string `json:"brainId"`
+	Source       string `json:"source,omitempty"`
+	ContentType  string `json:"contentType,omitempty"`
+}
+
+// DeadLetterEntry represents a job that has been moved to the dead letter
+// queue after exhausting its retry budget. It preserves the full error
+// history and original job context for operator inspection.
+type DeadLetterEntry struct {
+	ID            string            `json:"id"`
+	OriginalJobID string            `json:"originalJobId"`
+	BrainID       string            `json:"brainId"`
+	Payload       JobPayload        `json:"payload"`
+	FailureReason string            `json:"failureReason"`
+	LastError     string            `json:"lastError"`
+	RetryCount    int               `json:"retryCount"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	GroupID       string            `json:"groupId,omitempty"`
+	MovedAt       time.Time         `json:"movedAt"`
+	ResolvedAt    *time.Time        `json:"resolvedAt,omitempty"`
+	ResolvedBy    string            `json:"resolvedBy,omitempty"`
+}
+
+// DeadLetterListOptions controls filtering and pagination when listing
+// dead letter entries.
+type DeadLetterListOptions struct {
+	BrainID         string
+	Limit           int
+	Offset          int
+	IncludeResolved bool
+}
+
+// DeadLetterListResult holds a page of dead letter entries and the total
+// count matching the filter.
+type DeadLetterListResult struct {
+	Entries []DeadLetterEntry
+	Total   int
+}
+
+// PurgeKind discriminates the type of purge operation.
+type PurgeKind string
+
+const (
+	PurgeByID       PurgeKind = "by-id"
+	PurgeByBrain    PurgeKind = "by-brain"
+	PurgeOlderThan  PurgeKind = "older-than"
+	PurgeAllResolved PurgeKind = "all-resolved"
+)
+
+// PurgeOptions specifies which dead letter entries should be removed.
+type PurgeOptions struct {
+	Kind    PurgeKind
+	ID      string
+	BrainID string
+	Days    int
+}
+
+// DeadLetterAdapter defines the operations available on the dead letter
+// queue. Both SQLite and PostgreSQL implementations satisfy this
+// interface.
+type DeadLetterAdapter interface {
+	// Move transfers a failed job to the dead letter queue with a reason.
+	Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error)
+
+	// List returns a paginated, filtered view of dead letter entries.
+	List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error)
+
+	// Get retrieves a single entry by ID. Returns ErrDeadLetterNotFound
+	// when no entry exists.
+	Get(ctx context.Context, id string) (DeadLetterEntry, error)
+
+	// Retry marks an entry as resolved and returns a new JobPayload that
+	// can be re-enqueued. Returns ErrDeadLetterAlreadyResolved if the
+	// entry was already retried.
+	Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error)
+
+	// Purge removes entries matching the given options and returns the
+	// count of entries removed.
+	Purge(ctx context.Context, opts PurgeOptions) (int, error)
+
+	// Count returns the number of dead letter entries, optionally
+	// filtered by brain ID.
+	Count(ctx context.Context, brainID string) (int, error)
+}
+
+// deadLetterListCap is the initial slice capacity for list results.
+const deadLetterListCap = 32
+
+// SqliteDeadLetterAdapter implements DeadLetterAdapter backed by a SQLite
+// database. Used for local/embedded deployments.
+type SqliteDeadLetterAdapter struct {
+	db *sql.DB
+}
+
+// NewSqliteDeadLetterAdapter creates a dead letter adapter backed by
+// SQLite. The caller must ensure the ingest_dead_letter table exists.
+func NewSqliteDeadLetterAdapter(db *sql.DB) *SqliteDeadLetterAdapter {
+	return &SqliteDeadLetterAdapter{db: db}
+}
+
+// EnsureTable creates the dead letter table and indices if they do not
+// already exist.
+func (a *SqliteDeadLetterAdapter) EnsureTable(ctx context.Context) error {
+	_, err := a.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS ingest_dead_letter (
+			id              TEXT PRIMARY KEY,
+			original_job_id TEXT NOT NULL,
+			brain_id        TEXT NOT NULL,
+			payload         TEXT NOT NULL,
+			failure_reason  TEXT NOT NULL,
+			last_error      TEXT,
+			retry_count     INTEGER NOT NULL DEFAULT 0,
+			metadata        TEXT,
+			group_id        TEXT,
+			moved_at        TEXT NOT NULL DEFAULT (datetime('now')),
+			resolved_at     TEXT,
+			resolved_by     TEXT
+		)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter table: %w", err)
+	}
+	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_brain ON ingest_dead_letter(brain_id)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter brain index: %w", err)
+	}
+	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_moved ON ingest_dead_letter(moved_at)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter moved index: %w", err)
+	}
+	return nil
+}
+
+func (a *SqliteDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	if entry.MovedAt.IsZero() {
+		entry.MovedAt = time.Now().UTC()
+	}
+
+	payloadJSON, err := json.Marshal(entry.Payload)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
+	}
+
+	var metadataJSON []byte
+	if len(entry.Metadata) > 0 {
+		metadataJSON, err = json.Marshal(entry.Metadata)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
+		}
+	}
+
+	_, err = a.db.ExecContext(ctx, `
+		INSERT INTO ingest_dead_letter
+			(id, original_job_id, brain_id, payload, failure_reason, last_error,
+			 retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		entry.ID,
+		entry.OriginalJobID,
+		entry.BrainID,
+		string(payloadJSON),
+		entry.FailureReason,
+		nullableString(entry.LastError),
+		entry.RetryCount,
+		nullableBytes(metadataJSON),
+		nullableString(entry.GroupID),
+		entry.MovedAt.Format(time.RFC3339),
+		nullableTime(entry.ResolvedAt),
+		nullableString(entry.ResolvedBy),
+	)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: move to dead letter: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	whereClause, args := buildListWhere(opts)
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM ingest_dead_letter %s", whereClause)
+	var total int
+	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter count: %w", err)
+	}
+
+	selectQuery := fmt.Sprintf(`
+		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
+		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
+		  FROM ingest_dead_letter
+		  %s
+		 ORDER BY moved_at DESC
+		 LIMIT ? OFFSET ?`, whereClause)
+
+	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
+	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
+	if err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
+	for rows.Next() {
+		entry, scanErr := scanDeadLetterRow(rows)
+		if scanErr != nil {
+			return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list scan: %w", scanErr)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list iterate: %w", err)
+	}
+
+	return DeadLetterListResult{Entries: entries, Total: total}, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
+	row := a.db.QueryRowContext(ctx, `
+		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
+		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
+		  FROM ingest_dead_letter
+		 WHERE id = ?`, id)
+
+	entry, err := scanDeadLetterSingleRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DeadLetterEntry{}, ErrDeadLetterNotFound
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter get: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error) {
+	entry, err := a.Get(ctx, id)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+	if entry.ResolvedAt != nil {
+		return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
+	}
+
+	now := time.Now().UTC()
+	_, err = a.db.ExecContext(ctx, `
+		UPDATE ingest_dead_letter
+		   SET resolved_at = ?, resolved_by = ?
+		 WHERE id = ?`,
+		now.Format(time.RFC3339), resolvedBy, id)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry update: %w", err)
+	}
+
+	entry.ResolvedAt = &now
+	entry.ResolvedBy = resolvedBy
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
+	query, args := buildPurgeQuery(opts)
+	result, err := a.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("ingest: dead letter purge: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("ingest: dead letter purge rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
+func (a *SqliteDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
+	var count int
+	var err error
+	if brainID == "" {
+		err = a.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM ingest_dead_letter WHERE resolved_at IS NULL").Scan(&count)
+	} else {
+		err = a.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM ingest_dead_letter WHERE brain_id = ? AND resolved_at IS NULL",
+			brainID).Scan(&count)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("ingest: dead letter count: %w", err)
+	}
+	return count, nil
+}
+
+// PostgresDeadLetterAdapter implements DeadLetterAdapter backed by
+// PostgreSQL. Used for hosted/production deployments.
+type PostgresDeadLetterAdapter struct {
+	db     *sql.DB
+	schema string
+}
+
+// PostgresDeadLetterConfig configures the PostgreSQL dead letter adapter.
+type PostgresDeadLetterConfig struct {
+	DB     *sql.DB
+	Schema string
+}
+
+// NewPostgresDeadLetterAdapter creates a dead letter adapter backed by
+// PostgreSQL. Returns an error if the schema name is invalid.
+func NewPostgresDeadLetterAdapter(cfg PostgresDeadLetterConfig) (*PostgresDeadLetterAdapter, error) {
+	if cfg.DB == nil {
+		return nil, fmt.Errorf("ingest: postgres DB is required for dead letter adapter")
+	}
+	schema := cfg.Schema
+	if schema == "" {
+		schema = "memory"
+	}
+	if !schemaNamePattern.MatchString(schema) {
+		return nil, fmt.Errorf("ingest: invalid schema name %q for dead letter adapter", schema)
+	}
+	return &PostgresDeadLetterAdapter{db: cfg.DB, schema: schema}, nil
+}
+
+func (a *PostgresDeadLetterAdapter) table() string {
+	return fmt.Sprintf("%s.ingest_dead_letter", a.schema)
+}
+
+func (a *PostgresDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	if entry.MovedAt.IsZero() {
+		entry.MovedAt = time.Now().UTC()
+	}
+
+	payloadJSON, err := json.Marshal(entry.Payload)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
+	}
+
+	var metadataJSON []byte
+	if len(entry.Metadata) > 0 {
+		metadataJSON, err = json.Marshal(entry.Metadata)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
+		}
+	}
+
+	query := fmt.Sprintf(`
+		INSERT INTO %s
+			(id, original_job_id, brain_id, payload, failure_reason, last_error,
+			 retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, a.table())
+
+	_, err = a.db.ExecContext(ctx, query,
+		entry.ID,
+		entry.OriginalJobID,
+		entry.BrainID,
+		string(payloadJSON),
+		entry.FailureReason,
+		nullableString(entry.LastError),
+		entry.RetryCount,
+		nullableBytes(metadataJSON),
+		nullableString(entry.GroupID),
+		entry.MovedAt,
+		nullableTime(entry.ResolvedAt),
+		nullableString(entry.ResolvedBy),
+	)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg move to dead letter: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	whereClause, args := buildListWherePg(opts)
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", a.table(), whereClause)
+	var total int
+	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter count: %w", err)
+	}
+
+	nextParam := len(args) + 1
+	selectQuery := fmt.Sprintf(`
+		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
+		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
+		  FROM %s
+		  %s
+		 ORDER BY moved_at DESC
+		 LIMIT $%d OFFSET $%d`, a.table(), whereClause, nextParam, nextParam+1)
+
+	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
+	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
+	if err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
+	for rows.Next() {
+		entry, scanErr := scanDeadLetterRows(rows)
+		if scanErr != nil {
+			return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list scan: %w", scanErr)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list iterate: %w", err)
+	}
+
+	return DeadLetterListResult{Entries: entries, Total: total}, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
+	query := fmt.Sprintf(`
+		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
+		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
+		  FROM %s
+		 WHERE id = $1`, a.table())
+
+	row := a.db.QueryRowContext(ctx, query, id)
+	entry, err := scanDeadLetterSingleRow(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DeadLetterEntry{}, ErrDeadLetterNotFound
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter get: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error) {
+	entry, err := a.Get(ctx, id)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+	if entry.ResolvedAt != nil {
+		return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
+	}
+
+	now := time.Now().UTC()
+	query := fmt.Sprintf(`
+		UPDATE %s
+		   SET resolved_at = $1, resolved_by = $2
+		 WHERE id = $3`, a.table())
+
+	_, err = a.db.ExecContext(ctx, query, now, resolvedBy, id)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry update: %w", err)
+	}
+
+	entry.ResolvedAt = &now
+	entry.ResolvedBy = resolvedBy
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
+	query, args := buildPurgeQueryPg(opts, a.table())
+	result, err := a.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter purge: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter purge rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
+func (a *PostgresDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
+	var count int
+	var err error
+	if brainID == "" {
+		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE resolved_at IS NULL", a.table())
+		err = a.db.QueryRowContext(ctx, query).Scan(&count)
+	} else {
+		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE brain_id = $1 AND resolved_at IS NULL", a.table())
+		err = a.db.QueryRowContext(ctx, query, brainID).Scan(&count)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter count: %w", err)
+	}
+	return count, nil
+}
+
+// --- Helpers ----------------------------------------------------------------
+
+func nullableString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func nullableBytes(b []byte) *string {
+	if len(b) == 0 {
+		return nil
+	}
+	s := string(b)
+	return &s
+}
+
+func nullableTime(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}
+
+func buildListWhere(opts DeadLetterListOptions) (string, []interface{}) {
+	clauses := make([]string, 0, 2)
+	args := make([]interface{}, 0, 2)
+	paramIdx := 1
+
+	if opts.BrainID != "" {
+		clauses = append(clauses, fmt.Sprintf("brain_id = ?"))
+		args = append(args, opts.BrainID)
+		paramIdx++
+	}
+	if !opts.IncludeResolved {
+		clauses = append(clauses, "resolved_at IS NULL")
+	}
+
+	_ = paramIdx
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	where := "WHERE " + clauses[0]
+	for i := 1; i < len(clauses); i++ {
+		where += " AND " + clauses[i]
+	}
+	return where, args
+}
+
+func buildListWherePg(opts DeadLetterListOptions) (string, []interface{}) {
+	clauses := make([]string, 0, 2)
+	args := make([]interface{}, 0, 2)
+	paramIdx := 1
+
+	if opts.BrainID != "" {
+		clauses = append(clauses, fmt.Sprintf("brain_id = $%d", paramIdx))
+		args = append(args, opts.BrainID)
+		paramIdx++
+	}
+	if !opts.IncludeResolved {
+		clauses = append(clauses, "resolved_at IS NULL")
+	}
+
+	_ = paramIdx
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	where := "WHERE " + clauses[0]
+	for i := 1; i < len(clauses); i++ {
+		where += " AND " + clauses[i]
+	}
+	return where, args
+}
+
+func buildPurgeQuery(opts PurgeOptions) (string, []interface{}) {
+	purgeQueries := map[PurgeKind]struct {
+		query string
+		args  func() []interface{}
+	}{
+		PurgeByID: {
+			query: "DELETE FROM ingest_dead_letter WHERE id = ?",
+			args:  func() []interface{} { return []interface{}{opts.ID} },
+		},
+		PurgeByBrain: {
+			query: "DELETE FROM ingest_dead_letter WHERE brain_id = ?",
+			args:  func() []interface{} { return []interface{}{opts.BrainID} },
+		},
+		PurgeOlderThan: {
+			query: "DELETE FROM ingest_dead_letter WHERE moved_at < datetime('now', ?)",
+			args: func() []interface{} {
+				return []interface{}{fmt.Sprintf("-%d days", opts.Days)}
+			},
+		},
+		PurgeAllResolved: {
+			query: "DELETE FROM ingest_dead_letter WHERE resolved_at IS NOT NULL",
+			args:  func() []interface{} { return nil },
+		},
+	}
+
+	entry, ok := purgeQueries[opts.Kind]
+	if !ok {
+		return "SELECT 0", nil
+	}
+	return entry.query, entry.args()
+}
+
+func buildPurgeQueryPg(opts PurgeOptions, table string) (string, []interface{}) {
+	purgeQueries := map[PurgeKind]struct {
+		query string
+		args  func() []interface{}
+	}{
+		PurgeByID: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE id = $1", table),
+			args:  func() []interface{} { return []interface{}{opts.ID} },
+		},
+		PurgeByBrain: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE brain_id = $1", table),
+			args:  func() []interface{} { return []interface{}{opts.BrainID} },
+		},
+		PurgeOlderThan: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE moved_at < NOW() - INTERVAL '1 day' * $1", table),
+			args: func() []interface{} {
+				return []interface{}{opts.Days}
+			},
+		},
+		PurgeAllResolved: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE resolved_at IS NOT NULL", table),
+			args:  func() []interface{} { return nil },
+		},
+	}
+
+	entry, ok := purgeQueries[opts.Kind]
+	if !ok {
+		return "SELECT 0", nil
+	}
+	return entry.query, entry.args()
+}
+
+func scanDeadLetterRow(rows *sql.Rows) (DeadLetterEntry, error) {
+	var entry DeadLetterEntry
+	var payloadJSON string
+	var lastError sql.NullString
+	var metadataJSON sql.NullString
+	var groupID sql.NullString
+	var movedAt string
+	var resolvedAt sql.NullString
+	var resolvedBy sql.NullString
+
+	err := rows.Scan(
+		&entry.ID,
+		&entry.OriginalJobID,
+		&entry.BrainID,
+		&payloadJSON,
+		&entry.FailureReason,
+		&lastError,
+		&entry.RetryCount,
+		&metadataJSON,
+		&groupID,
+		&movedAt,
+		&resolvedAt,
+		&resolvedBy,
+	)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+
+	return populateDeadLetterEntry(entry, payloadJSON, lastError, metadataJSON, groupID, movedAt, resolvedAt, resolvedBy)
+}
+
+func scanDeadLetterRows(rows *sql.Rows) (DeadLetterEntry, error) {
+	var entry DeadLetterEntry
+	var payloadJSON string
+	var lastError sql.NullString
+	var metadataJSON sql.NullString
+	var groupID sql.NullString
+	var movedAt time.Time
+	var resolvedAt sql.NullTime
+	var resolvedBy sql.NullString
+
+	err := rows.Scan(
+		&entry.ID,
+		&entry.OriginalJobID,
+		&entry.BrainID,
+		&payloadJSON,
+		&entry.FailureReason,
+		&lastError,
+		&entry.RetryCount,
+		&metadataJSON,
+		&groupID,
+		&movedAt,
+		&resolvedAt,
+		&resolvedBy,
+	)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+
+	if err := json.Unmarshal([]byte(payloadJSON), &entry.Payload); err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter payload: %w", err)
+	}
+	if lastError.Valid {
+		entry.LastError = lastError.String
+	}
+	if metadataJSON.Valid {
+		meta := make(map[string]string)
+		if unmarshalErr := json.Unmarshal([]byte(metadataJSON.String), &meta); unmarshalErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter metadata: %w", unmarshalErr)
+		}
+		entry.Metadata = meta
+	}
+	if groupID.Valid {
+		entry.GroupID = groupID.String
+	}
+	entry.MovedAt = movedAt
+	if resolvedAt.Valid {
+		entry.ResolvedAt = &resolvedAt.Time
+	}
+	if resolvedBy.Valid {
+		entry.ResolvedBy = resolvedBy.String
+	}
+
+	return entry, nil
+}
+
+func scanDeadLetterSingleRow(row *sql.Row) (DeadLetterEntry, error) {
+	var entry DeadLetterEntry
+	var payloadJSON string
+	var lastError sql.NullString
+	var metadataJSON sql.NullString
+	var groupID sql.NullString
+	var movedAt string
+	var resolvedAt sql.NullString
+	var resolvedBy sql.NullString
+
+	err := row.Scan(
+		&entry.ID,
+		&entry.OriginalJobID,
+		&entry.BrainID,
+		&payloadJSON,
+		&entry.FailureReason,
+		&lastError,
+		&entry.RetryCount,
+		&metadataJSON,
+		&groupID,
+		&movedAt,
+		&resolvedAt,
+		&resolvedBy,
+	)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+
+	return populateDeadLetterEntry(entry, payloadJSON, lastError, metadataJSON, groupID, movedAt, resolvedAt, resolvedBy)
+}
+
+func populateDeadLetterEntry(
+	entry DeadLetterEntry,
+	payloadJSON string,
+	lastError sql.NullString,
+	metadataJSON sql.NullString,
+	groupID sql.NullString,
+	movedAt string,
+	resolvedAt sql.NullString,
+	resolvedBy sql.NullString,
+) (DeadLetterEntry, error) {
+	if err := json.Unmarshal([]byte(payloadJSON), &entry.Payload); err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter payload: %w", err)
+	}
+
+	if lastError.Valid {
+		entry.LastError = lastError.String
+	}
+	if metadataJSON.Valid {
+		meta := make(map[string]string)
+		if unmarshalErr := json.Unmarshal([]byte(metadataJSON.String), &meta); unmarshalErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter metadata: %w", unmarshalErr)
+		}
+		entry.Metadata = meta
+	}
+	if groupID.Valid {
+		entry.GroupID = groupID.String
+	}
+
+	parsed, err := time.Parse(time.RFC3339, movedAt)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter moved_at: %w", err)
+	}
+	entry.MovedAt = parsed
+
+	if resolvedAt.Valid {
+		parsedResolved, parseErr := time.Parse(time.RFC3339, resolvedAt.String)
+		if parseErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter resolved_at: %w", parseErr)
+		}
+		entry.ResolvedAt = &parsedResolved
+	}
+	if resolvedBy.Valid {
+		entry.ResolvedBy = resolvedBy.String
+	}
+
+	return entry, nil
+}
+
+// Compile-time interface assertions.
+var _ DeadLetterAdapter = (*SqliteDeadLetterAdapter)(nil)
+var _ DeadLetterAdapter = (*PostgresDeadLetterAdapter)(nil)

--- a/go/ingest/deadletter.go
+++ b/go/ingest/deadletter.go
@@ -7,9 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // DefaultMaxAttempts is the default number of failed attempts before a job
@@ -48,6 +47,7 @@ type DeadLetterEntry struct {
 	Payload       JobPayload        `json:"payload"`
 	FailureReason string            `json:"failureReason"`
 	LastError     string            `json:"lastError"`
+	ErrorHistory  []string          `json:"errorHistory,omitempty"`
 	RetryCount    int               `json:"retryCount"`
 	Metadata      map[string]string `json:"metadata,omitempty"`
 	GroupID       string            `json:"groupId,omitempty"`
@@ -76,9 +76,9 @@ type DeadLetterListResult struct {
 type PurgeKind string
 
 const (
-	PurgeByID       PurgeKind = "by-id"
-	PurgeByBrain    PurgeKind = "by-brain"
-	PurgeOlderThan  PurgeKind = "older-than"
+	PurgeByID        PurgeKind = "by-id"
+	PurgeByBrain     PurgeKind = "by-brain"
+	PurgeOlderThan   PurgeKind = "older-than"
 	PurgeAllResolved PurgeKind = "all-resolved"
 )
 
@@ -89,6 +89,12 @@ type PurgeOptions struct {
 	BrainID string
 	Days    int
 }
+
+// ReEnqueueFunc is a callback that creates a new queue job in the main
+// queue from a dead letter entry. The implementation is responsible for
+// resetting the retry count and assigning a new job ID. Returning an
+// error prevents the DLQ entry from being marked as resolved.
+type ReEnqueueFunc func(ctx context.Context, entry DeadLetterEntry) error
 
 // DeadLetterAdapter defines the operations available on the dead letter
 // queue. Both SQLite and PostgreSQL implementations satisfy this
@@ -104,10 +110,12 @@ type DeadLetterAdapter interface {
 	// when no entry exists.
 	Get(ctx context.Context, id string) (DeadLetterEntry, error)
 
-	// Retry marks an entry as resolved and returns a new JobPayload that
-	// can be re-enqueued. Returns ErrDeadLetterAlreadyResolved if the
-	// entry was already retried.
-	Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error)
+	// Retry marks an entry as resolved and invokes the re-enqueue
+	// callback to create a new queue job in the main queue. Returns
+	// ErrDeadLetterAlreadyResolved if the entry was already retried.
+	// If reEnqueue is nil, the entry is marked as resolved without
+	// re-enqueueing (caller takes responsibility).
+	Retry(ctx context.Context, id string, resolvedBy string, reEnqueue ReEnqueueFunc) (DeadLetterEntry, error)
 
 	// Purge removes entries matching the given options and returns the
 	// count of entries removed.
@@ -121,408 +129,12 @@ type DeadLetterAdapter interface {
 // deadLetterListCap is the initial slice capacity for list results.
 const deadLetterListCap = 32
 
-// SqliteDeadLetterAdapter implements DeadLetterAdapter backed by a SQLite
-// database. Used for local/embedded deployments.
-type SqliteDeadLetterAdapter struct {
-	db *sql.DB
-}
+// deadLetterColumns is the column list used in SELECT queries for dead
+// letter entries. Both adapters reference the same columns.
+const deadLetterColumns = `id, original_job_id, brain_id, payload, failure_reason, last_error,
+	       error_history, retry_count, metadata, group_id, moved_at, resolved_at, resolved_by`
 
-// NewSqliteDeadLetterAdapter creates a dead letter adapter backed by
-// SQLite. The caller must ensure the ingest_dead_letter table exists.
-func NewSqliteDeadLetterAdapter(db *sql.DB) *SqliteDeadLetterAdapter {
-	return &SqliteDeadLetterAdapter{db: db}
-}
-
-// EnsureTable creates the dead letter table and indices if they do not
-// already exist.
-func (a *SqliteDeadLetterAdapter) EnsureTable(ctx context.Context) error {
-	_, err := a.db.ExecContext(ctx, `
-		CREATE TABLE IF NOT EXISTS ingest_dead_letter (
-			id              TEXT PRIMARY KEY,
-			original_job_id TEXT NOT NULL,
-			brain_id        TEXT NOT NULL,
-			payload         TEXT NOT NULL,
-			failure_reason  TEXT NOT NULL,
-			last_error      TEXT,
-			retry_count     INTEGER NOT NULL DEFAULT 0,
-			metadata        TEXT,
-			group_id        TEXT,
-			moved_at        TEXT NOT NULL DEFAULT (datetime('now')),
-			resolved_at     TEXT,
-			resolved_by     TEXT
-		)`)
-	if err != nil {
-		return fmt.Errorf("ingest: create dead letter table: %w", err)
-	}
-	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_brain ON ingest_dead_letter(brain_id)`)
-	if err != nil {
-		return fmt.Errorf("ingest: create dead letter brain index: %w", err)
-	}
-	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_moved ON ingest_dead_letter(moved_at)`)
-	if err != nil {
-		return fmt.Errorf("ingest: create dead letter moved index: %w", err)
-	}
-	return nil
-}
-
-func (a *SqliteDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
-	if entry.ID == "" {
-		entry.ID = uuid.New().String()
-	}
-	if entry.MovedAt.IsZero() {
-		entry.MovedAt = time.Now().UTC()
-	}
-
-	payloadJSON, err := json.Marshal(entry.Payload)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
-	}
-
-	var metadataJSON []byte
-	if len(entry.Metadata) > 0 {
-		metadataJSON, err = json.Marshal(entry.Metadata)
-		if err != nil {
-			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
-		}
-	}
-
-	_, err = a.db.ExecContext(ctx, `
-		INSERT INTO ingest_dead_letter
-			(id, original_job_id, brain_id, payload, failure_reason, last_error,
-			 retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		entry.ID,
-		entry.OriginalJobID,
-		entry.BrainID,
-		string(payloadJSON),
-		entry.FailureReason,
-		nullableString(entry.LastError),
-		entry.RetryCount,
-		nullableBytes(metadataJSON),
-		nullableString(entry.GroupID),
-		entry.MovedAt.Format(time.RFC3339),
-		nullableTime(entry.ResolvedAt),
-		nullableString(entry.ResolvedBy),
-	)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: move to dead letter: %w", err)
-	}
-	return entry, nil
-}
-
-func (a *SqliteDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-
-	whereClause, args := buildListWhere(opts)
-
-	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM ingest_dead_letter %s", whereClause)
-	var total int
-	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter count: %w", err)
-	}
-
-	selectQuery := fmt.Sprintf(`
-		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
-		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
-		  FROM ingest_dead_letter
-		  %s
-		 ORDER BY moved_at DESC
-		 LIMIT ? OFFSET ?`, whereClause)
-
-	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
-	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
-	if err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list: %w", err)
-	}
-	defer rows.Close()
-
-	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
-	for rows.Next() {
-		entry, scanErr := scanDeadLetterRow(rows)
-		if scanErr != nil {
-			return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list scan: %w", scanErr)
-		}
-		entries = append(entries, entry)
-	}
-	if err := rows.Err(); err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list iterate: %w", err)
-	}
-
-	return DeadLetterListResult{Entries: entries, Total: total}, nil
-}
-
-func (a *SqliteDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
-	row := a.db.QueryRowContext(ctx, `
-		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
-		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
-		  FROM ingest_dead_letter
-		 WHERE id = ?`, id)
-
-	entry, err := scanDeadLetterSingleRow(row)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return DeadLetterEntry{}, ErrDeadLetterNotFound
-		}
-		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter get: %w", err)
-	}
-	return entry, nil
-}
-
-func (a *SqliteDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error) {
-	entry, err := a.Get(ctx, id)
-	if err != nil {
-		return DeadLetterEntry{}, err
-	}
-	if entry.ResolvedAt != nil {
-		return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
-	}
-
-	now := time.Now().UTC()
-	_, err = a.db.ExecContext(ctx, `
-		UPDATE ingest_dead_letter
-		   SET resolved_at = ?, resolved_by = ?
-		 WHERE id = ?`,
-		now.Format(time.RFC3339), resolvedBy, id)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry update: %w", err)
-	}
-
-	entry.ResolvedAt = &now
-	entry.ResolvedBy = resolvedBy
-	return entry, nil
-}
-
-func (a *SqliteDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
-	query, args := buildPurgeQuery(opts)
-	result, err := a.db.ExecContext(ctx, query, args...)
-	if err != nil {
-		return 0, fmt.Errorf("ingest: dead letter purge: %w", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("ingest: dead letter purge rows affected: %w", err)
-	}
-	return int(affected), nil
-}
-
-func (a *SqliteDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
-	var count int
-	var err error
-	if brainID == "" {
-		err = a.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM ingest_dead_letter WHERE resolved_at IS NULL").Scan(&count)
-	} else {
-		err = a.db.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM ingest_dead_letter WHERE brain_id = ? AND resolved_at IS NULL",
-			brainID).Scan(&count)
-	}
-	if err != nil {
-		return 0, fmt.Errorf("ingest: dead letter count: %w", err)
-	}
-	return count, nil
-}
-
-// PostgresDeadLetterAdapter implements DeadLetterAdapter backed by
-// PostgreSQL. Used for hosted/production deployments.
-type PostgresDeadLetterAdapter struct {
-	db     *sql.DB
-	schema string
-}
-
-// PostgresDeadLetterConfig configures the PostgreSQL dead letter adapter.
-type PostgresDeadLetterConfig struct {
-	DB     *sql.DB
-	Schema string
-}
-
-// NewPostgresDeadLetterAdapter creates a dead letter adapter backed by
-// PostgreSQL. Returns an error if the schema name is invalid.
-func NewPostgresDeadLetterAdapter(cfg PostgresDeadLetterConfig) (*PostgresDeadLetterAdapter, error) {
-	if cfg.DB == nil {
-		return nil, fmt.Errorf("ingest: postgres DB is required for dead letter adapter")
-	}
-	schema := cfg.Schema
-	if schema == "" {
-		schema = "memory"
-	}
-	if !schemaNamePattern.MatchString(schema) {
-		return nil, fmt.Errorf("ingest: invalid schema name %q for dead letter adapter", schema)
-	}
-	return &PostgresDeadLetterAdapter{db: cfg.DB, schema: schema}, nil
-}
-
-func (a *PostgresDeadLetterAdapter) table() string {
-	return fmt.Sprintf("%s.ingest_dead_letter", a.schema)
-}
-
-func (a *PostgresDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
-	if entry.ID == "" {
-		entry.ID = uuid.New().String()
-	}
-	if entry.MovedAt.IsZero() {
-		entry.MovedAt = time.Now().UTC()
-	}
-
-	payloadJSON, err := json.Marshal(entry.Payload)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
-	}
-
-	var metadataJSON []byte
-	if len(entry.Metadata) > 0 {
-		metadataJSON, err = json.Marshal(entry.Metadata)
-		if err != nil {
-			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
-		}
-	}
-
-	query := fmt.Sprintf(`
-		INSERT INTO %s
-			(id, original_job_id, brain_id, payload, failure_reason, last_error,
-			 retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, a.table())
-
-	_, err = a.db.ExecContext(ctx, query,
-		entry.ID,
-		entry.OriginalJobID,
-		entry.BrainID,
-		string(payloadJSON),
-		entry.FailureReason,
-		nullableString(entry.LastError),
-		entry.RetryCount,
-		nullableBytes(metadataJSON),
-		nullableString(entry.GroupID),
-		entry.MovedAt,
-		nullableTime(entry.ResolvedAt),
-		nullableString(entry.ResolvedBy),
-	)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: pg move to dead letter: %w", err)
-	}
-	return entry, nil
-}
-
-func (a *PostgresDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-
-	whereClause, args := buildListWherePg(opts)
-
-	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", a.table(), whereClause)
-	var total int
-	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter count: %w", err)
-	}
-
-	nextParam := len(args) + 1
-	selectQuery := fmt.Sprintf(`
-		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
-		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
-		  FROM %s
-		  %s
-		 ORDER BY moved_at DESC
-		 LIMIT $%d OFFSET $%d`, a.table(), whereClause, nextParam, nextParam+1)
-
-	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
-	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
-	if err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list: %w", err)
-	}
-	defer rows.Close()
-
-	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
-	for rows.Next() {
-		entry, scanErr := scanDeadLetterRows(rows)
-		if scanErr != nil {
-			return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list scan: %w", scanErr)
-		}
-		entries = append(entries, entry)
-	}
-	if err := rows.Err(); err != nil {
-		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list iterate: %w", err)
-	}
-
-	return DeadLetterListResult{Entries: entries, Total: total}, nil
-}
-
-func (a *PostgresDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
-	query := fmt.Sprintf(`
-		SELECT id, original_job_id, brain_id, payload, failure_reason, last_error,
-		       retry_count, metadata, group_id, moved_at, resolved_at, resolved_by
-		  FROM %s
-		 WHERE id = $1`, a.table())
-
-	row := a.db.QueryRowContext(ctx, query, id)
-	entry, err := scanDeadLetterSingleRow(row)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return DeadLetterEntry{}, ErrDeadLetterNotFound
-		}
-		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter get: %w", err)
-	}
-	return entry, nil
-}
-
-func (a *PostgresDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string) (DeadLetterEntry, error) {
-	entry, err := a.Get(ctx, id)
-	if err != nil {
-		return DeadLetterEntry{}, err
-	}
-	if entry.ResolvedAt != nil {
-		return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
-	}
-
-	now := time.Now().UTC()
-	query := fmt.Sprintf(`
-		UPDATE %s
-		   SET resolved_at = $1, resolved_by = $2
-		 WHERE id = $3`, a.table())
-
-	_, err = a.db.ExecContext(ctx, query, now, resolvedBy, id)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry update: %w", err)
-	}
-
-	entry.ResolvedAt = &now
-	entry.ResolvedBy = resolvedBy
-	return entry, nil
-}
-
-func (a *PostgresDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
-	query, args := buildPurgeQueryPg(opts, a.table())
-	result, err := a.db.ExecContext(ctx, query, args...)
-	if err != nil {
-		return 0, fmt.Errorf("ingest: pg dead letter purge: %w", err)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("ingest: pg dead letter purge rows affected: %w", err)
-	}
-	return int(affected), nil
-}
-
-func (a *PostgresDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
-	var count int
-	var err error
-	if brainID == "" {
-		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE resolved_at IS NULL", a.table())
-		err = a.db.QueryRowContext(ctx, query).Scan(&count)
-	} else {
-		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE brain_id = $1 AND resolved_at IS NULL", a.table())
-		err = a.db.QueryRowContext(ctx, query, brainID).Scan(&count)
-	}
-	if err != nil {
-		return 0, fmt.Errorf("ingest: pg dead letter count: %w", err)
-	}
-	return count, nil
-}
-
-// --- Helpers ----------------------------------------------------------------
+// --- Shared helpers ----------------------------------------------------------
 
 func nullableString(s string) *string {
 	if s == "" {
@@ -547,283 +159,83 @@ func nullableTime(t *time.Time) *string {
 	return &s
 }
 
-func buildListWhere(opts DeadLetterListOptions) (string, []interface{}) {
-	clauses := make([]string, 0, 2)
-	args := make([]interface{}, 0, 2)
-	paramIdx := 1
-
-	if opts.BrainID != "" {
-		clauses = append(clauses, fmt.Sprintf("brain_id = ?"))
-		args = append(args, opts.BrainID)
-		paramIdx++
-	}
-	if !opts.IncludeResolved {
-		clauses = append(clauses, "resolved_at IS NULL")
-	}
-
-	_ = paramIdx
-	if len(clauses) == 0 {
-		return "", nil
-	}
-	where := "WHERE " + clauses[0]
-	for i := 1; i < len(clauses); i++ {
-		where += " AND " + clauses[i]
-	}
-	return where, args
+// scanner is the common interface satisfied by both *sql.Row and *sql.Rows,
+// allowing a single scan function to handle both cases per dialect.
+type scanner interface {
+	Scan(dest ...any) error
 }
 
-func buildListWherePg(opts DeadLetterListOptions) (string, []interface{}) {
-	clauses := make([]string, 0, 2)
-	args := make([]interface{}, 0, 2)
-	paramIdx := 1
-
-	if opts.BrainID != "" {
-		clauses = append(clauses, fmt.Sprintf("brain_id = $%d", paramIdx))
-		args = append(args, opts.BrainID)
-		paramIdx++
-	}
-	if !opts.IncludeResolved {
-		clauses = append(clauses, "resolved_at IS NULL")
-	}
-
-	_ = paramIdx
-	if len(clauses) == 0 {
-		return "", nil
-	}
-	where := "WHERE " + clauses[0]
-	for i := 1; i < len(clauses); i++ {
-		where += " AND " + clauses[i]
-	}
-	return where, args
-}
-
-func buildPurgeQuery(opts PurgeOptions) (string, []interface{}) {
-	purgeQueries := map[PurgeKind]struct {
-		query string
-		args  func() []interface{}
-	}{
-		PurgeByID: {
-			query: "DELETE FROM ingest_dead_letter WHERE id = ?",
-			args:  func() []interface{} { return []interface{}{opts.ID} },
-		},
-		PurgeByBrain: {
-			query: "DELETE FROM ingest_dead_letter WHERE brain_id = ?",
-			args:  func() []interface{} { return []interface{}{opts.BrainID} },
-		},
-		PurgeOlderThan: {
-			query: "DELETE FROM ingest_dead_letter WHERE moved_at < datetime('now', ?)",
-			args: func() []interface{} {
-				return []interface{}{fmt.Sprintf("-%d days", opts.Days)}
-			},
-		},
-		PurgeAllResolved: {
-			query: "DELETE FROM ingest_dead_letter WHERE resolved_at IS NOT NULL",
-			args:  func() []interface{} { return nil },
-		},
-	}
-
-	entry, ok := purgeQueries[opts.Kind]
-	if !ok {
-		return "SELECT 0", nil
-	}
-	return entry.query, entry.args()
-}
-
-func buildPurgeQueryPg(opts PurgeOptions, table string) (string, []interface{}) {
-	purgeQueries := map[PurgeKind]struct {
-		query string
-		args  func() []interface{}
-	}{
-		PurgeByID: {
-			query: fmt.Sprintf("DELETE FROM %s WHERE id = $1", table),
-			args:  func() []interface{} { return []interface{}{opts.ID} },
-		},
-		PurgeByBrain: {
-			query: fmt.Sprintf("DELETE FROM %s WHERE brain_id = $1", table),
-			args:  func() []interface{} { return []interface{}{opts.BrainID} },
-		},
-		PurgeOlderThan: {
-			query: fmt.Sprintf("DELETE FROM %s WHERE moved_at < NOW() - INTERVAL '1 day' * $1", table),
-			args: func() []interface{} {
-				return []interface{}{opts.Days}
-			},
-		},
-		PurgeAllResolved: {
-			query: fmt.Sprintf("DELETE FROM %s WHERE resolved_at IS NOT NULL", table),
-			args:  func() []interface{} { return nil },
-		},
-	}
-
-	entry, ok := purgeQueries[opts.Kind]
-	if !ok {
-		return "SELECT 0", nil
-	}
-	return entry.query, entry.args()
-}
-
-func scanDeadLetterRow(rows *sql.Rows) (DeadLetterEntry, error) {
-	var entry DeadLetterEntry
-	var payloadJSON string
-	var lastError sql.NullString
-	var metadataJSON sql.NullString
-	var groupID sql.NullString
-	var movedAt string
-	var resolvedAt sql.NullString
-	var resolvedBy sql.NullString
-
-	err := rows.Scan(
-		&entry.ID,
-		&entry.OriginalJobID,
-		&entry.BrainID,
-		&payloadJSON,
-		&entry.FailureReason,
-		&lastError,
-		&entry.RetryCount,
-		&metadataJSON,
-		&groupID,
-		&movedAt,
-		&resolvedAt,
-		&resolvedBy,
-	)
-	if err != nil {
-		return DeadLetterEntry{}, err
-	}
-
-	return populateDeadLetterEntry(entry, payloadJSON, lastError, metadataJSON, groupID, movedAt, resolvedAt, resolvedBy)
-}
-
-func scanDeadLetterRows(rows *sql.Rows) (DeadLetterEntry, error) {
-	var entry DeadLetterEntry
-	var payloadJSON string
-	var lastError sql.NullString
-	var metadataJSON sql.NullString
-	var groupID sql.NullString
-	var movedAt time.Time
-	var resolvedAt sql.NullTime
-	var resolvedBy sql.NullString
-
-	err := rows.Scan(
-		&entry.ID,
-		&entry.OriginalJobID,
-		&entry.BrainID,
-		&payloadJSON,
-		&entry.FailureReason,
-		&lastError,
-		&entry.RetryCount,
-		&metadataJSON,
-		&groupID,
-		&movedAt,
-		&resolvedAt,
-		&resolvedBy,
-	)
-	if err != nil {
-		return DeadLetterEntry{}, err
-	}
-
-	if err := json.Unmarshal([]byte(payloadJSON), &entry.Payload); err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter payload: %w", err)
-	}
-	if lastError.Valid {
-		entry.LastError = lastError.String
-	}
-	if metadataJSON.Valid {
-		meta := make(map[string]string)
-		if unmarshalErr := json.Unmarshal([]byte(metadataJSON.String), &meta); unmarshalErr != nil {
-			return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter metadata: %w", unmarshalErr)
-		}
-		entry.Metadata = meta
-	}
-	if groupID.Valid {
-		entry.GroupID = groupID.String
-	}
-	entry.MovedAt = movedAt
-	if resolvedAt.Valid {
-		entry.ResolvedAt = &resolvedAt.Time
-	}
-	if resolvedBy.Valid {
-		entry.ResolvedBy = resolvedBy.String
-	}
-
-	return entry, nil
-}
-
-func scanDeadLetterSingleRow(row *sql.Row) (DeadLetterEntry, error) {
-	var entry DeadLetterEntry
-	var payloadJSON string
-	var lastError sql.NullString
-	var metadataJSON sql.NullString
-	var groupID sql.NullString
-	var movedAt string
-	var resolvedAt sql.NullString
-	var resolvedBy sql.NullString
-
-	err := row.Scan(
-		&entry.ID,
-		&entry.OriginalJobID,
-		&entry.BrainID,
-		&payloadJSON,
-		&entry.FailureReason,
-		&lastError,
-		&entry.RetryCount,
-		&metadataJSON,
-		&groupID,
-		&movedAt,
-		&resolvedAt,
-		&resolvedBy,
-	)
-	if err != nil {
-		return DeadLetterEntry{}, err
-	}
-
-	return populateDeadLetterEntry(entry, payloadJSON, lastError, metadataJSON, groupID, movedAt, resolvedAt, resolvedBy)
-}
-
-func populateDeadLetterEntry(
-	entry DeadLetterEntry,
+// populateCommonFields deserialises JSON fields and assigns nullable
+// columns that are common to both SQLite and PostgreSQL scan paths.
+func populateCommonFields(
+	entry *DeadLetterEntry,
 	payloadJSON string,
 	lastError sql.NullString,
+	errorHistoryJSON sql.NullString,
 	metadataJSON sql.NullString,
 	groupID sql.NullString,
-	movedAt string,
-	resolvedAt sql.NullString,
 	resolvedBy sql.NullString,
-) (DeadLetterEntry, error) {
+) error {
 	if err := json.Unmarshal([]byte(payloadJSON), &entry.Payload); err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter payload: %w", err)
+		return fmt.Errorf("ingest: unmarshal dead letter payload: %w", err)
 	}
 
 	if lastError.Valid {
 		entry.LastError = lastError.String
 	}
+
+	if errorHistoryJSON.Valid && errorHistoryJSON.String != "" {
+		var history []string
+		if unmarshalErr := json.Unmarshal([]byte(errorHistoryJSON.String), &history); unmarshalErr != nil {
+			return fmt.Errorf("ingest: unmarshal dead letter error history: %w", unmarshalErr)
+		}
+		entry.ErrorHistory = history
+	}
+
 	if metadataJSON.Valid {
 		meta := make(map[string]string)
 		if unmarshalErr := json.Unmarshal([]byte(metadataJSON.String), &meta); unmarshalErr != nil {
-			return DeadLetterEntry{}, fmt.Errorf("ingest: unmarshal dead letter metadata: %w", unmarshalErr)
+			return fmt.Errorf("ingest: unmarshal dead letter metadata: %w", unmarshalErr)
 		}
 		entry.Metadata = meta
 	}
+
 	if groupID.Valid {
 		entry.GroupID = groupID.String
-	}
-
-	parsed, err := time.Parse(time.RFC3339, movedAt)
-	if err != nil {
-		return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter moved_at: %w", err)
-	}
-	entry.MovedAt = parsed
-
-	if resolvedAt.Valid {
-		parsedResolved, parseErr := time.Parse(time.RFC3339, resolvedAt.String)
-		if parseErr != nil {
-			return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter resolved_at: %w", parseErr)
-		}
-		entry.ResolvedAt = &parsedResolved
 	}
 	if resolvedBy.Valid {
 		entry.ResolvedBy = resolvedBy.String
 	}
 
-	return entry, nil
+	return nil
+}
+
+// buildListWhere constructs a WHERE clause and parameter list for the
+// list query. The placeholder argument controls the style: use "?" for
+// SQLite or "$" for PostgreSQL (numbered placeholders).
+func buildListWhere(opts DeadLetterListOptions, placeholder string) (string, []any) {
+	clauses := make([]string, 0, 2)
+	args := make([]any, 0, 2)
+	paramIdx := 1
+
+	if opts.BrainID != "" {
+		ph := "?"
+		if placeholder == "$" {
+			ph = fmt.Sprintf("$%d", paramIdx)
+		}
+		clauses = append(clauses, "brain_id = "+ph)
+		args = append(args, opts.BrainID)
+		paramIdx++
+	}
+	if !opts.IncludeResolved {
+		clauses = append(clauses, "resolved_at IS NULL")
+	}
+
+	_ = paramIdx
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return "WHERE " + strings.Join(clauses, " AND "), args
 }
 
 // Compile-time interface assertions.

--- a/go/ingest/deadletter_pg.go
+++ b/go/ingest/deadletter_pg.go
@@ -184,7 +184,7 @@ func (a *PostgresDeadLetterAdapter) Retry(ctx context.Context, id string, resolv
 			// Distinguish between not-found and already-resolved.
 			var exists int
 			checkQuery := fmt.Sprintf("SELECT 1 FROM %s WHERE id = $1", a.table())
-			checkErr := a.db.QueryRowContext(ctx, checkQuery, id).Scan(&exists)
+			checkErr := tx.QueryRowContext(ctx, checkQuery, id).Scan(&exists)
 			if checkErr != nil {
 				return DeadLetterEntry{}, ErrDeadLetterNotFound
 			}

--- a/go/ingest/deadletter_pg.go
+++ b/go/ingest/deadletter_pg.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PostgresDeadLetterAdapter implements DeadLetterAdapter backed by
+// PostgreSQL. Used for hosted/production deployments.
+type PostgresDeadLetterAdapter struct {
+	db     *sql.DB
+	schema string
+}
+
+// PostgresDeadLetterConfig configures the PostgreSQL dead letter adapter.
+type PostgresDeadLetterConfig struct {
+	DB     *sql.DB
+	Schema string
+}
+
+// NewPostgresDeadLetterAdapter creates a dead letter adapter backed by
+// PostgreSQL. Returns an error if the schema name is invalid.
+func NewPostgresDeadLetterAdapter(cfg PostgresDeadLetterConfig) (*PostgresDeadLetterAdapter, error) {
+	if cfg.DB == nil {
+		return nil, fmt.Errorf("ingest: postgres DB is required for dead letter adapter")
+	}
+	schema := cfg.Schema
+	if schema == "" {
+		schema = "memory"
+	}
+	if !schemaNamePattern.MatchString(schema) {
+		return nil, fmt.Errorf("ingest: invalid schema name %q for dead letter adapter", schema)
+	}
+	return &PostgresDeadLetterAdapter{db: cfg.DB, schema: schema}, nil
+}
+
+func (a *PostgresDeadLetterAdapter) table() string {
+	return fmt.Sprintf("%s.ingest_dead_letter", a.schema)
+}
+
+func (a *PostgresDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	if entry.MovedAt.IsZero() {
+		entry.MovedAt = time.Now().UTC()
+	}
+
+	payloadJSON, err := json.Marshal(entry.Payload)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
+	}
+
+	var metadataJSON []byte
+	if len(entry.Metadata) > 0 {
+		metadataJSON, err = json.Marshal(entry.Metadata)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
+		}
+	}
+
+	var errorHistoryJSON []byte
+	if len(entry.ErrorHistory) > 0 {
+		errorHistoryJSON, err = json.Marshal(entry.ErrorHistory)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter error history: %w", err)
+		}
+	}
+
+	query := fmt.Sprintf(`
+		INSERT INTO %s
+			(id, original_job_id, brain_id, payload, failure_reason, last_error,
+			 error_history, retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`, a.table())
+
+	_, err = a.db.ExecContext(ctx, query,
+		entry.ID,
+		entry.OriginalJobID,
+		entry.BrainID,
+		string(payloadJSON),
+		entry.FailureReason,
+		nullableString(entry.LastError),
+		nullableBytes(errorHistoryJSON),
+		entry.RetryCount,
+		nullableBytes(metadataJSON),
+		nullableString(entry.GroupID),
+		entry.MovedAt,
+		nullableTime(entry.ResolvedAt),
+		nullableString(entry.ResolvedBy),
+	)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg move to dead letter: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	whereClause, args := buildListWhere(opts, "$")
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", a.table(), whereClause)
+	var total int
+	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter count: %w", err)
+	}
+
+	nextParam := len(args) + 1
+	selectQuery := fmt.Sprintf(`
+		SELECT %s
+		  FROM %s
+		  %s
+		 ORDER BY moved_at DESC
+		 LIMIT $%d OFFSET $%d`, deadLetterColumns, a.table(), whereClause, nextParam, nextParam+1)
+
+	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
+	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
+	if err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
+	for rows.Next() {
+		entry, scanErr := scanPgRow(rows)
+		if scanErr != nil {
+			return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list scan: %w", scanErr)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list iterate: %w", err)
+	}
+
+	return DeadLetterListResult{Entries: entries, Total: total}, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
+	query := fmt.Sprintf(`
+		SELECT %s
+		  FROM %s
+		 WHERE id = $1`, deadLetterColumns, a.table())
+
+	row := a.db.QueryRowContext(ctx, query, id)
+	entry, err := scanPgRow(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return DeadLetterEntry{}, ErrDeadLetterNotFound
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter get: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string, reEnqueue ReEnqueueFunc) (DeadLetterEntry, error) {
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	now := time.Now().UTC()
+
+	// Atomic update: only update if not already resolved.
+	query := fmt.Sprintf(`
+		UPDATE %s
+		   SET resolved_at = $1, resolved_by = $2
+		 WHERE id = $3 AND resolved_at IS NULL
+		 RETURNING %s`, a.table(), deadLetterColumns)
+
+	row := tx.QueryRowContext(ctx, query, now, resolvedBy, id)
+	entry, scanErr := scanPgRow(row)
+	if scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			// Distinguish between not-found and already-resolved.
+			var exists int
+			checkQuery := fmt.Sprintf("SELECT 1 FROM %s WHERE id = $1", a.table())
+			checkErr := a.db.QueryRowContext(ctx, checkQuery, id).Scan(&exists)
+			if checkErr != nil {
+				return DeadLetterEntry{}, ErrDeadLetterNotFound
+			}
+			return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry scan: %w", scanErr)
+	}
+
+	if reEnqueue != nil {
+		if enqueueErr := reEnqueue(ctx, entry); enqueueErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry re-enqueue: %w", enqueueErr)
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: pg dead letter retry commit: %w", commitErr)
+	}
+
+	return entry, nil
+}
+
+func (a *PostgresDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
+	query, args := buildPgPurgeQuery(opts, a.table())
+	result, err := a.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter purge: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter purge rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
+func (a *PostgresDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
+	query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE resolved_at IS NULL", a.table())
+	args := make([]any, 0, 1)
+	if brainID != "" {
+		query = fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE brain_id = $1 AND resolved_at IS NULL", a.table())
+		args = append(args, brainID)
+	}
+
+	var count int
+	if err := a.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("ingest: pg dead letter count: %w", err)
+	}
+	return count, nil
+}
+
+// --- PG scan & query helpers -------------------------------------------------
+
+// scanPgRow scans a dead letter row from PostgreSQL. It uses native
+// time.Time/sql.NullTime for TIMESTAMPTZ columns, unlike the SQLite
+// scanner which reads timestamps as strings.
+func scanPgRow(s scanner) (DeadLetterEntry, error) {
+	var entry DeadLetterEntry
+	var payloadJSON string
+	var lastError sql.NullString
+	var errorHistoryJSON sql.NullString
+	var metadataJSON sql.NullString
+	var groupID sql.NullString
+	var movedAt time.Time
+	var resolvedAt sql.NullTime
+	var resolvedBy sql.NullString
+
+	err := s.Scan(
+		&entry.ID,
+		&entry.OriginalJobID,
+		&entry.BrainID,
+		&payloadJSON,
+		&entry.FailureReason,
+		&lastError,
+		&errorHistoryJSON,
+		&entry.RetryCount,
+		&metadataJSON,
+		&groupID,
+		&movedAt,
+		&resolvedAt,
+		&resolvedBy,
+	)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+
+	if populateErr := populateCommonFields(&entry, payloadJSON, lastError, errorHistoryJSON, metadataJSON, groupID, resolvedBy); populateErr != nil {
+		return DeadLetterEntry{}, populateErr
+	}
+
+	entry.MovedAt = movedAt
+	if resolvedAt.Valid {
+		entry.ResolvedAt = &resolvedAt.Time
+	}
+
+	return entry, nil
+}
+
+func buildPgPurgeQuery(opts PurgeOptions, table string) (string, []any) {
+	purgeQueries := map[PurgeKind]struct {
+		query string
+		args  func() []any
+	}{
+		PurgeByID: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE id = $1", table),
+			args:  func() []any { return []any{opts.ID} },
+		},
+		PurgeByBrain: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE brain_id = $1", table),
+			args:  func() []any { return []any{opts.BrainID} },
+		},
+		PurgeOlderThan: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE moved_at < NOW() - INTERVAL '1 day' * $1", table),
+			args: func() []any {
+				return []any{opts.Days}
+			},
+		},
+		PurgeAllResolved: {
+			query: fmt.Sprintf("DELETE FROM %s WHERE resolved_at IS NOT NULL", table),
+			args:  func() []any { return nil },
+		},
+	}
+
+	entry, ok := purgeQueries[opts.Kind]
+	if !ok {
+		return "SELECT 0", nil
+	}
+	return entry.query, entry.args()
+}

--- a/go/ingest/deadletter_pg.go
+++ b/go/ingest/deadletter_pg.go
@@ -127,7 +127,7 @@ func (a *PostgresDeadLetterAdapter) List(ctx context.Context, opts DeadLetterLis
 	if err != nil {
 		return DeadLetterListResult{}, fmt.Errorf("ingest: pg dead letter list: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
 	for rows.Next() {

--- a/go/ingest/deadletter_sqlite.go
+++ b/go/ingest/deadletter_sqlite.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SqliteDeadLetterAdapter implements DeadLetterAdapter backed by a SQLite
+// database. Used for local/embedded deployments.
+type SqliteDeadLetterAdapter struct {
+	db *sql.DB
+}
+
+// NewSqliteDeadLetterAdapter creates a dead letter adapter backed by
+// SQLite. The caller must ensure the ingest_dead_letter table exists.
+func NewSqliteDeadLetterAdapter(db *sql.DB) *SqliteDeadLetterAdapter {
+	return &SqliteDeadLetterAdapter{db: db}
+}
+
+// EnsureTable creates the dead letter table and indices if they do not
+// already exist.
+func (a *SqliteDeadLetterAdapter) EnsureTable(ctx context.Context) error {
+	_, err := a.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS ingest_dead_letter (
+			id              TEXT PRIMARY KEY,
+			original_job_id TEXT NOT NULL,
+			brain_id        TEXT NOT NULL,
+			payload         TEXT NOT NULL,
+			failure_reason  TEXT NOT NULL,
+			last_error      TEXT,
+			error_history   TEXT,
+			retry_count     INTEGER NOT NULL DEFAULT 0,
+			metadata        TEXT,
+			group_id        TEXT,
+			moved_at        TEXT NOT NULL DEFAULT (datetime('now')),
+			resolved_at     TEXT,
+			resolved_by     TEXT
+		)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter table: %w", err)
+	}
+	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_brain ON ingest_dead_letter(brain_id)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter brain index: %w", err)
+	}
+	_, err = a.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_dlq_moved ON ingest_dead_letter(moved_at)`)
+	if err != nil {
+		return fmt.Errorf("ingest: create dead letter moved index: %w", err)
+	}
+	return nil
+}
+
+func (a *SqliteDeadLetterAdapter) Move(ctx context.Context, entry DeadLetterEntry) (DeadLetterEntry, error) {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	if entry.MovedAt.IsZero() {
+		entry.MovedAt = time.Now().UTC()
+	}
+
+	payloadJSON, err := json.Marshal(entry.Payload)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter payload: %w", err)
+	}
+
+	var metadataJSON []byte
+	if len(entry.Metadata) > 0 {
+		metadataJSON, err = json.Marshal(entry.Metadata)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter metadata: %w", err)
+		}
+	}
+
+	var errorHistoryJSON []byte
+	if len(entry.ErrorHistory) > 0 {
+		errorHistoryJSON, err = json.Marshal(entry.ErrorHistory)
+		if err != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: marshal dead letter error history: %w", err)
+		}
+	}
+
+	_, err = a.db.ExecContext(ctx, `
+		INSERT INTO ingest_dead_letter
+			(id, original_job_id, brain_id, payload, failure_reason, last_error,
+			 error_history, retry_count, metadata, group_id, moved_at, resolved_at, resolved_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		entry.ID,
+		entry.OriginalJobID,
+		entry.BrainID,
+		string(payloadJSON),
+		entry.FailureReason,
+		nullableString(entry.LastError),
+		nullableBytes(errorHistoryJSON),
+		entry.RetryCount,
+		nullableBytes(metadataJSON),
+		nullableString(entry.GroupID),
+		entry.MovedAt.Format(time.RFC3339),
+		nullableTime(entry.ResolvedAt),
+		nullableString(entry.ResolvedBy),
+	)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: move to dead letter: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListOptions) (DeadLetterListResult, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	whereClause, args := buildListWhere(opts, "?")
+
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM ingest_dead_letter %s", whereClause)
+	var total int
+	if err := a.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter count: %w", err)
+	}
+
+	selectQuery := fmt.Sprintf(`
+		SELECT %s
+		  FROM ingest_dead_letter
+		  %s
+		 ORDER BY moved_at DESC
+		 LIMIT ? OFFSET ?`, deadLetterColumns, whereClause)
+
+	selectArgs := append(args, limit, opts.Offset) //nolint:gocritic // append to copy is intentional
+	rows, err := a.db.QueryContext(ctx, selectQuery, selectArgs...)
+	if err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list: %w", err)
+	}
+	defer rows.Close()
+
+	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
+	for rows.Next() {
+		entry, scanErr := scanSqliteRow(rows)
+		if scanErr != nil {
+			return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list scan: %w", scanErr)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list iterate: %w", err)
+	}
+
+	return DeadLetterListResult{Entries: entries, Total: total}, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Get(ctx context.Context, id string) (DeadLetterEntry, error) {
+	row := a.db.QueryRowContext(ctx, fmt.Sprintf(`
+		SELECT %s
+		  FROM ingest_dead_letter
+		 WHERE id = ?`, deadLetterColumns), id)
+
+	entry, err := scanSqliteRow(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return DeadLetterEntry{}, ErrDeadLetterNotFound
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter get: %w", err)
+	}
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Retry(ctx context.Context, id string, resolvedBy string, reEnqueue ReEnqueueFunc) (DeadLetterEntry, error) {
+	tx, err := a.db.BeginTx(ctx, nil)
+	if err != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	now := time.Now().UTC()
+	nowStr := now.Format(time.RFC3339)
+
+	// Atomic update: only update if not already resolved.
+	row := tx.QueryRowContext(ctx, fmt.Sprintf(`
+		UPDATE ingest_dead_letter
+		   SET resolved_at = ?, resolved_by = ?
+		 WHERE id = ? AND resolved_at IS NULL
+		 RETURNING %s`, deadLetterColumns),
+		nowStr, resolvedBy, id)
+
+	entry, scanErr := scanSqliteRow(row)
+	if scanErr != nil {
+		if scanErr == sql.ErrNoRows {
+			// Distinguish between not-found and already-resolved.
+			var exists int
+			checkErr := tx.QueryRowContext(ctx, "SELECT 1 FROM ingest_dead_letter WHERE id = ?", id).Scan(&exists)
+			if checkErr != nil {
+				return DeadLetterEntry{}, ErrDeadLetterNotFound
+			}
+			return DeadLetterEntry{}, ErrDeadLetterAlreadyResolved
+		}
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry scan: %w", scanErr)
+	}
+
+	if reEnqueue != nil {
+		if enqueueErr := reEnqueue(ctx, entry); enqueueErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry re-enqueue: %w", enqueueErr)
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: dead letter retry commit: %w", commitErr)
+	}
+
+	return entry, nil
+}
+
+func (a *SqliteDeadLetterAdapter) Purge(ctx context.Context, opts PurgeOptions) (int, error) {
+	query, args := buildSqlitePurgeQuery(opts)
+	result, err := a.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("ingest: dead letter purge: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("ingest: dead letter purge rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
+func (a *SqliteDeadLetterAdapter) Count(ctx context.Context, brainID string) (int, error) {
+	query := "SELECT COUNT(*) FROM ingest_dead_letter WHERE resolved_at IS NULL"
+	args := make([]any, 0, 1)
+	if brainID != "" {
+		query = "SELECT COUNT(*) FROM ingest_dead_letter WHERE brain_id = ? AND resolved_at IS NULL"
+		args = append(args, brainID)
+	}
+
+	var count int
+	if err := a.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("ingest: dead letter count: %w", err)
+	}
+	return count, nil
+}
+
+// --- SQLite scan & query helpers ---------------------------------------------
+
+// scanSqliteRow scans a dead letter row from SQLite. It handles
+// timestamps stored as RFC 3339 strings and nullable columns stored as
+// sql.NullString.
+func scanSqliteRow(s scanner) (DeadLetterEntry, error) {
+	var entry DeadLetterEntry
+	var payloadJSON string
+	var lastError sql.NullString
+	var errorHistoryJSON sql.NullString
+	var metadataJSON sql.NullString
+	var groupID sql.NullString
+	var movedAt string
+	var resolvedAt sql.NullString
+	var resolvedBy sql.NullString
+
+	err := s.Scan(
+		&entry.ID,
+		&entry.OriginalJobID,
+		&entry.BrainID,
+		&payloadJSON,
+		&entry.FailureReason,
+		&lastError,
+		&errorHistoryJSON,
+		&entry.RetryCount,
+		&metadataJSON,
+		&groupID,
+		&movedAt,
+		&resolvedAt,
+		&resolvedBy,
+	)
+	if err != nil {
+		return DeadLetterEntry{}, err
+	}
+
+	if populateErr := populateCommonFields(&entry, payloadJSON, lastError, errorHistoryJSON, metadataJSON, groupID, resolvedBy); populateErr != nil {
+		return DeadLetterEntry{}, populateErr
+	}
+
+	parsed, parseErr := time.Parse(time.RFC3339, movedAt)
+	if parseErr != nil {
+		return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter moved_at: %w", parseErr)
+	}
+	entry.MovedAt = parsed
+
+	if resolvedAt.Valid {
+		parsedResolved, parseResolvedErr := time.Parse(time.RFC3339, resolvedAt.String)
+		if parseResolvedErr != nil {
+			return DeadLetterEntry{}, fmt.Errorf("ingest: parse dead letter resolved_at: %w", parseResolvedErr)
+		}
+		entry.ResolvedAt = &parsedResolved
+	}
+
+	return entry, nil
+}
+
+func buildSqlitePurgeQuery(opts PurgeOptions) (string, []any) {
+	purgeQueries := map[PurgeKind]struct {
+		query string
+		args  func() []any
+	}{
+		PurgeByID: {
+			query: "DELETE FROM ingest_dead_letter WHERE id = ?",
+			args:  func() []any { return []any{opts.ID} },
+		},
+		PurgeByBrain: {
+			query: "DELETE FROM ingest_dead_letter WHERE brain_id = ?",
+			args:  func() []any { return []any{opts.BrainID} },
+		},
+		PurgeOlderThan: {
+			query: "DELETE FROM ingest_dead_letter WHERE moved_at < datetime('now', ?)",
+			args: func() []any {
+				return []any{fmt.Sprintf("-%d days", opts.Days)}
+			},
+		},
+		PurgeAllResolved: {
+			query: "DELETE FROM ingest_dead_letter WHERE resolved_at IS NOT NULL",
+			args:  func() []any { return nil },
+		},
+	}
+
+	entry, ok := purgeQueries[opts.Kind]
+	if !ok {
+		return "SELECT 0", nil
+	}
+	return entry.query, entry.args()
+}

--- a/go/ingest/deadletter_sqlite.go
+++ b/go/ingest/deadletter_sqlite.go
@@ -136,7 +136,7 @@ func (a *SqliteDeadLetterAdapter) List(ctx context.Context, opts DeadLetterListO
 	if err != nil {
 		return DeadLetterListResult{}, fmt.Errorf("ingest: dead letter list: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	entries := make([]DeadLetterEntry, 0, deadLetterListCap)
 	for rows.Next() {

--- a/go/ingest/deadletter_test.go
+++ b/go/ingest/deadletter_test.go
@@ -1,0 +1,631 @@
+// SPDX-License-Identifier: Apache-2.0
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func setupAdapter(t *testing.T) *SqliteDeadLetterAdapter {
+	t.Helper()
+	db := setupTestDB(t)
+	adapter := NewSqliteDeadLetterAdapter(db)
+	if err := adapter.EnsureTable(context.Background()); err != nil {
+		t.Fatalf("ensure table: %v", err)
+	}
+	return adapter
+}
+
+func makeTestEntry(overrides ...func(*DeadLetterEntry)) DeadLetterEntry {
+	entry := DeadLetterEntry{
+		ID:            "dlq-001",
+		OriginalJobID: "job-001",
+		BrainID:       "brain-1",
+		Payload: JobPayload{
+			DocumentHash: "abc123def4560000000000000000000000000000000000000000000000000000",
+			BrainID:      "brain-1",
+			Source:       "file:///test.md",
+			ContentType:  "text/markdown",
+		},
+		FailureReason: "embedding provider returned 500",
+		LastError:     "context deadline exceeded",
+		RetryCount:    3,
+		MovedAt:       time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	}
+	for _, fn := range overrides {
+		fn(&entry)
+	}
+	return entry
+}
+
+func TestSqliteDeadLetter_Move(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	result, err := adapter.Move(ctx, entry)
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	if result.ID != entry.ID {
+		t.Errorf("expected id %q, got %q", entry.ID, result.ID)
+	}
+	if result.BrainID != entry.BrainID {
+		t.Errorf("expected brainId %q, got %q", entry.BrainID, result.BrainID)
+	}
+	if result.FailureReason != entry.FailureReason {
+		t.Errorf("expected failure reason %q, got %q", entry.FailureReason, result.FailureReason)
+	}
+}
+
+func TestSqliteDeadLetter_MoveGeneratesIDWhenEmpty(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = ""
+	})
+	result, err := adapter.Move(ctx, entry)
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if result.ID == "" {
+		t.Error("expected generated ID, got empty")
+	}
+}
+
+func TestSqliteDeadLetter_Get(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if got.ID != entry.ID {
+		t.Errorf("id: expected %q, got %q", entry.ID, got.ID)
+	}
+	if got.OriginalJobID != entry.OriginalJobID {
+		t.Errorf("originalJobId: expected %q, got %q", entry.OriginalJobID, got.OriginalJobID)
+	}
+	if got.BrainID != entry.BrainID {
+		t.Errorf("brainId: expected %q, got %q", entry.BrainID, got.BrainID)
+	}
+	if got.Payload.DocumentHash != entry.Payload.DocumentHash {
+		t.Errorf("payload.documentHash: expected %q, got %q", entry.Payload.DocumentHash, got.Payload.DocumentHash)
+	}
+	if got.FailureReason != entry.FailureReason {
+		t.Errorf("failureReason: expected %q, got %q", entry.FailureReason, got.FailureReason)
+	}
+	if got.LastError != entry.LastError {
+		t.Errorf("lastError: expected %q, got %q", entry.LastError, got.LastError)
+	}
+	if got.RetryCount != entry.RetryCount {
+		t.Errorf("retryCount: expected %d, got %d", entry.RetryCount, got.RetryCount)
+	}
+}
+
+func TestSqliteDeadLetter_GetNotFound(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	_, err := adapter.Get(ctx, "nonexistent")
+	if err != ErrDeadLetterNotFound {
+		t.Errorf("expected ErrDeadLetterNotFound, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_ListUnresolvedByDefault(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	// Insert two entries: one unresolved, one resolved.
+	unresolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-unresolved"
+	})
+	if _, err := adapter.Move(ctx, unresolved); err != nil {
+		t.Fatalf("move unresolved: %v", err)
+	}
+
+	resolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-resolved"
+		now := time.Now().UTC()
+		e.ResolvedAt = &now
+		e.ResolvedBy = "operator"
+	})
+	if _, err := adapter.Move(ctx, resolved); err != nil {
+		t.Fatalf("move resolved: %v", err)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected total 1 (unresolved only), got %d", result.Total)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	if result.Entries[0].ID != "dlq-unresolved" {
+		t.Errorf("expected unresolved entry, got %q", result.Entries[0].ID)
+	}
+}
+
+func TestSqliteDeadLetter_ListIncludeResolved(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	unresolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-a"
+	})
+	if _, err := adapter.Move(ctx, unresolved); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	resolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-b"
+		now := time.Now().UTC()
+		e.ResolvedAt = &now
+		e.ResolvedBy = "operator"
+	})
+	if _, err := adapter.Move(ctx, resolved); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{IncludeResolved: true})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("expected total 2, got %d", result.Total)
+	}
+}
+
+func TestSqliteDeadLetter_ListFilterByBrain(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry1 := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-brain1"
+		e.BrainID = "brain-alpha"
+	})
+	if _, err := adapter.Move(ctx, entry1); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	entry2 := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-brain2"
+		e.BrainID = "brain-beta"
+	})
+	if _, err := adapter.Move(ctx, entry2); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{BrainID: "brain-alpha"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected total 1, got %d", result.Total)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	if result.Entries[0].BrainID != "brain-alpha" {
+		t.Errorf("expected brain-alpha, got %q", result.Entries[0].BrainID)
+	}
+}
+
+func TestSqliteDeadLetter_ListPagination(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		entry := makeTestEntry(func(e *DeadLetterEntry) {
+			e.ID = fmt.Sprintf("dlq-page-%d", i)
+			e.MovedAt = time.Date(2026, 5, 1, 12, 0, i, 0, time.UTC)
+		})
+		if _, err := adapter.Move(ctx, entry); err != nil {
+			t.Fatalf("move %d: %v", i, err)
+		}
+	}
+
+	// Page 1: limit 2, offset 0.
+	result, err := adapter.List(ctx, DeadLetterListOptions{Limit: 2, Offset: 0})
+	if err != nil {
+		t.Fatalf("list page 1: %v", err)
+	}
+	if result.Total != 5 {
+		t.Errorf("expected total 5, got %d", result.Total)
+	}
+	if len(result.Entries) != 2 {
+		t.Errorf("expected 2 entries on page 1, got %d", len(result.Entries))
+	}
+
+	// Page 2: limit 2, offset 2.
+	result2, err := adapter.List(ctx, DeadLetterListOptions{Limit: 2, Offset: 2})
+	if err != nil {
+		t.Fatalf("list page 2: %v", err)
+	}
+	if len(result2.Entries) != 2 {
+		t.Errorf("expected 2 entries on page 2, got %d", len(result2.Entries))
+	}
+
+	// Page 3: limit 2, offset 4.
+	result3, err := adapter.List(ctx, DeadLetterListOptions{Limit: 2, Offset: 4})
+	if err != nil {
+		t.Fatalf("list page 3: %v", err)
+	}
+	if len(result3.Entries) != 1 {
+		t.Errorf("expected 1 entry on page 3, got %d", len(result3.Entries))
+	}
+}
+
+func TestSqliteDeadLetter_Retry(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	resolved, err := adapter.Retry(ctx, entry.ID, "admin@example.com")
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if resolved.ResolvedAt == nil {
+		t.Fatal("expected resolvedAt to be set")
+	}
+	if resolved.ResolvedBy != "admin@example.com" {
+		t.Errorf("expected resolvedBy admin@example.com, got %q", resolved.ResolvedBy)
+	}
+
+	// Verify stored state.
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get after retry: %v", err)
+	}
+	if got.ResolvedAt == nil {
+		t.Error("expected resolvedAt to be persisted")
+	}
+}
+
+func TestSqliteDeadLetter_RetryNonExistent(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	_, err := adapter.Retry(ctx, "nonexistent", "operator")
+	if err != ErrDeadLetterNotFound {
+		t.Errorf("expected ErrDeadLetterNotFound, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_DoubleRetryFails(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if _, err := adapter.Retry(ctx, entry.ID, "operator-1"); err != nil {
+		t.Fatalf("first retry: %v", err)
+	}
+
+	_, err := adapter.Retry(ctx, entry.ID, "operator-2")
+	if err != ErrDeadLetterAlreadyResolved {
+		t.Errorf("expected ErrDeadLetterAlreadyResolved, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_PurgeByID(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	count, err := adapter.Purge(ctx, PurgeOptions{Kind: PurgeByID, ID: entry.ID})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 purged, got %d", count)
+	}
+
+	_, err = adapter.Get(ctx, entry.ID)
+	if err != ErrDeadLetterNotFound {
+		t.Errorf("expected not found after purge, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_PurgeByBrain(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		entry := makeTestEntry(func(e *DeadLetterEntry) {
+			e.ID = fmt.Sprintf("dlq-purge-brain-%d", i)
+			e.BrainID = "brain-to-purge"
+		})
+		if _, err := adapter.Move(ctx, entry); err != nil {
+			t.Fatalf("move %d: %v", i, err)
+		}
+	}
+
+	other := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-other-brain"
+		e.BrainID = "brain-keep"
+	})
+	if _, err := adapter.Move(ctx, other); err != nil {
+		t.Fatalf("move other: %v", err)
+	}
+
+	count, err := adapter.Purge(ctx, PurgeOptions{Kind: PurgeByBrain, BrainID: "brain-to-purge"})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 purged, got %d", count)
+	}
+
+	// Verify the other brain's entry survives.
+	result, err := adapter.List(ctx, DeadLetterListOptions{IncludeResolved: true})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 remaining, got %d", result.Total)
+	}
+}
+
+func TestSqliteDeadLetter_PurgeOlderThan(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	old := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-old"
+		e.MovedAt = time.Now().UTC().AddDate(0, 0, -60)
+	})
+	if _, err := adapter.Move(ctx, old); err != nil {
+		t.Fatalf("move old: %v", err)
+	}
+
+	recent := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-recent"
+		e.MovedAt = time.Now().UTC()
+	})
+	if _, err := adapter.Move(ctx, recent); err != nil {
+		t.Fatalf("move recent: %v", err)
+	}
+
+	count, err := adapter.Purge(ctx, PurgeOptions{Kind: PurgeOlderThan, Days: 30})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 purged, got %d", count)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{IncludeResolved: true})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 remaining, got %d", result.Total)
+	}
+}
+
+func TestSqliteDeadLetter_PurgeAllResolved(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	unresolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-unres"
+	})
+	if _, err := adapter.Move(ctx, unresolved); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	resolved := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-res"
+		now := time.Now().UTC()
+		e.ResolvedAt = &now
+		e.ResolvedBy = "operator"
+	})
+	if _, err := adapter.Move(ctx, resolved); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	count, err := adapter.Purge(ctx, PurgeOptions{Kind: PurgeAllResolved})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 purged, got %d", count)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{IncludeResolved: true})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 remaining, got %d", result.Total)
+	}
+	if result.Entries[0].ID != "dlq-unres" {
+		t.Errorf("expected unresolved entry to survive, got %q", result.Entries[0].ID)
+	}
+}
+
+func TestSqliteDeadLetter_Count(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	// Empty state.
+	count, err := adapter.Count(ctx, "")
+	if err != nil {
+		t.Fatalf("count empty: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+
+	// Add entries for two brains.
+	for i := 0; i < 3; i++ {
+		entry := makeTestEntry(func(e *DeadLetterEntry) {
+			e.ID = fmt.Sprintf("dlq-count-a-%d", i)
+			e.BrainID = "brain-a"
+		})
+		if _, err := adapter.Move(ctx, entry); err != nil {
+			t.Fatalf("move: %v", err)
+		}
+	}
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ID = "dlq-count-b"
+		e.BrainID = "brain-b"
+	})
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	// Resolve one entry.
+	if _, err := adapter.Retry(ctx, "dlq-count-a-0", "operator"); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+
+	// Global count (unresolved only).
+	count, err = adapter.Count(ctx, "")
+	if err != nil {
+		t.Fatalf("count global: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 unresolved globally, got %d", count)
+	}
+
+	// Per-brain count.
+	countA, err := adapter.Count(ctx, "brain-a")
+	if err != nil {
+		t.Fatalf("count brain-a: %v", err)
+	}
+	if countA != 2 {
+		t.Errorf("expected 2 unresolved for brain-a, got %d", countA)
+	}
+
+	countB, err := adapter.Count(ctx, "brain-b")
+	if err != nil {
+		t.Fatalf("count brain-b: %v", err)
+	}
+	if countB != 1 {
+		t.Errorf("expected 1 unresolved for brain-b, got %d", countB)
+	}
+}
+
+func TestSqliteDeadLetter_MetadataRoundTrip(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.Metadata = map[string]string{
+			"source":    "webhook",
+			"requestId": "req-12345",
+		}
+		e.GroupID = "batch-001"
+	})
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Metadata) != 2 {
+		t.Fatalf("expected 2 metadata entries, got %d", len(got.Metadata))
+	}
+	if got.Metadata["source"] != "webhook" {
+		t.Errorf("expected metadata source 'webhook', got %q", got.Metadata["source"])
+	}
+	if got.Metadata["requestId"] != "req-12345" {
+		t.Errorf("expected metadata requestId 'req-12345', got %q", got.Metadata["requestId"])
+	}
+	if got.GroupID != "batch-001" {
+		t.Errorf("expected groupId 'batch-001', got %q", got.GroupID)
+	}
+}
+
+func TestSqliteDeadLetter_PayloadRoundTrip(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.Payload = JobPayload{
+			DocumentHash: "abc123def4560000000000000000000000000000000000000000000000000000",
+			BrainID:      "brain-1",
+			Source:       "https://example.com/doc.pdf",
+			ContentType:  "application/pdf",
+		}
+	})
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Payload.DocumentHash != entry.Payload.DocumentHash {
+		t.Errorf("payload.documentHash: expected %q, got %q", entry.Payload.DocumentHash, got.Payload.DocumentHash)
+	}
+	if got.Payload.Source != entry.Payload.Source {
+		t.Errorf("payload.source: expected %q, got %q", entry.Payload.Source, got.Payload.Source)
+	}
+	if got.Payload.ContentType != entry.Payload.ContentType {
+		t.Errorf("payload.contentType: expected %q, got %q", entry.Payload.ContentType, got.Payload.ContentType)
+	}
+}
+

--- a/go/ingest/deadletter_test.go
+++ b/go/ingest/deadletter_test.go
@@ -4,7 +4,9 @@ package ingest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,7 +15,10 @@ import (
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
+	// Use shared-cache mode so all connections within the pool see the
+	// same in-memory database. Required for concurrent tests.
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
@@ -302,7 +307,7 @@ func TestSqliteDeadLetter_Retry(t *testing.T) {
 		t.Fatalf("move: %v", err)
 	}
 
-	resolved, err := adapter.Retry(ctx, entry.ID, "admin@example.com")
+	resolved, err := adapter.Retry(ctx, entry.ID, "admin@example.com", nil)
 	if err != nil {
 		t.Fatalf("retry: %v", err)
 	}
@@ -323,12 +328,76 @@ func TestSqliteDeadLetter_Retry(t *testing.T) {
 	}
 }
 
+func TestSqliteDeadLetter_RetryCallsReEnqueue(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	var enqueued DeadLetterEntry
+	reEnqueue := func(_ context.Context, e DeadLetterEntry) error {
+		enqueued = e
+		return nil
+	}
+
+	resolved, err := adapter.Retry(ctx, entry.ID, "operator", reEnqueue)
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if resolved.ResolvedAt == nil {
+		t.Fatal("expected resolvedAt to be set")
+	}
+	if enqueued.ID != entry.ID {
+		t.Errorf("expected re-enqueue callback to receive entry %q, got %q", entry.ID, enqueued.ID)
+	}
+	if enqueued.Payload.DocumentHash != entry.Payload.DocumentHash {
+		t.Errorf("expected re-enqueue payload hash %q, got %q", entry.Payload.DocumentHash, enqueued.Payload.DocumentHash)
+	}
+}
+
+func TestSqliteDeadLetter_RetryReEnqueueFailureRollsBack(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	reEnqueueErr := errors.New("queue is full")
+	failingReEnqueue := func(_ context.Context, _ DeadLetterEntry) error {
+		return reEnqueueErr
+	}
+
+	_, err := adapter.Retry(ctx, entry.ID, "operator", failingReEnqueue)
+	if err == nil {
+		t.Fatal("expected error from failing re-enqueue")
+	}
+	if !errors.Is(err, reEnqueueErr) {
+		t.Errorf("expected wrapped queue error, got %v", err)
+	}
+
+	// Entry should still be unresolved because the transaction rolled back.
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get after failed retry: %v", err)
+	}
+	if got.ResolvedAt != nil {
+		t.Error("expected entry to remain unresolved after failed re-enqueue")
+	}
+}
+
 func TestSqliteDeadLetter_RetryNonExistent(t *testing.T) {
 	t.Parallel()
 	adapter := setupAdapter(t)
 	ctx := context.Background()
 
-	_, err := adapter.Retry(ctx, "nonexistent", "operator")
+	_, err := adapter.Retry(ctx, "nonexistent", "operator", nil)
 	if err != ErrDeadLetterNotFound {
 		t.Errorf("expected ErrDeadLetterNotFound, got %v", err)
 	}
@@ -343,13 +412,61 @@ func TestSqliteDeadLetter_DoubleRetryFails(t *testing.T) {
 	if _, err := adapter.Move(ctx, entry); err != nil {
 		t.Fatalf("move: %v", err)
 	}
-	if _, err := adapter.Retry(ctx, entry.ID, "operator-1"); err != nil {
+	if _, err := adapter.Retry(ctx, entry.ID, "operator-1", nil); err != nil {
 		t.Fatalf("first retry: %v", err)
 	}
 
-	_, err := adapter.Retry(ctx, entry.ID, "operator-2")
+	_, err := adapter.Retry(ctx, entry.ID, "operator-2", nil)
 	if err != ErrDeadLetterAlreadyResolved {
 		t.Errorf("expected ErrDeadLetterAlreadyResolved, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_RetryConcurrent(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	const goroutines = 5
+	results := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, retryErr := adapter.Retry(ctx, entry.ID, fmt.Sprintf("operator-%d", idx), nil)
+			results <- retryErr
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	var successes, alreadyResolved, notFound int
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, ErrDeadLetterAlreadyResolved):
+			alreadyResolved++
+		case errors.Is(err, ErrDeadLetterNotFound):
+			notFound++
+		default:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	if successes != 1 {
+		t.Errorf("expected exactly 1 successful retry, got %d", successes)
+	}
+	if alreadyResolved+notFound != goroutines-1 {
+		t.Errorf("expected %d already-resolved/not-found errors, got %d", goroutines-1, alreadyResolved+notFound)
 	}
 }
 
@@ -374,6 +491,20 @@ func TestSqliteDeadLetter_PurgeByID(t *testing.T) {
 	_, err = adapter.Get(ctx, entry.ID)
 	if err != ErrDeadLetterNotFound {
 		t.Errorf("expected not found after purge, got %v", err)
+	}
+}
+
+func TestSqliteDeadLetter_PurgeNonExistent(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	count, err := adapter.Purge(ctx, PurgeOptions{Kind: PurgeByID, ID: "nonexistent"})
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 purged for non-existent, got %d", count)
 	}
 }
 
@@ -532,7 +663,7 @@ func TestSqliteDeadLetter_Count(t *testing.T) {
 	}
 
 	// Resolve one entry.
-	if _, err := adapter.Retry(ctx, "dlq-count-a-0", "operator"); err != nil {
+	if _, err := adapter.Retry(ctx, "dlq-count-a-0", "operator", nil); err != nil {
 		t.Fatalf("retry: %v", err)
 	}
 
@@ -629,3 +760,76 @@ func TestSqliteDeadLetter_PayloadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSqliteDeadLetter_ErrorHistoryRoundTrip(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ErrorHistory = []string{
+			"attempt 1: connection refused",
+			"attempt 2: timeout after 30s",
+			"attempt 3: context deadline exceeded",
+		}
+	})
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.ErrorHistory) != 3 {
+		t.Fatalf("expected 3 error history entries, got %d", len(got.ErrorHistory))
+	}
+	if got.ErrorHistory[0] != "attempt 1: connection refused" {
+		t.Errorf("expected first error %q, got %q", "attempt 1: connection refused", got.ErrorHistory[0])
+	}
+	if got.ErrorHistory[2] != "attempt 3: context deadline exceeded" {
+		t.Errorf("expected third error %q, got %q", "attempt 3: context deadline exceeded", got.ErrorHistory[2])
+	}
+}
+
+func TestSqliteDeadLetter_ErrorHistoryEmptyRoundTrip(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry()
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	got, err := adapter.Get(ctx, entry.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.ErrorHistory) != 0 {
+		t.Errorf("expected empty error history, got %d entries", len(got.ErrorHistory))
+	}
+}
+
+func TestSqliteDeadLetter_ErrorHistoryViaList(t *testing.T) {
+	t.Parallel()
+	adapter := setupAdapter(t)
+	ctx := context.Background()
+
+	entry := makeTestEntry(func(e *DeadLetterEntry) {
+		e.ErrorHistory = []string{"err-1", "err-2"}
+	})
+	if _, err := adapter.Move(ctx, entry); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+
+	result, err := adapter.List(ctx, DeadLetterListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result.Entries))
+	}
+	if len(result.Entries[0].ErrorHistory) != 2 {
+		t.Errorf("expected 2 error history entries in list, got %d", len(result.Entries[0].ErrorHistory))
+	}
+}

--- a/sdks/ts/memory-postgres/migrations/0007_dead_letter.sql
+++ b/sdks/ts/memory-postgres/migrations/0007_dead_letter.sql
@@ -1,0 +1,29 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Migration 0007: Dead letter queue for permanent failure isolation (P3-3).
+-- Jobs that exhaust their retry budget are moved here with full error
+-- context so operators can inspect, retry, or purge them.
+
+CREATE TABLE IF NOT EXISTS memory.ingest_dead_letter (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  original_job_id UUID NOT NULL,
+  brain_id        TEXT NOT NULL,
+  payload         JSONB NOT NULL,
+  failure_reason  TEXT NOT NULL,
+  last_error      TEXT,
+  retry_count     INTEGER NOT NULL DEFAULT 0,
+  metadata        JSONB,
+  group_id        TEXT,
+  moved_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at     TIMESTAMPTZ,
+  resolved_by     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_dlq_brain
+  ON memory.ingest_dead_letter (brain_id);
+
+CREATE INDEX IF NOT EXISTS idx_dlq_moved
+  ON memory.ingest_dead_letter (moved_at);
+
+CREATE INDEX IF NOT EXISTS idx_dlq_unresolved
+  ON memory.ingest_dead_letter (resolved_at)
+  WHERE resolved_at IS NULL;

--- a/sdks/ts/memory-postgres/migrations/0007_dead_letter.sql
+++ b/sdks/ts/memory-postgres/migrations/0007_dead_letter.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS memory.ingest_dead_letter (
   payload         JSONB NOT NULL,
   failure_reason  TEXT NOT NULL,
   last_error      TEXT,
+  error_history   JSONB,
   retry_count     INTEGER NOT NULL DEFAULT 0,
   metadata        JSONB,
   group_id        TEXT,

--- a/sdks/ts/memory/src/ingest/dead-letter.test.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.test.ts
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the dead letter queue adapter. Covers the in-memory adapter
+ * which validates the full interface contract. PostgreSQL and SQLite
+ * adapters are tested separately with real database connections.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  createInMemoryDeadLetterAdapter,
+  DeadLetterNotFoundError,
+  DeadLetterAlreadyResolvedError,
+  type DeadLetterAdapter,
+  type DeadLetterEntry,
+} from './dead-letter.js'
+
+const makeEntry = (overrides: Partial<DeadLetterEntry> = {}): DeadLetterEntry => ({
+  id: 'dlq-001',
+  originalJobId: 'job-001',
+  brainId: 'brain-1',
+  payload: {
+    documentHash: 'abc123def4560000000000000000000000000000000000000000000000000000',
+    brainId: 'brain-1',
+    source: 'file:///test.md',
+    contentType: 'text/markdown',
+  },
+  failureReason: 'embedding provider returned 500',
+  lastError: 'context deadline exceeded',
+  retryCount: 3,
+  movedAt: new Date('2026-05-01T12:00:00Z'),
+  ...overrides,
+})
+
+describe('InMemoryDeadLetterAdapter', () => {
+  let adapter: DeadLetterAdapter
+
+  beforeEach(() => {
+    adapter = createInMemoryDeadLetterAdapter()
+  })
+
+  describe('move', () => {
+    it('stores an entry and returns it', async () => {
+      const entry = makeEntry()
+      const result = await adapter.move(entry)
+
+      expect(result.id).toBe(entry.id)
+      expect(result.brainId).toBe(entry.brainId)
+      expect(result.failureReason).toBe(entry.failureReason)
+      expect(result.lastError).toBe(entry.lastError)
+      expect(result.retryCount).toBe(entry.retryCount)
+    })
+
+    it('generates an ID when empty', async () => {
+      const entry = makeEntry({ id: '' })
+      const result = await adapter.move(entry)
+      expect(result.id).toBeTruthy()
+      expect(result.id).not.toBe('')
+    })
+
+    it('preserves full payload', async () => {
+      const entry = makeEntry()
+      const result = await adapter.move(entry)
+
+      expect(result.payload.documentHash).toBe(entry.payload.documentHash)
+      expect(result.payload.brainId).toBe(entry.payload.brainId)
+      expect(result.payload.source).toBe(entry.payload.source)
+      expect(result.payload.contentType).toBe(entry.payload.contentType)
+    })
+  })
+
+  describe('get', () => {
+    it('returns the entry by ID', async () => {
+      const entry = makeEntry()
+      await adapter.move(entry)
+
+      const got = await adapter.get(entry.id)
+      expect(got).toBeDefined()
+      expect(got?.id).toBe(entry.id)
+      expect(got?.originalJobId).toBe(entry.originalJobId)
+      expect(got?.failureReason).toBe(entry.failureReason)
+    })
+
+    it('returns undefined for non-existent ID', async () => {
+      const got = await adapter.get('nonexistent')
+      expect(got).toBeUndefined()
+    })
+  })
+
+  describe('list', () => {
+    it('returns unresolved entries by default', async () => {
+      await adapter.move(makeEntry({ id: 'dlq-unresolved' }))
+      await adapter.move(makeEntry({
+        id: 'dlq-resolved',
+        resolvedAt: new Date(),
+        resolvedBy: 'operator',
+      }))
+
+      const result = await adapter.list()
+      expect(result.total).toBe(1)
+      expect(result.entries).toHaveLength(1)
+      expect(result.entries[0].id).toBe('dlq-unresolved')
+    })
+
+    it('includes resolved entries when requested', async () => {
+      await adapter.move(makeEntry({ id: 'dlq-a' }))
+      await adapter.move(makeEntry({
+        id: 'dlq-b',
+        resolvedAt: new Date(),
+        resolvedBy: 'operator',
+      }))
+
+      const result = await adapter.list({ includeResolved: true })
+      expect(result.total).toBe(2)
+      expect(result.entries).toHaveLength(2)
+    })
+
+    it('filters by brainId', async () => {
+      await adapter.move(makeEntry({ id: 'dlq-alpha', brainId: 'brain-alpha' }))
+      await adapter.move(makeEntry({ id: 'dlq-beta', brainId: 'brain-beta' }))
+
+      const result = await adapter.list({ brainId: 'brain-alpha' })
+      expect(result.total).toBe(1)
+      expect(result.entries[0].brainId).toBe('brain-alpha')
+    })
+
+    it('paginates results', async () => {
+      for (let i = 0; i < 5; i++) {
+        await adapter.move(makeEntry({
+          id: `dlq-page-${i}`,
+          movedAt: new Date(Date.UTC(2026, 4, 1, 12, 0, i)),
+        }))
+      }
+
+      const page1 = await adapter.list({ limit: 2, offset: 0 })
+      expect(page1.total).toBe(5)
+      expect(page1.entries).toHaveLength(2)
+
+      const page2 = await adapter.list({ limit: 2, offset: 2 })
+      expect(page2.entries).toHaveLength(2)
+
+      const page3 = await adapter.list({ limit: 2, offset: 4 })
+      expect(page3.entries).toHaveLength(1)
+    })
+
+    it('returns entries sorted by movedAt descending', async () => {
+      await adapter.move(makeEntry({
+        id: 'dlq-oldest',
+        movedAt: new Date('2026-01-01T00:00:00Z'),
+      }))
+      await adapter.move(makeEntry({
+        id: 'dlq-newest',
+        movedAt: new Date('2026-06-01T00:00:00Z'),
+      }))
+      await adapter.move(makeEntry({
+        id: 'dlq-middle',
+        movedAt: new Date('2026-03-01T00:00:00Z'),
+      }))
+
+      const result = await adapter.list()
+      expect(result.entries[0].id).toBe('dlq-newest')
+      expect(result.entries[1].id).toBe('dlq-middle')
+      expect(result.entries[2].id).toBe('dlq-oldest')
+    })
+  })
+
+  describe('retry', () => {
+    it('marks an entry as resolved and returns it', async () => {
+      await adapter.move(makeEntry())
+
+      const resolved = await adapter.retry('dlq-001', 'admin@example.com')
+      expect(resolved.resolvedAt).toBeDefined()
+      expect(resolved.resolvedBy).toBe('admin@example.com')
+    })
+
+    it('persists the resolved state', async () => {
+      await adapter.move(makeEntry())
+      await adapter.retry('dlq-001', 'admin@example.com')
+
+      const got = await adapter.get('dlq-001')
+      expect(got?.resolvedAt).toBeDefined()
+      expect(got?.resolvedBy).toBe('admin@example.com')
+    })
+
+    it('throws DeadLetterNotFoundError for non-existent ID', async () => {
+      await expect(adapter.retry('nonexistent', 'operator'))
+        .rejects.toThrow(DeadLetterNotFoundError)
+    })
+
+    it('throws DeadLetterAlreadyResolvedError on double retry', async () => {
+      await adapter.move(makeEntry())
+      await adapter.retry('dlq-001', 'operator-1')
+
+      await expect(adapter.retry('dlq-001', 'operator-2'))
+        .rejects.toThrow(DeadLetterAlreadyResolvedError)
+    })
+  })
+
+  describe('purge', () => {
+    it('removes entry by ID', async () => {
+      await adapter.move(makeEntry())
+
+      const removed = await adapter.purge({ kind: 'by-id', id: 'dlq-001' })
+      expect(removed).toBe(1)
+
+      const got = await adapter.get('dlq-001')
+      expect(got).toBeUndefined()
+    })
+
+    it('returns 0 when purging non-existent ID', async () => {
+      const removed = await adapter.purge({ kind: 'by-id', id: 'nonexistent' })
+      expect(removed).toBe(0)
+    })
+
+    it('removes all entries for a brain', async () => {
+      for (let i = 0; i < 3; i++) {
+        await adapter.move(makeEntry({ id: `dlq-purge-${i}`, brainId: 'brain-to-purge' }))
+      }
+      await adapter.move(makeEntry({ id: 'dlq-keep', brainId: 'brain-keep' }))
+
+      const removed = await adapter.purge({ kind: 'by-brain', brainId: 'brain-to-purge' })
+      expect(removed).toBe(3)
+
+      const result = await adapter.list({ includeResolved: true })
+      expect(result.total).toBe(1)
+      expect(result.entries[0].brainId).toBe('brain-keep')
+    })
+
+    it('removes entries older than threshold', async () => {
+      await adapter.move(makeEntry({
+        id: 'dlq-old',
+        movedAt: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
+      }))
+      await adapter.move(makeEntry({
+        id: 'dlq-recent',
+        movedAt: new Date(),
+      }))
+
+      const removed = await adapter.purge({ kind: 'older-than', days: 30 })
+      expect(removed).toBe(1)
+
+      const result = await adapter.list({ includeResolved: true })
+      expect(result.total).toBe(1)
+      expect(result.entries[0].id).toBe('dlq-recent')
+    })
+
+    it('removes all resolved entries', async () => {
+      await adapter.move(makeEntry({ id: 'dlq-unres' }))
+      await adapter.move(makeEntry({
+        id: 'dlq-res',
+        resolvedAt: new Date(),
+        resolvedBy: 'operator',
+      }))
+
+      const removed = await adapter.purge({ kind: 'all-resolved' })
+      expect(removed).toBe(1)
+
+      const result = await adapter.list({ includeResolved: true })
+      expect(result.total).toBe(1)
+      expect(result.entries[0].id).toBe('dlq-unres')
+    })
+  })
+
+  describe('count', () => {
+    it('returns 0 when empty', async () => {
+      const total = await adapter.count()
+      expect(total).toBe(0)
+    })
+
+    it('counts unresolved entries globally', async () => {
+      for (let i = 0; i < 3; i++) {
+        await adapter.move(makeEntry({ id: `dlq-count-${i}`, brainId: 'brain-a' }))
+      }
+      await adapter.move(makeEntry({ id: 'dlq-count-b', brainId: 'brain-b' }))
+      await adapter.retry('dlq-count-0', 'operator')
+
+      const total = await adapter.count()
+      expect(total).toBe(3)
+    })
+
+    it('counts unresolved entries per brain', async () => {
+      for (let i = 0; i < 3; i++) {
+        await adapter.move(makeEntry({ id: `dlq-ca-${i}`, brainId: 'brain-a' }))
+      }
+      await adapter.move(makeEntry({ id: 'dlq-cb', brainId: 'brain-b' }))
+      await adapter.retry('dlq-ca-0', 'operator')
+
+      expect(await adapter.count('brain-a')).toBe(2)
+      expect(await adapter.count('brain-b')).toBe(1)
+    })
+  })
+
+  describe('metadata round-trip', () => {
+    it('preserves metadata and groupId', async () => {
+      await adapter.move(makeEntry({
+        metadata: { source: 'webhook', requestId: 'req-12345' },
+        groupId: 'batch-001',
+      }))
+
+      const got = await adapter.get('dlq-001')
+      expect(got?.metadata?.source).toBe('webhook')
+      expect(got?.metadata?.requestId).toBe('req-12345')
+      expect(got?.groupId).toBe('batch-001')
+    })
+  })
+})

--- a/sdks/ts/memory/src/ingest/dead-letter.test.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.test.ts
@@ -340,6 +340,79 @@ describe('InMemoryDeadLetterAdapter', () => {
     })
   })
 
+  describe('input validation', () => {
+    it('rejects negative limit', async () => {
+      await expect(adapter.list({ limit: -1 }))
+        .rejects.toThrow(RangeError)
+    })
+
+    it('rejects negative offset', async () => {
+      await expect(adapter.list({ offset: -1 }))
+        .rejects.toThrow(RangeError)
+    })
+
+    it('rejects negative days in purge', async () => {
+      await expect(adapter.purge({ kind: 'older-than', days: -5 }))
+        .rejects.toThrow(RangeError)
+    })
+  })
+
+  describe('deep clone isolation', () => {
+    it('move returns a clone that does not affect the store', async () => {
+      const entry = makeEntry({
+        metadata: { key: 'original' },
+        errorHistory: ['err-1'],
+      })
+      const result = await adapter.move(entry)
+
+      // Mutate the returned value.
+      ;(result as Record<string, unknown>).failureReason = 'tampered'
+      ;(result.metadata as Record<string, string>).key = 'tampered'
+      ;(result.errorHistory as string[]).push('tampered')
+
+      const stored = await adapter.get(entry.id)
+      expect(stored?.failureReason).toBe('embedding provider returned 500')
+      expect(stored?.metadata?.key).toBe('original')
+      expect(stored?.errorHistory).toHaveLength(1)
+    })
+
+    it('get returns a clone that does not affect the store', async () => {
+      await adapter.move(makeEntry({ metadata: { key: 'original' } }))
+
+      const got = await adapter.get('dlq-001')
+      ;(got as Record<string, unknown>).failureReason = 'tampered'
+      ;(got?.metadata as Record<string, string>).key = 'tampered'
+
+      const fresh = await adapter.get('dlq-001')
+      expect(fresh?.failureReason).toBe('embedding provider returned 500')
+      expect(fresh?.metadata?.key).toBe('original')
+    })
+
+    it('list returns clones that do not affect the store', async () => {
+      await adapter.move(makeEntry({ metadata: { key: 'original' } }))
+
+      const result = await adapter.list()
+      ;(result.entries[0] as Record<string, unknown>).failureReason = 'tampered'
+      ;(result.entries[0].metadata as Record<string, string>).key = 'tampered'
+
+      const fresh = await adapter.get('dlq-001')
+      expect(fresh?.failureReason).toBe('embedding provider returned 500')
+      expect(fresh?.metadata?.key).toBe('original')
+    })
+
+    it('retry returns a clone that does not affect the store', async () => {
+      await adapter.move(makeEntry({ metadata: { key: 'original' } }))
+
+      const resolved = await adapter.retry('dlq-001', 'op')
+      ;(resolved as Record<string, unknown>).failureReason = 'tampered'
+      ;(resolved.metadata as Record<string, string>).key = 'tampered'
+
+      const stored = await adapter.get('dlq-001')
+      expect(stored?.failureReason).toBe('embedding provider returned 500')
+      expect(stored?.metadata?.key).toBe('original')
+    })
+  })
+
   describe('error history', () => {
     it('preserves error history array', async () => {
       await adapter.move(makeEntry({

--- a/sdks/ts/memory/src/ingest/dead-letter.test.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.test.ts
@@ -13,6 +13,7 @@ import {
   DeadLetterAlreadyResolvedError,
   type DeadLetterAdapter,
   type DeadLetterEntry,
+  type ReEnqueueFn,
 } from './dead-letter.js'
 
 const makeEntry = (overrides: Partial<DeadLetterEntry> = {}): DeadLetterEntry => ({
@@ -194,6 +195,41 @@ describe('InMemoryDeadLetterAdapter', () => {
       await expect(adapter.retry('dlq-001', 'operator-2'))
         .rejects.toThrow(DeadLetterAlreadyResolvedError)
     })
+
+    it('calls reEnqueue callback with resolved entry', async () => {
+      await adapter.move(makeEntry())
+
+      let enqueuedEntry: DeadLetterEntry | undefined
+      const reEnqueue: ReEnqueueFn = async (entry) => {
+        enqueuedEntry = entry
+      }
+
+      const resolved = await adapter.retry('dlq-001', 'operator', reEnqueue)
+      expect(resolved.resolvedAt).toBeDefined()
+      expect(enqueuedEntry).toBeDefined()
+      expect(enqueuedEntry?.id).toBe('dlq-001')
+      expect(enqueuedEntry?.payload.documentHash).toBe(makeEntry().payload.documentHash)
+    })
+
+    it('does not resolve entry when reEnqueue throws', async () => {
+      await adapter.move(makeEntry())
+
+      const failingReEnqueue: ReEnqueueFn = async () => {
+        throw new Error('queue is full')
+      }
+
+      await expect(adapter.retry('dlq-001', 'operator', failingReEnqueue))
+        .rejects.toThrow('queue is full')
+
+      const got = await adapter.get('dlq-001')
+      expect(got?.resolvedAt).toBeUndefined()
+    })
+
+    it('defaults resolvedBy to system when omitted', async () => {
+      await adapter.move(makeEntry())
+      const resolved = await adapter.retry('dlq-001')
+      expect(resolved.resolvedBy).toBe('system')
+    })
   })
 
   describe('purge', () => {
@@ -301,6 +337,30 @@ describe('InMemoryDeadLetterAdapter', () => {
       expect(got?.metadata?.source).toBe('webhook')
       expect(got?.metadata?.requestId).toBe('req-12345')
       expect(got?.groupId).toBe('batch-001')
+    })
+  })
+
+  describe('error history', () => {
+    it('preserves error history array', async () => {
+      await adapter.move(makeEntry({
+        errorHistory: [
+          'attempt 1: connection refused',
+          'attempt 2: timeout after 30s',
+          'attempt 3: context deadline exceeded',
+        ],
+      }))
+
+      const got = await adapter.get('dlq-001')
+      expect(got?.errorHistory).toHaveLength(3)
+      expect(got?.errorHistory?.[0]).toBe('attempt 1: connection refused')
+      expect(got?.errorHistory?.[2]).toBe('attempt 3: context deadline exceeded')
+    })
+
+    it('round-trips entries without error history', async () => {
+      await adapter.move(makeEntry())
+
+      const got = await adapter.get('dlq-001')
+      expect(got?.errorHistory).toBeUndefined()
     })
   })
 })

--- a/sdks/ts/memory/src/ingest/dead-letter.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Dead letter queue for permanent failure isolation. Jobs that exhaust
+ * their retry budget are moved here with full error context so that
+ * operators can inspect, retry, or purge them.
+ *
+ * Provides an in-memory adapter for testing/local use and a type-safe
+ * interface that PostgreSQL and SQLite adapters implement.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Serialised job data preserved when a job is moved to the DLQ. */
+export type JobPayload = {
+  readonly documentHash: string
+  readonly brainId: string
+  readonly source?: string
+  readonly contentType?: string
+}
+
+/** A job that has been moved to the dead letter queue. */
+export type DeadLetterEntry = {
+  readonly id: string
+  readonly originalJobId: string
+  readonly brainId: string
+  readonly payload: JobPayload
+  readonly failureReason: string
+  readonly lastError: string
+  readonly retryCount: number
+  readonly metadata?: Readonly<Record<string, string>>
+  readonly groupId?: string
+  readonly movedAt: Date
+  readonly resolvedAt?: Date
+  readonly resolvedBy?: string
+}
+
+/** Options for listing dead letter entries. */
+export type DeadLetterListOptions = {
+  readonly brainId?: string
+  readonly limit?: number
+  readonly offset?: number
+  readonly includeResolved?: boolean
+}
+
+/** Paginated result from a list operation. */
+export type DeadLetterListResult = {
+  readonly entries: readonly DeadLetterEntry[]
+  readonly total: number
+}
+
+/** Discriminated union for purge operations. */
+export type PurgeOptions =
+  | { readonly kind: 'by-id'; readonly id: string }
+  | { readonly kind: 'by-brain'; readonly brainId: string }
+  | { readonly kind: 'older-than'; readonly days: number }
+  | { readonly kind: 'all-resolved' }
+
+/** Interface for dead letter queue operations. */
+export type DeadLetterAdapter = {
+  /** Move a failed job to the dead letter queue. */
+  readonly move: (entry: DeadLetterEntry) => Promise<DeadLetterEntry>
+
+  /** List dead letter entries with pagination and filtering. */
+  readonly list: (opts?: DeadLetterListOptions) => Promise<DeadLetterListResult>
+
+  /** Get a single entry by ID. Returns undefined when not found. */
+  readonly get: (id: string) => Promise<DeadLetterEntry | undefined>
+
+  /** Mark an entry as resolved for retry. Returns the resolved entry. */
+  readonly retry: (id: string, resolvedBy?: string) => Promise<DeadLetterEntry>
+
+  /** Purge entries matching the given options. Returns count removed. */
+  readonly purge: (opts: PurgeOptions) => Promise<number>
+
+  /** Count unresolved entries, optionally filtered by brain ID. */
+  readonly count: (brainId?: string) => Promise<number>
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/** Dead letter entry not found. */
+export class DeadLetterNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Dead letter entry not found: ${id}`)
+    this.name = 'DeadLetterNotFoundError'
+  }
+}
+
+/** Dead letter entry already resolved (double retry). */
+export class DeadLetterAlreadyResolvedError extends Error {
+  constructor(id: string) {
+    super(`Dead letter entry already resolved: ${id}`)
+    this.name = 'DeadLetterAlreadyResolvedError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default configuration
+// ---------------------------------------------------------------------------
+
+/** Default maximum failed attempts before a job is moved to the DLQ. */
+export const DEFAULT_MAX_ATTEMPTS = 3
+
+/** Default retention period in days for dead letter entries. */
+export const DEFAULT_RETENTION_DAYS = 30
+
+/** Default page size for list operations. */
+const DEFAULT_LIST_LIMIT = 50
+
+// ---------------------------------------------------------------------------
+// In-memory adapter (testing / local use)
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an in-memory dead letter adapter. Useful for testing and
+ * local/embedded deployments that do not need persistent storage.
+ */
+export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
+  const store = new Map<string, DeadLetterEntry>()
+
+  const move = async (entry: DeadLetterEntry): Promise<DeadLetterEntry> => {
+    const resolved: DeadLetterEntry = {
+      ...entry,
+      id: entry.id || randomUUID(),
+      movedAt: entry.movedAt ?? new Date(),
+    }
+    store.set(resolved.id, resolved)
+    return resolved
+  }
+
+  const list = async (opts?: DeadLetterListOptions): Promise<DeadLetterListResult> => {
+    const limit = opts?.limit ?? DEFAULT_LIST_LIMIT
+    const offset = opts?.offset ?? 0
+    const includeResolved = opts?.includeResolved ?? false
+    const brainId = opts?.brainId
+
+    const filtered = Array.from(store.values()).filter((entry) => {
+      if (!includeResolved && entry.resolvedAt !== undefined) return false
+      if (brainId !== undefined && entry.brainId !== brainId) return false
+      return true
+    })
+
+    // Sort by movedAt descending (most recent first).
+    filtered.sort((a, b) => b.movedAt.getTime() - a.movedAt.getTime())
+
+    const total = filtered.length
+    const entries = filtered.slice(offset, offset + limit)
+    return { entries, total }
+  }
+
+  const get = async (id: string): Promise<DeadLetterEntry | undefined> => {
+    return store.get(id)
+  }
+
+  const retry = async (id: string, resolvedBy?: string): Promise<DeadLetterEntry> => {
+    const entry = store.get(id)
+    if (entry === undefined) {
+      throw new DeadLetterNotFoundError(id)
+    }
+    if (entry.resolvedAt !== undefined) {
+      throw new DeadLetterAlreadyResolvedError(id)
+    }
+
+    const resolved: DeadLetterEntry = {
+      ...entry,
+      resolvedAt: new Date(),
+      resolvedBy: resolvedBy ?? 'system',
+    }
+    store.set(id, resolved)
+    return resolved
+  }
+
+  const purge = async (opts: PurgeOptions): Promise<number> => {
+    const purgeStrategies: Record<PurgeOptions['kind'], () => number> = {
+      'by-id': () => {
+        const optsById = opts as { readonly kind: 'by-id'; readonly id: string }
+        return store.delete(optsById.id) ? 1 : 0
+      },
+      'by-brain': () => {
+        const optsByBrain = opts as { readonly kind: 'by-brain'; readonly brainId: string }
+        let removed = 0
+        for (const [id, entry] of store) {
+          if (entry.brainId === optsByBrain.brainId) {
+            store.delete(id)
+            removed++
+          }
+        }
+        return removed
+      },
+      'older-than': () => {
+        const optsOlder = opts as { readonly kind: 'older-than'; readonly days: number }
+        const cutoff = new Date()
+        cutoff.setDate(cutoff.getDate() - optsOlder.days)
+        let removed = 0
+        for (const [id, entry] of store) {
+          if (entry.movedAt < cutoff) {
+            store.delete(id)
+            removed++
+          }
+        }
+        return removed
+      },
+      'all-resolved': () => {
+        let removed = 0
+        for (const [id, entry] of store) {
+          if (entry.resolvedAt !== undefined) {
+            store.delete(id)
+            removed++
+          }
+        }
+        return removed
+      },
+    }
+
+    return purgeStrategies[opts.kind]()
+  }
+
+  const count = async (brainId?: string): Promise<number> => {
+    let total = 0
+    for (const entry of store.values()) {
+      if (entry.resolvedAt !== undefined) continue
+      if (brainId !== undefined && entry.brainId !== brainId) continue
+      total++
+    }
+    return total
+  }
+
+  return { move, list, get, retry, purge, count } as const
+}

--- a/sdks/ts/memory/src/ingest/dead-letter.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.ts
@@ -132,6 +132,16 @@ const DEFAULT_LIST_LIMIT = 50
 // In-memory adapter (testing / local use)
 // ---------------------------------------------------------------------------
 
+/** Deep-clone a dead letter entry so the in-memory store never exposes mutable references. */
+const cloneEntry = (entry: DeadLetterEntry): DeadLetterEntry => ({
+  ...entry,
+  payload: { ...entry.payload },
+  movedAt: new Date(entry.movedAt.getTime()),
+  ...(entry.errorHistory !== undefined ? { errorHistory: [...entry.errorHistory] } : {}),
+  ...(entry.metadata !== undefined ? { metadata: { ...entry.metadata } } : {}),
+  ...(entry.resolvedAt !== undefined ? { resolvedAt: new Date(entry.resolvedAt.getTime()) } : {}),
+})
+
 /**
  * Creates an in-memory dead letter adapter. Useful for testing and
  * local/embedded deployments that do not need persistent storage.
@@ -145,13 +155,17 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
       id: entry.id || randomUUID(),
       movedAt: entry.movedAt ?? new Date(),
     }
-    store.set(resolved.id, resolved)
-    return resolved
+    store.set(resolved.id, cloneEntry(resolved))
+    return cloneEntry(resolved)
   }
 
   const list = async (opts?: DeadLetterListOptions): Promise<DeadLetterListResult> => {
     const limit = opts?.limit ?? DEFAULT_LIST_LIMIT
     const offset = opts?.offset ?? 0
+
+    if (limit < 0) throw new RangeError('limit must not be negative')
+    if (offset < 0) throw new RangeError('offset must not be negative')
+
     const includeResolved = opts?.includeResolved ?? false
     const brainId = opts?.brainId
 
@@ -165,12 +179,13 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
     filtered.sort((a, b) => b.movedAt.getTime() - a.movedAt.getTime())
 
     const total = filtered.length
-    const entries = filtered.slice(offset, offset + limit)
+    const entries = filtered.slice(offset, offset + limit).map(cloneEntry)
     return { entries, total }
   }
 
   const get = async (id: string): Promise<DeadLetterEntry | undefined> => {
-    return store.get(id)
+    const entry = store.get(id)
+    return entry !== undefined ? cloneEntry(entry) : undefined
   }
 
   const retry = async (id: string, resolvedBy?: string, reEnqueue?: ReEnqueueFn): Promise<DeadLetterEntry> => {
@@ -189,11 +204,11 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
     }
 
     if (reEnqueue !== undefined) {
-      await reEnqueue(resolved)
+      await reEnqueue(cloneEntry(resolved))
     }
 
-    store.set(id, resolved)
-    return resolved
+    store.set(id, cloneEntry(resolved))
+    return cloneEntry(resolved)
   }
 
   const purge = async (opts: PurgeOptions): Promise<number> => {
@@ -215,6 +230,7 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
       },
       'older-than': () => {
         const optsOlder = opts as { readonly kind: 'older-than'; readonly days: number }
+        if (optsOlder.days < 0) throw new RangeError('days must not be negative')
         const cutoff = new Date()
         cutoff.setDate(cutoff.getDate() - optsOlder.days)
         let removed = 0

--- a/sdks/ts/memory/src/ingest/dead-letter.ts
+++ b/sdks/ts/memory/src/ingest/dead-letter.ts
@@ -31,6 +31,7 @@ export type DeadLetterEntry = {
   readonly payload: JobPayload
   readonly failureReason: string
   readonly lastError: string
+  readonly errorHistory?: readonly string[]
   readonly retryCount: number
   readonly metadata?: Readonly<Record<string, string>>
   readonly groupId?: string
@@ -60,6 +61,14 @@ export type PurgeOptions =
   | { readonly kind: 'older-than'; readonly days: number }
   | { readonly kind: 'all-resolved' }
 
+/**
+ * Callback that creates a new queue job in the main queue from a dead
+ * letter entry. The implementation is responsible for resetting the
+ * retry count and assigning a new job ID. Returning a rejected promise
+ * prevents the DLQ entry from being marked as resolved.
+ */
+export type ReEnqueueFn = (entry: DeadLetterEntry) => Promise<void>
+
 /** Interface for dead letter queue operations. */
 export type DeadLetterAdapter = {
   /** Move a failed job to the dead letter queue. */
@@ -71,8 +80,13 @@ export type DeadLetterAdapter = {
   /** Get a single entry by ID. Returns undefined when not found. */
   readonly get: (id: string) => Promise<DeadLetterEntry | undefined>
 
-  /** Mark an entry as resolved for retry. Returns the resolved entry. */
-  readonly retry: (id: string, resolvedBy?: string) => Promise<DeadLetterEntry>
+  /**
+   * Mark an entry as resolved for retry. If reEnqueue is provided, it
+   * is called with the entry to create a new queue job before the
+   * entry is committed as resolved. If reEnqueue throws, the entry
+   * remains unresolved.
+   */
+  readonly retry: (id: string, resolvedBy?: string, reEnqueue?: ReEnqueueFn) => Promise<DeadLetterEntry>
 
   /** Purge entries matching the given options. Returns count removed. */
   readonly purge: (opts: PurgeOptions) => Promise<number>
@@ -159,7 +173,7 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
     return store.get(id)
   }
 
-  const retry = async (id: string, resolvedBy?: string): Promise<DeadLetterEntry> => {
+  const retry = async (id: string, resolvedBy?: string, reEnqueue?: ReEnqueueFn): Promise<DeadLetterEntry> => {
     const entry = store.get(id)
     if (entry === undefined) {
       throw new DeadLetterNotFoundError(id)
@@ -173,6 +187,11 @@ export const createInMemoryDeadLetterAdapter = (): DeadLetterAdapter => {
       resolvedAt: new Date(),
       resolvedBy: resolvedBy ?? 'system',
     }
+
+    if (reEnqueue !== undefined) {
+      await reEnqueue(resolved)
+    }
+
     store.set(id, resolved)
     return resolved
   }

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -142,3 +142,17 @@ export {
 } from './migrate-hash.js'
 
 export * from './queue/index.js'
+
+export {
+  createInMemoryDeadLetterAdapter,
+  DeadLetterNotFoundError,
+  DeadLetterAlreadyResolvedError,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_RETENTION_DAYS,
+  type DeadLetterAdapter,
+  type DeadLetterEntry,
+  type DeadLetterListOptions,
+  type DeadLetterListResult,
+  type JobPayload as DeadLetterJobPayload,
+  type PurgeOptions as DeadLetterPurgeOptions,
+} from './dead-letter.js'

--- a/sdks/ts/memory/src/ingest/index.ts
+++ b/sdks/ts/memory/src/ingest/index.ts
@@ -155,4 +155,5 @@ export {
   type DeadLetterListResult,
   type JobPayload as DeadLetterJobPayload,
   type PurgeOptions as DeadLetterPurgeOptions,
+  type ReEnqueueFn as DeadLetterReEnqueueFn,
 } from './dead-letter.js'


### PR DESCRIPTION
## What

Dead letter queue for isolating permanently failed ingestion jobs with full error history and safe retry.

## Why

Failed documents were retrying indefinitely or blocking the queue. Need isolation with visibility into failure history and a safe path back to the main queue.

## How

- `DeadLetterAdapter` interface with 6 operations: move, list, get, retry, purge, count
- SQLite adapter for local-first, PostgreSQL adapter for hosted deployments
- Full error history: JSON array of all attempt errors with timestamps
- Retry creates new queue job via `ReEnqueueFunc` callback within transaction — rollback on failure
- Concurrent retry safety: atomic `UPDATE ... WHERE resolved_at IS NULL RETURNING *`
- Purge with discriminated union: by-id, by-brain, older-than, all-resolved
- Configurable: `DEFAULT_MAX_ATTEMPTS=3`, `DEFAULT_RETENTION_DAYS=30`

## Changes

| Language | Files | Tests |
|----------|-------|-------|
| Go | `go/ingest/` — deadletter.go, deadletter_sqlite.go, deadletter_pg.go | 28 tests with race detector |
| TypeScript | `sdks/ts/memory/src/ingest/` — dead-letter.ts | 28 tests |
| SQL | `migrations/0007_dead_letter.sql` | error_history JSONB column |

## Ticket

LLE-9805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue system for managing failed ingest jobs
  * Enabled retry of failed entries with optional callback support
  * Introduced purge functionality with multiple strategies (by ID, brain, age, or all resolved)
  * Added listing and filtering with pagination, ordering, and total count tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jeffs-brain/memory/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->