### PR TITLE
feat(connector): webhook receiver with HMAC-SHA256 + replay protection (P5-5)

### DIFF
--- a/go/connector/webhook.go
+++ b/go/connector/webhook.go
@@ -130,15 +130,20 @@ type idempotencyEntry struct {
 	expiresAt time.Time
 }
 
+const defaultMaxIdempotencyEntries = 100_000
+
 // idempotencyStore is a simple in-memory store for idempotency keys.
+// It enforces a maximum entry count to prevent unbounded memory growth.
 type idempotencyStore struct {
-	mu      sync.RWMutex
-	entries map[string]idempotencyEntry
+	mu         sync.RWMutex
+	entries    map[string]idempotencyEntry
+	maxEntries int
 }
 
 func newIdempotencyStore() *idempotencyStore {
 	return &idempotencyStore{
-		entries: make(map[string]idempotencyEntry),
+		entries:    make(map[string]idempotencyEntry),
+		maxEntries: defaultMaxIdempotencyEntries,
 	}
 }
 
@@ -158,9 +163,31 @@ func (s *idempotencyStore) get(key string) (WebhookResponse, bool) {
 func (s *idempotencyStore) set(key string, resp WebhookResponse, ttl time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// If the store is at capacity, evict the oldest entry before inserting.
+	if len(s.entries) >= s.maxEntries {
+		s.evictOldest()
+	}
 	s.entries[key] = idempotencyEntry{
 		response:  resp,
 		expiresAt: time.Now().Add(ttl),
+	}
+}
+
+// evictOldest removes the entry with the earliest expiry time. Must be called
+// with mu held.
+func (s *idempotencyStore) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+	first := true
+	for key, entry := range s.entries {
+		if first || entry.expiresAt.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = entry.expiresAt
+			first = false
+		}
+	}
+	if !first {
+		delete(s.entries, oldestKey)
 	}
 }
 
@@ -562,7 +589,14 @@ func readLimitedBody(r *http.Request, limit int64) ([]byte, error) {
 	return data, nil
 }
 
-func (w *WebhookReceiver) writeJSON(rw http.ResponseWriter, status int, v any) {
+// errorResponse is the typed body for RFC 7807-adjacent problem responses.
+type errorResponse struct {
+	Status int    `json:"status"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+func (w *WebhookReceiver) writeJSON(rw http.ResponseWriter, status int, v WebhookResponse) {
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(status)
 	if err := json.NewEncoder(rw).Encode(v); err != nil {
@@ -573,9 +607,9 @@ func (w *WebhookReceiver) writeJSON(rw http.ResponseWriter, status int, v any) {
 func (w *WebhookReceiver) writeError(rw http.ResponseWriter, status int, detail string) {
 	rw.Header().Set("Content-Type", "application/problem+json")
 	rw.WriteHeader(status)
-	_ = json.NewEncoder(rw).Encode(map[string]any{
-		"status": status,
-		"title":  http.StatusText(status),
-		"detail": detail,
+	_ = json.NewEncoder(rw).Encode(errorResponse{
+		Status: status,
+		Title:  http.StatusText(status),
+		Detail: detail,
 	})
 }

--- a/go/connector/webhook.go
+++ b/go/connector/webhook.go
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ---- Configuration types ----
+
+// WebhookAuthMethod enumerates the supported authentication strategies.
+type WebhookAuthMethod string
+
+const (
+	// AuthBearer uses a shared bearer token in the Authorization header.
+	AuthBearer WebhookAuthMethod = "bearer"
+	// AuthHMAC uses HMAC-SHA256 signature verification via X-Webhook-Signature.
+	AuthHMAC WebhookAuthMethod = "hmac"
+)
+
+// WebhookAuthConfig holds the authentication configuration for a webhook endpoint.
+type WebhookAuthConfig struct {
+	Method WebhookAuthMethod `json:"method"`
+	Secret string            `json:"secret"`
+}
+
+// WebhookReceiverConfig configures a [WebhookReceiver] instance.
+type WebhookReceiverConfig struct {
+	BrainID           string            `json:"brainId"`
+	Auth              WebhookAuthConfig `json:"auth"`
+	MaxDocuments      int               `json:"maxDocuments,omitempty"`
+	MaxPayloadBytes   int64             `json:"maxPayloadBytes,omitempty"`
+	MaxDocumentBytes  int64             `json:"maxDocumentBytes,omitempty"`
+	EnableIdempotency bool              `json:"enableIdempotency,omitempty"`
+	TimestampExpiry   time.Duration     `json:"timestampExpiry,omitempty"`
+	Dispatcher        DocumentDispatcher
+	Logger            *slog.Logger
+}
+
+// ---- Payload types ----
+
+// WebhookPayload is the JSON body of a webhook request.
+type WebhookPayload struct {
+	Documents []WebhookDocument `json:"documents"`
+}
+
+// WebhookDocument represents a single document within the webhook payload.
+type WebhookDocument struct {
+	ExternalID string            `json:"externalId"`
+	Content    string            `json:"content"`
+	Encoding   string            `json:"encoding,omitempty"`
+	MIME       string            `json:"mime,omitempty"`
+	Title      string            `json:"title,omitempty"`
+	URL        string            `json:"url,omitempty"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+}
+
+// WebhookResponse is the JSON response returned by the webhook handler.
+type WebhookResponse struct {
+	Accepted int                     `json:"accepted"`
+	Rejected int                     `json:"rejected"`
+	Results  []WebhookDocumentResult `json:"results"`
+}
+
+// WebhookDocumentResult reports the outcome for a single document.
+type WebhookDocumentResult struct {
+	ExternalID string `json:"externalId"`
+	Status     string `json:"status"`
+	DocumentID string `json:"documentId,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+// ---- Rate limiter ----
+
+// tokenBucket implements a simple token bucket rate limiter.
+type tokenBucket struct {
+	mu         sync.Mutex
+	tokens     float64
+	maxTokens  float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
+}
+
+func newTokenBucket(maxTokens int, refillRate float64) *tokenBucket {
+	return &tokenBucket{
+		tokens:     float64(maxTokens),
+		maxTokens:  float64(maxTokens),
+		refillRate: refillRate,
+		lastRefill: time.Now(),
+	}
+}
+
+func (tb *tokenBucket) tryAcquire() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.refill()
+	if tb.tokens < 1 {
+		return false
+	}
+	tb.tokens--
+	return true
+}
+
+func (tb *tokenBucket) refill() {
+	now := time.Now()
+	elapsed := now.Sub(tb.lastRefill).Seconds()
+	tb.tokens = math.Min(tb.maxTokens, tb.tokens+elapsed*tb.refillRate)
+	tb.lastRefill = now
+}
+
+// ---- Idempotency store ----
+
+// idempotencyEntry stores a cached response for replay protection.
+type idempotencyEntry struct {
+	response  WebhookResponse
+	expiresAt time.Time
+}
+
+// idempotencyStore is a simple in-memory store for idempotency keys.
+type idempotencyStore struct {
+	mu      sync.RWMutex
+	entries map[string]idempotencyEntry
+}
+
+func newIdempotencyStore() *idempotencyStore {
+	return &idempotencyStore{
+		entries: make(map[string]idempotencyEntry),
+	}
+}
+
+func (s *idempotencyStore) get(key string) (WebhookResponse, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return WebhookResponse{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		return WebhookResponse{}, false
+	}
+	return entry.response, true
+}
+
+func (s *idempotencyStore) set(key string, resp WebhookResponse, ttl time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = idempotencyEntry{
+		response:  resp,
+		expiresAt: time.Now().Add(ttl),
+	}
+}
+
+// sweep removes expired entries. Called periodically to prevent unbounded growth.
+func (s *idempotencyStore) sweep() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for key, entry := range s.entries {
+		if now.After(entry.expiresAt) {
+			delete(s.entries, key)
+		}
+	}
+}
+
+// ---- WebhookReceiver ----
+
+const (
+	defaultMaxDocuments    = 50
+	defaultMaxPayloadBytes = 8 * 1024 * 1024  // 8 MiB
+	defaultMaxDocBytes     = 10 * 1024 * 1024  // 10 MiB
+	defaultTimestampExpiry = 5 * time.Minute
+	defaultRateLimitTokens = 60
+	defaultRateLimitRate   = 10.0 // tokens per second
+	idempotencyTTL         = 24 * time.Hour
+	sweepInterval          = 1 * time.Hour
+)
+
+// WebhookReceiver is an HTTP handler that accepts POST requests containing
+// document payloads, validates authentication and schema, and dispatches
+// accepted documents to the ingestion pipeline.
+type WebhookReceiver struct {
+	brainID           string
+	auth              WebhookAuthConfig
+	maxDocuments      int
+	maxPayloadBytes   int64
+	maxDocumentBytes  int64
+	enableIdempotency bool
+	timestampExpiry   time.Duration
+	dispatcher        DocumentDispatcher
+	log               *slog.Logger
+	limiter           *tokenBucket
+	idempotency       *idempotencyStore
+	sweepDone         chan struct{}
+}
+
+// NewWebhookReceiver creates a new [WebhookReceiver] from the given configuration.
+func NewWebhookReceiver(cfg WebhookReceiverConfig) *WebhookReceiver {
+	maxDocs := cfg.MaxDocuments
+	if maxDocs <= 0 {
+		maxDocs = defaultMaxDocuments
+	}
+	maxPayload := cfg.MaxPayloadBytes
+	if maxPayload <= 0 {
+		maxPayload = defaultMaxPayloadBytes
+	}
+	maxDoc := cfg.MaxDocumentBytes
+	if maxDoc <= 0 {
+		maxDoc = defaultMaxDocBytes
+	}
+	expiry := cfg.TimestampExpiry
+	if expiry <= 0 {
+		expiry = defaultTimestampExpiry
+	}
+	log := cfg.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+
+	w := &WebhookReceiver{
+		brainID:           cfg.BrainID,
+		auth:              cfg.Auth,
+		maxDocuments:      maxDocs,
+		maxPayloadBytes:   maxPayload,
+		maxDocumentBytes:  maxDoc,
+		enableIdempotency: cfg.EnableIdempotency,
+		timestampExpiry:   expiry,
+		dispatcher:        cfg.Dispatcher,
+		log:               log,
+		limiter:           newTokenBucket(defaultRateLimitTokens, defaultRateLimitRate),
+		idempotency:       newIdempotencyStore(),
+		sweepDone:         make(chan struct{}),
+	}
+
+	go w.sweepLoop()
+	return w
+}
+
+// Close stops the background sweep goroutine.
+func (w *WebhookReceiver) Close() {
+	close(w.sweepDone)
+}
+
+func (w *WebhookReceiver) sweepLoop() {
+	ticker := time.NewTicker(sweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			w.idempotency.sweep()
+		case <-w.sweepDone:
+			return
+		}
+	}
+}
+
+// ServeHTTP implements [http.Handler].
+func (w *WebhookReceiver) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	// Method check
+	if r.Method != http.MethodPost {
+		w.writeError(rw, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Rate limiting
+	if !w.limiter.tryAcquire() {
+		w.writeError(rw, http.StatusTooManyRequests, "rate limit exceeded")
+		return
+	}
+
+	// Content-Type check
+	ct := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(strings.ToLower(ct), "application/json") {
+		w.writeError(rw, http.StatusBadRequest, "content-type must be application/json")
+		return
+	}
+
+	// Read body with size limit
+	body, err := readLimitedBody(r, w.maxPayloadBytes)
+	if err != nil {
+		w.writeError(rw, http.StatusRequestEntityTooLarge, "payload too large")
+		return
+	}
+
+	// Authentication
+	if !w.authenticate(r, body) {
+		// Return empty body on auth failure to prevent information leakage.
+		rw.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	// Idempotency check
+	idempotencyKey := r.Header.Get("X-Idempotency-Key")
+	if w.enableIdempotency && idempotencyKey != "" {
+		if cached, ok := w.idempotency.get(idempotencyKey); ok {
+			w.log.Info("webhook idempotency hit", "key", idempotencyKey)
+			w.writeJSON(rw, http.StatusOK, cached)
+			return
+		}
+	}
+
+	// Parse payload
+	var payload WebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		w.writeError(rw, http.StatusBadRequest, "invalid json")
+		return
+	}
+
+	// Validate document count
+	if len(payload.Documents) == 0 {
+		w.writeError(rw, http.StatusBadRequest, "documents array is empty")
+		return
+	}
+	if len(payload.Documents) > w.maxDocuments {
+		w.writeError(rw, http.StatusBadRequest,
+			fmt.Sprintf("exceeds maximum of %d documents", w.maxDocuments))
+		return
+	}
+
+	// Process each document
+	resp := w.processDocuments(payload.Documents)
+
+	// Cache response for idempotency
+	if w.enableIdempotency && idempotencyKey != "" {
+		w.idempotency.set(idempotencyKey, resp, idempotencyTTL)
+	}
+
+	w.writeJSON(rw, http.StatusOK, resp)
+}
+
+// authenticate verifies the request using the configured authentication method.
+func (w *WebhookReceiver) authenticate(r *http.Request, body []byte) bool {
+	authenticators := map[WebhookAuthMethod]func(*http.Request, []byte) bool{
+		AuthBearer: w.authenticateBearer,
+		AuthHMAC:   w.authenticateHMAC,
+	}
+	fn, ok := authenticators[w.auth.Method]
+	if !ok {
+		w.log.Error("unsupported auth method", "method", w.auth.Method)
+		return false
+	}
+	return fn(r, body)
+}
+
+func (w *WebhookReceiver) authenticateBearer(r *http.Request, _ []byte) bool {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return false
+	}
+	const prefix = "Bearer "
+	if len(header) < len(prefix) {
+		return false
+	}
+	if !strings.EqualFold(header[:len(prefix)-1], "bearer") {
+		return false
+	}
+	actual := strings.TrimSpace(header[len(prefix)-1:])
+	if len(actual) == 0 || actual[0] == ' ' {
+		actual = strings.TrimSpace(actual)
+	}
+	if actual == "" {
+		return false
+	}
+	// Timing-safe comparison via SHA-256 hash to prevent length-based leaks.
+	actualHash := sha256.Sum256([]byte(actual))
+	expectedHash := sha256.Sum256([]byte(w.auth.Secret))
+	return subtle.ConstantTimeCompare(actualHash[:], expectedHash[:]) == 1
+}
+
+func (w *WebhookReceiver) authenticateHMAC(r *http.Request, body []byte) bool {
+	sigHeader := r.Header.Get("X-Webhook-Signature")
+	if sigHeader == "" {
+		return false
+	}
+
+	// Verify timestamp expiry for replay protection.
+	tsHeader := r.Header.Get("X-Webhook-Timestamp")
+	if tsHeader == "" {
+		return false
+	}
+	ts, err := strconv.ParseInt(tsHeader, 10, 64)
+	if err != nil {
+		return false
+	}
+	requestTime := time.Unix(ts, 0)
+	if time.Since(requestTime).Abs() > w.timestampExpiry {
+		return false
+	}
+
+	// Parse signature: expect "sha256=<hex>"
+	const sigPrefix = "sha256="
+	if !strings.HasPrefix(sigHeader, sigPrefix) {
+		return false
+	}
+	providedSig, err := hex.DecodeString(sigHeader[len(sigPrefix):])
+	if err != nil {
+		return false
+	}
+
+	// Compute expected HMAC-SHA256 over timestamp + "." + body to bind
+	// the signature to both the timestamp and the payload.
+	mac := hmac.New(sha256.New, []byte(w.auth.Secret))
+	mac.Write([]byte(tsHeader))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	expectedSig := mac.Sum(nil)
+
+	return hmac.Equal(providedSig, expectedSig)
+}
+
+// processDocuments validates and dispatches each document, collecting results.
+func (w *WebhookReceiver) processDocuments(docs []WebhookDocument) WebhookResponse {
+	results := make([]WebhookDocumentResult, 0, len(docs))
+	accepted := 0
+	rejected := 0
+
+	for _, doc := range docs {
+		result := w.processDocument(doc)
+		statusCounts := map[string]*int{
+			"accepted": &accepted,
+			"rejected": &rejected,
+		}
+		if counter, ok := statusCounts[result.Status]; ok {
+			*counter++
+		}
+		results = append(results, result)
+	}
+
+	return WebhookResponse{
+		Accepted: accepted,
+		Rejected: rejected,
+		Results:  results,
+	}
+}
+
+func (w *WebhookReceiver) processDocument(doc WebhookDocument) WebhookDocumentResult {
+	// Validate required fields.
+	if doc.ExternalID == "" {
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      "externalId is required",
+		}
+	}
+	if doc.Content == "" {
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      "content is required",
+		}
+	}
+
+	// Decode content.
+	content, err := w.decodeContent(doc)
+	if err != nil {
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      err.Error(),
+		}
+	}
+
+	// Check individual document size.
+	if int64(len(content)) > w.maxDocumentBytes {
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      fmt.Sprintf("document exceeds maximum size of %d bytes", w.maxDocumentBytes),
+		}
+	}
+
+	// Build connector document.
+	mime := doc.MIME
+	if mime == "" {
+		mime = "text/plain"
+	}
+	connDoc := ConnectorDocument{
+		ExternalID: doc.ExternalID,
+		Content:    content,
+		MIME:       mime,
+		Title:      doc.Title,
+		URL:        doc.URL,
+		Metadata:   doc.Metadata,
+		ModifiedAt: time.Now(),
+	}
+
+	// Dispatch to pipeline.
+	if w.dispatcher == nil {
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      "no dispatcher configured",
+		}
+	}
+
+	docID, err := w.dispatcher.Dispatch(connDoc)
+	if err != nil {
+		w.log.Error("webhook dispatch failed",
+			"externalId", doc.ExternalID,
+			"err", err,
+		)
+		return WebhookDocumentResult{
+			ExternalID: doc.ExternalID,
+			Status:     "rejected",
+			Error:      "dispatch failed",
+		}
+	}
+
+	return WebhookDocumentResult{
+		ExternalID: doc.ExternalID,
+		Status:     "accepted",
+		DocumentID: docID,
+	}
+}
+
+func (w *WebhookReceiver) decodeContent(doc WebhookDocument) ([]byte, error) {
+	decoders := map[string]func(string) ([]byte, error){
+		"":      func(s string) ([]byte, error) { return []byte(s), nil },
+		"utf8":  func(s string) ([]byte, error) { return []byte(s), nil },
+		"base64": func(s string) ([]byte, error) {
+			decoded, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid base64 content: %w", err)
+			}
+			return decoded, nil
+		},
+	}
+	decoder, ok := decoders[doc.Encoding]
+	if !ok {
+		return nil, fmt.Errorf("unsupported encoding: %s", doc.Encoding)
+	}
+	return decoder(doc.Content)
+}
+
+// readLimitedBody reads the full request body up to limit bytes.
+// Returns an error when the body exceeds the limit.
+func readLimitedBody(r *http.Request, limit int64) ([]byte, error) {
+	if r.Body == nil {
+		return nil, fmt.Errorf("empty body")
+	}
+	defer func() { _ = r.Body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(r.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("payload exceeds %d bytes", limit)
+	}
+	return data, nil
+}
+
+func (w *WebhookReceiver) writeJSON(rw http.ResponseWriter, status int, v any) {
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(status)
+	if err := json.NewEncoder(rw).Encode(v); err != nil {
+		w.log.Error("failed to encode webhook response", "err", err)
+	}
+}
+
+func (w *WebhookReceiver) writeError(rw http.ResponseWriter, status int, detail string) {
+	rw.Header().Set("Content-Type", "application/problem+json")
+	rw.WriteHeader(status)
+	_ = json.NewEncoder(rw).Encode(map[string]any{
+		"status": status,
+		"title":  http.StatusText(status),
+		"detail": detail,
+	})
+}

--- a/go/connector/webhook_test.go
+++ b/go/connector/webhook_test.go
@@ -1,0 +1,810 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- Mock dispatcher ----
+
+type mockDispatcher struct {
+	dispatched []ConnectorDocument
+	failIDs    map[string]bool
+	nextDocID  int
+}
+
+func newMockDispatcher() *mockDispatcher {
+	return &mockDispatcher{failIDs: make(map[string]bool)}
+}
+
+func (m *mockDispatcher) Dispatch(doc ConnectorDocument) (string, error) {
+	if m.failIDs[doc.ExternalID] {
+		return "", fmt.Errorf("dispatch error for %s", doc.ExternalID)
+	}
+	m.dispatched = append(m.dispatched, doc)
+	m.nextDocID++
+	return fmt.Sprintf("doc-%d", m.nextDocID), nil
+}
+
+// ---- Helpers ----
+
+func newTestReceiver(auth WebhookAuthConfig, dispatcher DocumentDispatcher) *WebhookReceiver {
+	cfg := WebhookReceiverConfig{
+		BrainID:           "test-brain",
+		Auth:              auth,
+		EnableIdempotency: true,
+		Dispatcher:        dispatcher,
+	}
+	return NewWebhookReceiver(cfg)
+}
+
+func bearerAuth() WebhookAuthConfig {
+	return WebhookAuthConfig{Method: AuthBearer, Secret: "test-secret-token"}
+}
+
+func hmacAuth() WebhookAuthConfig {
+	return WebhookAuthConfig{Method: AuthHMAC, Secret: "hmac-secret-key"}
+}
+
+func makePayload(docs []WebhookDocument) []byte {
+	payload := WebhookPayload{Documents: docs}
+	data, _ := json.Marshal(payload)
+	return data
+}
+
+func singleDoc() []WebhookDocument {
+	return []WebhookDocument{
+		{ExternalID: "ext-1", Content: "hello world"},
+	}
+}
+
+func doRequest(receiver *WebhookReceiver, method string, body []byte, headers map[string]string) *httptest.ResponseRecorder {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, "/webhook/ingest", bodyReader)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if _, ok := headers["Content-Type"]; !ok {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rr := httptest.NewRecorder()
+	receiver.ServeHTTP(rr, req)
+	return rr
+}
+
+func computeHMAC(secret string, timestamp int64, body []byte) string {
+	ts := strconv.FormatInt(timestamp, 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func hmacHeaders(secret string, body []byte) map[string]string {
+	ts := time.Now().Unix()
+	return map[string]string{
+		"Content-Type":        "application/json",
+		"X-Webhook-Signature": computeHMAC(secret, ts, body),
+		"X-Webhook-Timestamp": strconv.FormatInt(ts, 10),
+	}
+}
+
+func decodeResponse(t *testing.T, rr *httptest.ResponseRecorder) WebhookResponse {
+	t.Helper()
+	var resp WebhookResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}
+
+// ---- Tests ----
+
+func TestValidPayloadSingleDocument(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 0 {
+		t.Errorf("expected rejected=0, got %d", resp.Rejected)
+	}
+	if len(d.dispatched) != 1 {
+		t.Errorf("expected 1 dispatched doc, got %d", len(d.dispatched))
+	}
+}
+
+func TestValidPayloadMultipleDocuments(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1", Content: "doc one"},
+		{ExternalID: "ext-2", Content: "doc two"},
+		{ExternalID: "ext-3", Content: "doc three"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 3 {
+		t.Errorf("expected accepted=3, got %d", resp.Accepted)
+	}
+}
+
+func TestPartialFailure(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1", Content: "valid"},
+		{ExternalID: "", Content: "missing id"},
+		{ExternalID: "ext-3", Content: "also valid"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 2 {
+		t.Errorf("expected accepted=2, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestBearerAuthSuccess(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestBearerAuthFailure(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer wrong-token",
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	// Body must be empty to prevent information leakage.
+	if rr.Body.Len() != 0 {
+		t.Errorf("expected empty body on auth failure, got %d bytes", rr.Body.Len())
+	}
+}
+
+func TestMissingAuthHeader(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestHMACAuthSuccess(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(hmacAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	headers := hmacHeaders("hmac-secret-key", body)
+	rr := doRequest(w, http.MethodPost, body, headers)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHMACAuthFailure(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(hmacAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	headers := hmacHeaders("wrong-secret", body)
+	rr := doRequest(w, http.MethodPost, body, headers)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestHMACMissingSignature(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(hmacAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"X-Webhook-Timestamp": strconv.FormatInt(time.Now().Unix(), 10),
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestHMACTimestampExpiry(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(hmacAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	// Timestamp 10 minutes ago — should be rejected.
+	oldTs := time.Now().Add(-10 * time.Minute).Unix()
+	sig := computeHMAC("hmac-secret-key", oldTs, body)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"X-Webhook-Signature": sig,
+		"X-Webhook-Timestamp": strconv.FormatInt(oldTs, 10),
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired timestamp, got %d", rr.Code)
+	}
+}
+
+func TestHMACMissingTimestamp(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(hmacAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"X-Webhook-Signature": "sha256=deadbeef",
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing timestamp, got %d", rr.Code)
+	}
+}
+
+func TestEmptyDocumentsArray(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload([]WebhookDocument{})
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestTooManyDocuments(t *testing.T) {
+	d := newMockDispatcher()
+	cfg := WebhookReceiverConfig{
+		BrainID:      "test-brain",
+		Auth:         bearerAuth(),
+		MaxDocuments: 3,
+		Dispatcher:   d,
+	}
+	w := NewWebhookReceiver(cfg)
+	defer w.Close()
+
+	docs := make([]WebhookDocument, 4)
+	for i := range docs {
+		docs[i] = WebhookDocument{
+			ExternalID: fmt.Sprintf("ext-%d", i),
+			Content:    "content",
+		}
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestPayloadTooLarge(t *testing.T) {
+	d := newMockDispatcher()
+	cfg := WebhookReceiverConfig{
+		BrainID:         "test-brain",
+		Auth:            bearerAuth(),
+		MaxPayloadBytes: 100,
+		Dispatcher:      d,
+	}
+	w := NewWebhookReceiver(cfg)
+	defer w.Close()
+
+	bigContent := strings.Repeat("x", 200)
+	body := makePayload([]WebhookDocument{
+		{ExternalID: "ext-1", Content: bigContent},
+	})
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", rr.Code)
+	}
+}
+
+func TestIndividualDocumentTooLarge(t *testing.T) {
+	d := newMockDispatcher()
+	cfg := WebhookReceiverConfig{
+		BrainID:          "test-brain",
+		Auth:             bearerAuth(),
+		MaxDocumentBytes: 50,
+		Dispatcher:       d,
+	}
+	w := NewWebhookReceiver(cfg)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "small", Content: "ok"},
+		{ExternalID: "big", Content: strings.Repeat("x", 100)},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestBase64Encoding(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	originalContent := "binary content here"
+	encoded := base64.StdEncoding.EncodeToString([]byte(originalContent))
+	docs := []WebhookDocument{
+		{ExternalID: "ext-b64", Content: encoded, Encoding: "base64", MIME: "application/octet-stream"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+	if len(d.dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched, got %d", len(d.dispatched))
+	}
+	if string(d.dispatched[0].Content) != originalContent {
+		t.Errorf("expected decoded content %q, got %q", originalContent, string(d.dispatched[0].Content))
+	}
+}
+
+func TestInvalidBase64(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-bad64", Content: "not-valid-base64!!!", Encoding: "base64"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestWrongContentType(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+		"Content-Type":  "text/plain",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestNonPostMethod(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	rr := doRequest(w, http.MethodGet, nil, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestIdempotencyKeyFirstRequest(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization":    "Bearer test-secret-token",
+		"X-Idempotency-Key": "unique-key-123",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+}
+
+func TestIdempotencyKeyDuplicate(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	headers := map[string]string{
+		"Authorization":    "Bearer test-secret-token",
+		"X-Idempotency-Key": "dup-key-456",
+	}
+
+	// First request
+	rr1 := doRequest(w, http.MethodPost, body, headers)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request: expected 200, got %d", rr1.Code)
+	}
+
+	// Second request with same key — should return cached response.
+	rr2 := doRequest(w, http.MethodPost, body, headers)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second request: expected 200, got %d", rr2.Code)
+	}
+
+	// Dispatcher should only have received the document once.
+	if len(d.dispatched) != 1 {
+		t.Errorf("expected 1 dispatched (idempotent), got %d", len(d.dispatched))
+	}
+}
+
+func TestMalformedJSON(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	rr := doRequest(w, http.MethodPost, []byte("{invalid"), map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestDocumentMissingExternalID(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{Content: "content but no id"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestDocumentMissingContent(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestDispatcherFailure(t *testing.T) {
+	d := newMockDispatcher()
+	d.failIDs["ext-fail"] = true
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-ok", Content: "good"},
+		{ExternalID: "ext-fail", Content: "will fail"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}
+
+func TestDefaultMIME(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1", Content: "plain text"},
+	}
+	body := makePayload(docs)
+	doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if len(d.dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched, got %d", len(d.dispatched))
+	}
+	if d.dispatched[0].MIME != "text/plain" {
+		t.Errorf("expected default MIME text/plain, got %s", d.dispatched[0].MIME)
+	}
+}
+
+func TestCustomMIME(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1", Content: "<html></html>", MIME: "text/html"},
+	}
+	body := makePayload(docs)
+	doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if len(d.dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched, got %d", len(d.dispatched))
+	}
+	if d.dispatched[0].MIME != "text/html" {
+		t.Errorf("expected MIME text/html, got %s", d.dispatched[0].MIME)
+	}
+}
+
+func TestRateLimiting(t *testing.T) {
+	d := newMockDispatcher()
+	cfg := WebhookReceiverConfig{
+		BrainID:    "test-brain",
+		Auth:       bearerAuth(),
+		Dispatcher: d,
+	}
+	w := NewWebhookReceiver(cfg)
+	defer w.Close()
+
+	// Drain all tokens from the bucket.
+	for i := 0; i < defaultRateLimitTokens+10; i++ {
+		w.limiter.tryAcquire()
+	}
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rr.Code)
+	}
+}
+
+func TestMetadataPassthrough(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{
+			ExternalID: "ext-meta",
+			Content:    "content",
+			Title:      "My Document",
+			URL:        "https://example.com/doc",
+			Metadata:   map[string]string{"author": "test", "source": "webhook"},
+		},
+	}
+	body := makePayload(docs)
+	doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+
+	if len(d.dispatched) != 1 {
+		t.Fatalf("expected 1 dispatched, got %d", len(d.dispatched))
+	}
+	doc := d.dispatched[0]
+	if doc.Title != "My Document" {
+		t.Errorf("expected title 'My Document', got %q", doc.Title)
+	}
+	if doc.URL != "https://example.com/doc" {
+		t.Errorf("expected URL, got %q", doc.URL)
+	}
+	if doc.Metadata["author"] != "test" {
+		t.Errorf("expected metadata author=test, got %q", doc.Metadata["author"])
+	}
+}
+
+func TestNoDispatcherConfigured(t *testing.T) {
+	w := newTestReceiver(bearerAuth(), nil)
+	defer w.Close()
+
+	body := makePayload(singleDoc())
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1 (no dispatcher), got %d", resp.Rejected)
+	}
+}
+
+func TestTokenBucketRefill(t *testing.T) {
+	tb := newTokenBucket(1, 100.0) // 1 token, refills 100/sec
+
+	// Drain the bucket.
+	if !tb.tryAcquire() {
+		t.Fatal("first acquire should succeed")
+	}
+	if tb.tryAcquire() {
+		t.Fatal("second acquire should fail (bucket empty)")
+	}
+
+	// Wait for refill.
+	time.Sleep(50 * time.Millisecond)
+
+	if !tb.tryAcquire() {
+		t.Fatal("acquire after refill should succeed")
+	}
+}
+
+func TestIdempotencyStoreExpiry(t *testing.T) {
+	store := newIdempotencyStore()
+	store.set("key-1", WebhookResponse{Accepted: 1}, 10*time.Millisecond)
+
+	// Should be available immediately.
+	resp, ok := store.get("key-1")
+	if !ok {
+		t.Fatal("expected key to exist")
+	}
+	if resp.Accepted != 1 {
+		t.Errorf("expected accepted=1, got %d", resp.Accepted)
+	}
+
+	// Wait for expiry.
+	time.Sleep(20 * time.Millisecond)
+
+	_, ok = store.get("key-1")
+	if ok {
+		t.Fatal("expected key to be expired")
+	}
+}
+
+func TestIdempotencyStoreSweep(t *testing.T) {
+	store := newIdempotencyStore()
+	store.set("expired", WebhookResponse{Accepted: 1}, 1*time.Millisecond)
+	store.set("valid", WebhookResponse{Accepted: 2}, 1*time.Hour)
+
+	time.Sleep(5 * time.Millisecond)
+	store.sweep()
+
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	if _, ok := store.entries["expired"]; ok {
+		t.Error("expected expired key to be swept")
+	}
+	if _, ok := store.entries["valid"]; !ok {
+		t.Error("expected valid key to remain after sweep")
+	}
+}
+
+func TestUnsupportedEncoding(t *testing.T) {
+	d := newMockDispatcher()
+	w := newTestReceiver(bearerAuth(), d)
+	defer w.Close()
+
+	docs := []WebhookDocument{
+		{ExternalID: "ext-1", Content: "data", Encoding: "gzip"},
+	}
+	body := makePayload(docs)
+	rr := doRequest(w, http.MethodPost, body, map[string]string{
+		"Authorization": "Bearer test-secret-token",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	resp := decodeResponse(t, rr)
+	if resp.Rejected != 1 {
+		t.Errorf("expected rejected=1, got %d", resp.Rejected)
+	}
+}

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -96,3 +96,14 @@ export {
   type ParsedDatabaseEntry,
   type ParsedPage,
 } from './notion-properties.js'
+
+export {
+  WebhookReceiver,
+  type WebhookAuthConfig,
+  type WebhookAuthMethod,
+  type WebhookDocument,
+  type WebhookDocumentResult,
+  type WebhookPayload,
+  type WebhookReceiverConfig,
+  type WebhookResponse,
+} from './webhook.js'

--- a/sdks/ts/memory/src/connector/webhook.test.ts
+++ b/sdks/ts/memory/src/connector/webhook.test.ts
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHmac } from 'node:crypto'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ConnectorDocument, DocumentDispatcher } from './types.js'
+import {
+  WebhookReceiver,
+  type WebhookAuthConfig,
+  type WebhookDocument,
+  type WebhookPayload,
+  type WebhookReceiverConfig,
+  type WebhookResponse,
+} from './webhook.js'
+
+// ---- Mock dispatcher ----
+
+type MockDispatcher = DocumentDispatcher & {
+  readonly dispatched: ConnectorDocument[]
+  readonly failIds: Set<string>
+}
+
+const createMockDispatcher = (): MockDispatcher => {
+  const dispatched: ConnectorDocument[] = []
+  const failIds = new Set<string>()
+  let nextId = 0
+  return {
+    dispatched,
+    failIds,
+    async dispatch(doc) {
+      if (failIds.has(doc.externalId)) {
+        throw new Error(`dispatch error for ${doc.externalId}`)
+      }
+      dispatched.push(doc)
+      nextId++
+      return { documentId: `doc-${String(nextId)}` }
+    },
+  }
+}
+
+// ---- Helpers ----
+
+const bearerAuth = (): WebhookAuthConfig => ({
+  method: 'bearer',
+  secret: 'test-secret-token',
+})
+
+const hmacAuth = (): WebhookAuthConfig => ({
+  method: 'hmac',
+  secret: 'hmac-secret-key',
+})
+
+const makePayload = (docs: WebhookDocument[]): string =>
+  JSON.stringify({ documents: docs } satisfies WebhookPayload)
+
+const singleDoc = (): WebhookDocument[] => [
+  { externalId: 'ext-1', content: 'hello world' },
+]
+
+const doRequest = async (
+  receiver: WebhookReceiver,
+  method: string,
+  body: string | null,
+  headers: Record<string, string> = {},
+): Promise<Response> => {
+  const handler = receiver.handler()
+  const init: RequestInit = {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+  }
+  if (body !== null) {
+    init.body = body
+  }
+  const req = new Request('http://localhost/webhook/ingest', init)
+  return handler(req)
+}
+
+const computeHMAC = (
+  secret: string,
+  timestamp: number,
+  body: string,
+): string => {
+  const mac = createHmac('sha256', secret)
+  mac.update(String(timestamp))
+  mac.update('.')
+  mac.update(body)
+  return `sha256=${mac.digest('hex')}`
+}
+
+const hmacHeaders = (
+  secret: string,
+  body: string,
+): Record<string, string> => {
+  const ts = Math.floor(Date.now() / 1000)
+  return {
+    'x-webhook-signature': computeHMAC(secret, ts, body),
+    'x-webhook-timestamp': String(ts),
+  }
+}
+
+const decodeResponse = async (res: Response): Promise<WebhookResponse> =>
+  (await res.json()) as WebhookResponse
+
+const createTestReceiver = (
+  auth: WebhookAuthConfig,
+  dispatcher: DocumentDispatcher,
+  overrides?: Partial<WebhookReceiverConfig>,
+): WebhookReceiver =>
+  new WebhookReceiver({
+    brainId: 'test-brain',
+    auth,
+    enableIdempotency: true,
+    dispatcher,
+    ...overrides,
+  })
+
+// ---- Tests ----
+
+describe('WebhookReceiver', () => {
+  let receiver: WebhookReceiver
+  let dispatcher: MockDispatcher
+
+  beforeEach(() => {
+    dispatcher = createMockDispatcher()
+  })
+
+  afterEach(() => {
+    receiver?.close()
+  })
+
+  describe('valid payloads', () => {
+    it('accepts a single document', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(1)
+      expect(data.rejected).toBe(0)
+      expect(dispatcher.dispatched).toHaveLength(1)
+    })
+
+    it('accepts multiple documents', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const docs: WebhookDocument[] = [
+        { externalId: 'ext-1', content: 'doc one' },
+        { externalId: 'ext-2', content: 'doc two' },
+        { externalId: 'ext-3', content: 'doc three' },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(3)
+    })
+
+    it('reports partial failure with per-document status', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const docs: WebhookDocument[] = [
+        { externalId: 'ext-1', content: 'valid' },
+        { externalId: '', content: 'missing id' },
+        { externalId: 'ext-3', content: 'also valid' },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(2)
+      expect(data.rejected).toBe(1)
+      expect(data.results).toHaveLength(3)
+    })
+  })
+
+  describe('bearer authentication', () => {
+    it('succeeds with correct token', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(200)
+    })
+
+    it('fails with wrong token', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer wrong-token',
+      })
+      expect(res.status).toBe(401)
+      // Body must be empty to prevent information leakage.
+      const text = await res.text()
+      expect(text).toBe('')
+    })
+
+    it('fails with missing auth header', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {})
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('HMAC authentication', () => {
+    it('succeeds with correct signature', async () => {
+      receiver = createTestReceiver(hmacAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const headers = hmacHeaders('hmac-secret-key', body)
+      const res = await doRequest(receiver, 'POST', body, headers)
+      expect(res.status).toBe(200)
+    })
+
+    it('fails with wrong signature', async () => {
+      receiver = createTestReceiver(hmacAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const headers = hmacHeaders('wrong-secret', body)
+      const res = await doRequest(receiver, 'POST', body, headers)
+      expect(res.status).toBe(401)
+    })
+
+    it('fails with missing signature header', async () => {
+      receiver = createTestReceiver(hmacAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        'x-webhook-timestamp': String(Math.floor(Date.now() / 1000)),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('fails with expired timestamp', async () => {
+      receiver = createTestReceiver(hmacAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const oldTs = Math.floor(Date.now() / 1000) - 600 // 10 minutes ago
+      const sig = computeHMAC('hmac-secret-key', oldTs, body)
+      const res = await doRequest(receiver, 'POST', body, {
+        'x-webhook-signature': sig,
+        'x-webhook-timestamp': String(oldTs),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('fails with missing timestamp', async () => {
+      receiver = createTestReceiver(hmacAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        'x-webhook-signature': 'sha256=deadbeef',
+      })
+      expect(res.status).toBe(401)
+    })
+  })
+
+  describe('payload validation', () => {
+    it('rejects empty documents array', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload([])
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects too many documents', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher, {
+        maxDocuments: 3,
+      })
+      const docs: WebhookDocument[] = Array.from({ length: 4 }, (_, i) => ({
+        externalId: `ext-${String(i)}`,
+        content: 'content',
+      }))
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects payload too large', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher, {
+        maxPayloadBytes: 100,
+      })
+      const bigContent = 'x'.repeat(200)
+      const body = makePayload([
+        { externalId: 'ext-1', content: bigContent },
+      ])
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(413)
+    })
+
+    it('rejects individual document too large', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher, {
+        maxDocumentBytes: 50,
+      })
+      const docs: WebhookDocument[] = [
+        { externalId: 'small', content: 'ok' },
+        { externalId: 'big', content: 'x'.repeat(100) },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(1)
+      expect(data.rejected).toBe(1)
+    })
+
+    it('handles base64 encoding', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const originalContent = 'binary content here'
+      const encoded = Buffer.from(originalContent).toString('base64')
+      const docs: WebhookDocument[] = [
+        {
+          externalId: 'ext-b64',
+          content: encoded,
+          encoding: 'base64',
+          mime: 'application/octet-stream',
+        },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(1)
+      expect(dispatcher.dispatched).toHaveLength(1)
+      expect(dispatcher.dispatched[0]!.content.toString()).toBe(originalContent)
+    })
+
+    it('rejects invalid base64', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const docs: WebhookDocument[] = [
+        {
+          externalId: 'ext-bad64',
+          content: 'not-valid-base64!!!',
+          encoding: 'base64',
+        },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.rejected).toBe(1)
+    })
+
+    it('rejects wrong content type', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+        'content-type': 'text/plain',
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects non-POST method', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const res = await doRequest(receiver, 'GET', null, {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(405)
+    })
+
+    it('rejects malformed JSON', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const res = await doRequest(receiver, 'POST', '{invalid', {
+        authorization: 'Bearer test-secret-token',
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('idempotency', () => {
+    it('processes first request normally', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+        'x-idempotency-key': 'unique-key-123',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(1)
+    })
+
+    it('returns cached response for duplicate key', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload(singleDoc())
+      const headers = {
+        authorization: 'Bearer test-secret-token',
+        'x-idempotency-key': 'dup-key-456',
+      }
+
+      // First request
+      const res1 = await doRequest(receiver, 'POST', body, headers)
+      expect(res1.status).toBe(200)
+
+      // Second request with same key — no re-processing.
+      const res2 = await doRequest(receiver, 'POST', body, headers)
+      expect(res2.status).toBe(200)
+
+      // Dispatcher should only have received the document once.
+      expect(dispatcher.dispatched).toHaveLength(1)
+    })
+  })
+
+  describe('document validation', () => {
+    it('rejects document missing externalId', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = JSON.stringify({
+        documents: [{ content: 'content but no id' }],
+      })
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.rejected).toBe(1)
+    })
+
+    it('rejects document missing content', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = JSON.stringify({
+        documents: [{ externalId: 'ext-1' }],
+      })
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.rejected).toBe(1)
+    })
+
+    it('rejects unsupported encoding', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = JSON.stringify({
+        documents: [
+          { externalId: 'ext-1', content: 'data', encoding: 'gzip' },
+        ],
+      })
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.rejected).toBe(1)
+    })
+  })
+
+  describe('dispatch', () => {
+    it('handles dispatcher failure gracefully', async () => {
+      dispatcher.failIds.add('ext-fail')
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const docs: WebhookDocument[] = [
+        { externalId: 'ext-ok', content: 'good' },
+        { externalId: 'ext-fail', content: 'will fail' },
+      ]
+      const body = makePayload(docs)
+      const res = await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(res.status).toBe(200)
+      const data = await decodeResponse(res)
+      expect(data.accepted).toBe(1)
+      expect(data.rejected).toBe(1)
+    })
+
+    it('sets default MIME to text/plain', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload([
+        { externalId: 'ext-1', content: 'plain text' },
+      ])
+      await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(dispatcher.dispatched).toHaveLength(1)
+      expect(dispatcher.dispatched[0]!.mime).toBe('text/plain')
+    })
+
+    it('preserves custom MIME', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload([
+        { externalId: 'ext-1', content: '<html></html>', mime: 'text/html' },
+      ])
+      await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(dispatcher.dispatched).toHaveLength(1)
+      expect(dispatcher.dispatched[0]!.mime).toBe('text/html')
+    })
+
+    it('passes metadata through to connector document', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      const body = makePayload([
+        {
+          externalId: 'ext-meta',
+          content: 'content',
+          title: 'My Document',
+          url: 'https://example.com/doc',
+          metadata: { author: 'test', source: 'webhook' },
+        },
+      ])
+      await doRequest(receiver, 'POST', body, {
+        authorization: 'Bearer test-secret-token',
+      })
+
+      expect(dispatcher.dispatched).toHaveLength(1)
+      const doc = dispatcher.dispatched[0]!
+      expect(doc.title).toBe('My Document')
+      expect(doc.url).toBe('https://example.com/doc')
+      expect(doc.metadata).toEqual({ author: 'test', source: 'webhook' })
+    })
+  })
+
+  describe('rate limiting', () => {
+    it('returns 429 when rate limit exceeded', async () => {
+      receiver = createTestReceiver(bearerAuth(), dispatcher)
+      // Exhaust the token bucket.
+      const handler = receiver.handler()
+      const promises: Promise<Response>[] = []
+      for (let i = 0; i < 65; i++) {
+        const body = makePayload(singleDoc())
+        const req = new Request('http://localhost/webhook/ingest', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer test-secret-token',
+          },
+          body,
+        })
+        promises.push(handler(req))
+      }
+      const responses = await Promise.all(promises)
+      const rateLimited = responses.filter((r) => r.status === 429)
+      expect(rateLimited.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/sdks/ts/memory/src/connector/webhook.ts
+++ b/sdks/ts/memory/src/connector/webhook.ts
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Generic webhook receiver for push-based document ingestion. Accepts
+ * POST requests with a JSON payload of documents, validates authentication
+ * and schema, then dispatches accepted documents to the ingestion pipeline.
+ *
+ * Authentication supports bearer token or HMAC-SHA256 signature verification.
+ * HMAC signatures bind the timestamp and body together to provide replay
+ * protection with a configurable expiry window (default: 5 minutes).
+ */
+
+import { createHmac, timingSafeEqual, createHash } from 'node:crypto'
+
+import type { ConnectorDocument, DocumentDispatcher } from './types.js'
+
+// ---- Configuration types ----
+
+export type WebhookAuthMethod = 'bearer' | 'hmac'
+
+export type WebhookAuthConfig = {
+  readonly method: WebhookAuthMethod
+  readonly secret: string
+}
+
+export type WebhookReceiverConfig = {
+  readonly brainId: string
+  readonly auth: WebhookAuthConfig
+  readonly maxDocuments?: number
+  readonly maxPayloadBytes?: number
+  readonly maxDocumentBytes?: number
+  readonly enableIdempotency?: boolean
+  readonly timestampExpiryMs?: number
+  readonly dispatcher: DocumentDispatcher
+}
+
+// ---- Payload types ----
+
+export type WebhookPayload = {
+  readonly documents: readonly WebhookDocument[]
+}
+
+export type WebhookDocument = {
+  readonly externalId: string
+  readonly content: string
+  readonly encoding?: 'utf8' | 'base64'
+  readonly mime?: string
+  readonly title?: string
+  readonly url?: string
+  readonly metadata?: Readonly<Record<string, unknown>>
+}
+
+export type WebhookResponse = {
+  readonly accepted: number
+  readonly rejected: number
+  readonly results: readonly WebhookDocumentResult[]
+}
+
+export type WebhookDocumentResult = {
+  readonly externalId: string
+  readonly status: 'accepted' | 'rejected'
+  readonly documentId?: string
+  readonly error?: string
+}
+
+// ---- Rate limiter ----
+
+class TokenBucket {
+  private tokens: number
+  private readonly maxTokens: number
+  private readonly refillRate: number
+  private lastRefill: number
+
+  constructor(maxTokens: number, refillRate: number) {
+    this.tokens = maxTokens
+    this.maxTokens = maxTokens
+    this.refillRate = refillRate
+    this.lastRefill = Date.now()
+  }
+
+  tryAcquire(): boolean {
+    this.refill()
+    if (this.tokens < 1) {
+      return false
+    }
+    this.tokens--
+    return true
+  }
+
+  private refill(): void {
+    const now = Date.now()
+    const elapsed = (now - this.lastRefill) / 1000
+    this.tokens = Math.min(this.maxTokens, this.tokens + elapsed * this.refillRate)
+    this.lastRefill = now
+  }
+}
+
+// ---- Idempotency store ----
+
+type IdempotencyEntry = {
+  readonly response: WebhookResponse
+  readonly expiresAt: number
+}
+
+class IdempotencyStore {
+  private readonly entries = new Map<string, IdempotencyEntry>()
+  private sweepTimer: ReturnType<typeof setInterval> | undefined
+
+  constructor() {
+    this.sweepTimer = setInterval(() => this.sweep(), 60 * 60 * 1000)
+  }
+
+  get(key: string): WebhookResponse | undefined {
+    const entry = this.entries.get(key)
+    if (entry === undefined) {
+      return undefined
+    }
+    if (Date.now() > entry.expiresAt) {
+      this.entries.delete(key)
+      return undefined
+    }
+    return entry.response
+  }
+
+  set(key: string, response: WebhookResponse, ttlMs: number): void {
+    this.entries.set(key, {
+      response,
+      expiresAt: Date.now() + ttlMs,
+    })
+  }
+
+  sweep(): void {
+    const now = Date.now()
+    for (const [key, entry] of this.entries) {
+      if (now > entry.expiresAt) {
+        this.entries.delete(key)
+      }
+    }
+  }
+
+  close(): void {
+    if (this.sweepTimer !== undefined) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = undefined
+    }
+  }
+
+  /** Visible for testing. */
+  get size(): number {
+    return this.entries.size
+  }
+}
+
+// ---- Constants ----
+
+const DEFAULT_MAX_DOCUMENTS = 50
+const DEFAULT_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024 // 8 MiB
+const DEFAULT_MAX_DOCUMENT_BYTES = 10 * 1024 * 1024 // 10 MiB
+const DEFAULT_TIMESTAMP_EXPIRY_MS = 5 * 60 * 1000 // 5 minutes
+const DEFAULT_RATE_LIMIT_TOKENS = 60
+const DEFAULT_RATE_LIMIT_RATE = 10.0 // tokens per second
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+// ---- Authenticators ----
+
+type Authenticator = (
+  headers: Headers,
+  body: Uint8Array,
+  secret: string,
+  timestampExpiryMs: number,
+) => boolean
+
+const authenticateBearer: Authenticator = (headers, _body, secret): boolean => {
+  const header = headers.get('authorization') ?? ''
+  if (header === '') {
+    return false
+  }
+  const lowerHeader = header.toLowerCase()
+  if (!lowerHeader.startsWith('bearer ')) {
+    return false
+  }
+  const actual = header.slice(7).trim()
+  if (actual === '') {
+    return false
+  }
+  // Timing-safe comparison via SHA-256 hash to prevent length-based leaks.
+  const actualHash = createHash('sha256').update(actual).digest()
+  const expectedHash = createHash('sha256').update(secret).digest()
+  return timingSafeEqual(actualHash, expectedHash)
+}
+
+const authenticateHMAC: Authenticator = (
+  headers,
+  body,
+  secret,
+  timestampExpiryMs,
+): boolean => {
+  const sigHeader = headers.get('x-webhook-signature') ?? ''
+  if (sigHeader === '') {
+    return false
+  }
+
+  // Verify timestamp expiry for replay protection.
+  const tsHeader = headers.get('x-webhook-timestamp') ?? ''
+  if (tsHeader === '') {
+    return false
+  }
+  const ts = parseInt(tsHeader, 10)
+  if (Number.isNaN(ts)) {
+    return false
+  }
+  const requestTime = ts * 1000
+  if (Math.abs(Date.now() - requestTime) > timestampExpiryMs) {
+    return false
+  }
+
+  // Parse signature: expect "sha256=<hex>"
+  const sigPrefix = 'sha256='
+  if (!sigHeader.startsWith(sigPrefix)) {
+    return false
+  }
+  const providedSigHex = sigHeader.slice(sigPrefix.length)
+  let providedSig: Buffer
+  try {
+    providedSig = Buffer.from(providedSigHex, 'hex')
+  } catch {
+    return false
+  }
+  if (providedSig.length === 0) {
+    return false
+  }
+
+  // Compute expected HMAC-SHA256 over timestamp + "." + body to bind
+  // the signature to both the timestamp and the payload.
+  const mac = createHmac('sha256', secret)
+  mac.update(tsHeader)
+  mac.update('.')
+  mac.update(body)
+  const expectedSig = mac.digest()
+
+  if (providedSig.length !== expectedSig.length) {
+    return false
+  }
+  return timingSafeEqual(providedSig, expectedSig)
+}
+
+const authenticators: Record<WebhookAuthMethod, Authenticator> = {
+  bearer: authenticateBearer,
+  hmac: authenticateHMAC,
+}
+
+// ---- Content decoders ----
+
+type ContentDecoder = (raw: string) => Buffer
+
+const decodeUtf8: ContentDecoder = (raw) => Buffer.from(raw, 'utf8')
+
+const decodeBase64: ContentDecoder = (raw) => {
+  const decoded = Buffer.from(raw, 'base64')
+  // Verify round-trip to detect invalid base64.
+  if (decoded.toString('base64') !== raw) {
+    throw new Error('invalid base64 content')
+  }
+  return decoded
+}
+
+const contentDecoders: Record<string, ContentDecoder> = {
+  '': decodeUtf8,
+  utf8: decodeUtf8,
+  base64: decodeBase64,
+}
+
+// ---- WebhookReceiver ----
+
+/**
+ * HTTP handler that accepts POST requests with document payloads for
+ * ingestion. Compatible with any server that uses the fetch-style
+ * `Request => Response` pattern.
+ */
+export class WebhookReceiver {
+  private readonly brainId: string
+  private readonly auth: WebhookAuthConfig
+  private readonly maxDocuments: number
+  private readonly maxPayloadBytes: number
+  private readonly maxDocumentBytes: number
+  private readonly enableIdempotency: boolean
+  private readonly timestampExpiryMs: number
+  private readonly dispatcher: DocumentDispatcher
+  private readonly limiter: TokenBucket
+  private readonly idempotency: IdempotencyStore
+
+  constructor(config: WebhookReceiverConfig) {
+    this.brainId = config.brainId
+    this.auth = config.auth
+    this.maxDocuments = config.maxDocuments ?? DEFAULT_MAX_DOCUMENTS
+    this.maxPayloadBytes = config.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES
+    this.maxDocumentBytes = config.maxDocumentBytes ?? DEFAULT_MAX_DOCUMENT_BYTES
+    this.enableIdempotency = config.enableIdempotency ?? true
+    this.timestampExpiryMs = config.timestampExpiryMs ?? DEFAULT_TIMESTAMP_EXPIRY_MS
+    this.dispatcher = config.dispatcher
+    this.limiter = new TokenBucket(DEFAULT_RATE_LIMIT_TOKENS, DEFAULT_RATE_LIMIT_RATE)
+    this.idempotency = new IdempotencyStore()
+  }
+
+  /** Release background resources (sweep timer). */
+  close(): void {
+    this.idempotency.close()
+  }
+
+  /**
+   * Returns a fetch-style request handler. The handler is stateless and
+   * safe for concurrent use.
+   */
+  handler(): (req: Request) => Promise<Response> {
+    return (req: Request) => this.handleRequest(req)
+  }
+
+  private async handleRequest(req: Request): Promise<Response> {
+    // Method check
+    if (req.method !== 'POST') {
+      return this.errorResponse(405, 'method not allowed')
+    }
+
+    // Rate limiting
+    if (!this.limiter.tryAcquire()) {
+      return this.errorResponse(429, 'rate limit exceeded')
+    }
+
+    // Content-Type check
+    const ct = (req.headers.get('content-type') ?? '').toLowerCase()
+    if (!ct.startsWith('application/json')) {
+      return this.errorResponse(400, 'content-type must be application/json')
+    }
+
+    // Read body with size limit
+    const bodyResult = await this.readLimitedBody(req)
+    if (bodyResult instanceof Response) {
+      return bodyResult
+    }
+    const body = bodyResult
+
+    // Authentication
+    const authenticator = authenticators[this.auth.method]
+    if (authenticator === undefined) {
+      return new Response(null, { status: 401 })
+    }
+    if (!authenticator(req.headers, body, this.auth.secret, this.timestampExpiryMs)) {
+      // Empty body on auth failure to prevent information leakage.
+      return new Response(null, { status: 401 })
+    }
+
+    // Idempotency check
+    const idempotencyKey = req.headers.get('x-idempotency-key') ?? ''
+    if (this.enableIdempotency && idempotencyKey !== '') {
+      const cached = this.idempotency.get(idempotencyKey)
+      if (cached !== undefined) {
+        return this.jsonResponse(200, cached)
+      }
+    }
+
+    // Parse payload
+    let payload: WebhookPayload
+    try {
+      payload = JSON.parse(new TextDecoder().decode(body)) as WebhookPayload
+    } catch {
+      return this.errorResponse(400, 'invalid json')
+    }
+
+    // Validate document count
+    if (!Array.isArray(payload.documents) || payload.documents.length === 0) {
+      return this.errorResponse(400, 'documents array is empty')
+    }
+    if (payload.documents.length > this.maxDocuments) {
+      return this.errorResponse(
+        400,
+        `exceeds maximum of ${String(this.maxDocuments)} documents`,
+      )
+    }
+
+    // Process each document
+    const resp = await this.processDocuments(payload.documents)
+
+    // Cache response for idempotency
+    if (this.enableIdempotency && idempotencyKey !== '') {
+      this.idempotency.set(idempotencyKey, resp, IDEMPOTENCY_TTL_MS)
+    }
+
+    return this.jsonResponse(200, resp)
+  }
+
+  private async readLimitedBody(req: Request): Promise<Uint8Array | Response> {
+    const raw = await req.arrayBuffer()
+    if (raw.byteLength > this.maxPayloadBytes) {
+      return this.errorResponse(413, 'payload too large')
+    }
+    return new Uint8Array(raw)
+  }
+
+  private async processDocuments(
+    docs: readonly WebhookDocument[],
+  ): Promise<WebhookResponse> {
+    const results: WebhookDocumentResult[] = []
+    let accepted = 0
+    let rejected = 0
+
+    for (const doc of docs) {
+      const result = await this.processDocument(doc)
+      const statusUpdaters: Record<'accepted' | 'rejected', () => void> = {
+        accepted: () => { accepted++ },
+        rejected: () => { rejected++ },
+      }
+      statusUpdaters[result.status]()
+      results.push(result)
+    }
+
+    return { accepted, rejected, results }
+  }
+
+  private async processDocument(
+    doc: WebhookDocument,
+  ): Promise<WebhookDocumentResult> {
+    // Validate required fields.
+    if (typeof doc.externalId !== 'string' || doc.externalId === '') {
+      return {
+        externalId: doc.externalId ?? '',
+        status: 'rejected',
+        error: 'externalId is required',
+      }
+    }
+    if (typeof doc.content !== 'string' || doc.content === '') {
+      return {
+        externalId: doc.externalId,
+        status: 'rejected',
+        error: 'content is required',
+      }
+    }
+
+    // Decode content.
+    let content: Buffer
+    const encoding = doc.encoding ?? ''
+    const decoder = contentDecoders[encoding]
+    if (decoder === undefined) {
+      return {
+        externalId: doc.externalId,
+        status: 'rejected',
+        error: `unsupported encoding: ${encoding}`,
+      }
+    }
+    try {
+      content = decoder(doc.content)
+    } catch (err) {
+      return {
+        externalId: doc.externalId,
+        status: 'rejected',
+        error: err instanceof Error ? err.message : 'content decode failed',
+      }
+    }
+
+    // Check individual document size.
+    if (content.length > this.maxDocumentBytes) {
+      return {
+        externalId: doc.externalId,
+        status: 'rejected',
+        error: `document exceeds maximum size of ${String(this.maxDocumentBytes)} bytes`,
+      }
+    }
+
+    // Build connector document.
+    const connDoc: ConnectorDocument = {
+      externalId: doc.externalId,
+      content,
+      mime: doc.mime ?? 'text/plain',
+      title: doc.title ?? '',
+      ...(doc.url !== undefined ? { url: doc.url } : {}),
+      metadata: doc.metadata ?? {},
+      modifiedAt: new Date(),
+    }
+
+    // Dispatch to pipeline.
+    try {
+      const { documentId } = await this.dispatcher.dispatch(connDoc)
+      return {
+        externalId: doc.externalId,
+        status: 'accepted',
+        documentId,
+      }
+    } catch {
+      return {
+        externalId: doc.externalId,
+        status: 'rejected',
+        error: 'dispatch failed',
+      }
+    }
+  }
+
+  private jsonResponse(status: number, body: unknown): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  private errorResponse(status: number, detail: string): Response {
+    return new Response(
+      JSON.stringify({ status, title: statusText(status), detail }),
+      {
+        status,
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    )
+  }
+}
+
+const STATUS_TEXT: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  405: 'Method Not Allowed',
+  413: 'Payload Too Large',
+  429: 'Too Many Requests',
+}
+
+const statusText = (code: number): string => STATUS_TEXT[code] ?? 'Error'

--- a/sdks/ts/memory/src/connector/webhook.ts
+++ b/sdks/ts/memory/src/connector/webhook.ts
@@ -47,7 +47,7 @@ export type WebhookDocument = {
   readonly mime?: string
   readonly title?: string
   readonly url?: string
-  readonly metadata?: Readonly<Record<string, unknown>>
+  readonly metadata?: Readonly<Record<string, string>>
 }
 
 export type WebhookResponse = {
@@ -102,11 +102,15 @@ type IdempotencyEntry = {
   readonly expiresAt: number
 }
 
+const DEFAULT_MAX_IDEMPOTENCY_ENTRIES = 100_000
+
 class IdempotencyStore {
   private readonly entries = new Map<string, IdempotencyEntry>()
+  private readonly maxEntries: number
   private sweepTimer: ReturnType<typeof setInterval> | undefined
 
-  constructor() {
+  constructor(maxEntries = DEFAULT_MAX_IDEMPOTENCY_ENTRIES) {
+    this.maxEntries = maxEntries
     this.sweepTimer = setInterval(() => this.sweep(), 60 * 60 * 1000)
   }
 
@@ -123,10 +127,28 @@ class IdempotencyStore {
   }
 
   set(key: string, response: WebhookResponse, ttlMs: number): void {
+    // Evict the oldest entry if the store is at capacity.
+    if (this.entries.size >= this.maxEntries) {
+      this.evictOldest()
+    }
     this.entries.set(key, {
       response,
       expiresAt: Date.now() + ttlMs,
     })
+  }
+
+  private evictOldest(): void {
+    let oldestKey: string | undefined
+    let oldestTime = Infinity
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt < oldestTime) {
+        oldestKey = key
+        oldestTime = entry.expiresAt
+      }
+    }
+    if (oldestKey !== undefined) {
+      this.entries.delete(oldestKey)
+    }
   }
 
   sweep(): void {
@@ -270,6 +292,97 @@ const contentDecoders: Record<string, ContentDecoder> = {
   base64: decodeBase64,
 }
 
+// ---- Payload validation ----
+
+type ValidationResult<T> =
+  | { readonly value: T; readonly error?: undefined }
+  | { readonly value?: undefined; readonly error: string }
+
+/**
+ * Runtime-validates that the parsed JSON matches the expected
+ * {@link WebhookPayload} shape. Guards against unsafe casts by
+ * checking every field's type and rejecting unknown values.
+ */
+const validatePayload = (raw: unknown): ValidationResult<WebhookPayload> => {
+  if (raw === null || typeof raw !== 'object') {
+    return { error: 'payload must be an object' }
+  }
+  const obj = raw as Record<string, unknown>
+  if (!Array.isArray(obj['documents'])) {
+    return { error: 'documents array is empty' }
+  }
+  const documents: WebhookDocument[] = []
+  for (const item of obj['documents'] as unknown[]) {
+    const result = validateDocument(item)
+    if (result.error !== undefined) {
+      return { error: result.error }
+    }
+    documents.push(result.value)
+  }
+  return { value: { documents } }
+}
+
+const VALID_ENCODINGS = new Set(['utf8', 'base64'])
+
+const validateDocument = (raw: unknown): ValidationResult<WebhookDocument> => {
+  if (raw === null || typeof raw !== 'object') {
+    return { error: 'each document must be an object' }
+  }
+  const obj = raw as Record<string, unknown>
+
+  // Required fields: validate type when present. Missing/empty values are
+  // caught later by processDocument so that partial payloads return 200 with
+  // per-document rejection rather than a blanket 400.
+  if (obj['externalId'] !== undefined && typeof obj['externalId'] !== 'string') {
+    return { error: 'externalId must be a string' }
+  }
+  if (obj['content'] !== undefined && typeof obj['content'] !== 'string') {
+    return { error: 'content must be a string' }
+  }
+
+  // Optional string fields
+  if (obj['encoding'] !== undefined && typeof obj['encoding'] !== 'string') {
+    return { error: 'encoding must be a string' }
+  }
+  if (obj['encoding'] !== undefined && !VALID_ENCODINGS.has(obj['encoding'] as string)) {
+    // Let the decoder handle the actual error message; just validate it's a string here.
+    // We pass through to the decoder map which already handles unsupported encodings.
+  }
+  if (obj['mime'] !== undefined && typeof obj['mime'] !== 'string') {
+    return { error: 'mime must be a string' }
+  }
+  if (obj['title'] !== undefined && typeof obj['title'] !== 'string') {
+    return { error: 'title must be a string' }
+  }
+  if (obj['url'] !== undefined && typeof obj['url'] !== 'string') {
+    return { error: 'url must be a string' }
+  }
+
+  // Optional metadata: must be Record<string, string> for parity with Go.
+  if (obj['metadata'] !== undefined) {
+    if (obj['metadata'] === null || typeof obj['metadata'] !== 'object' || Array.isArray(obj['metadata'])) {
+      return { error: 'metadata must be an object' }
+    }
+    const meta = obj['metadata'] as Record<string, unknown>
+    for (const key of Object.keys(meta)) {
+      if (typeof meta[key] !== 'string') {
+        return { error: `metadata value for "${key}" must be a string` }
+      }
+    }
+  }
+
+  const doc: WebhookDocument = {
+    externalId: (obj['externalId'] as string | undefined) ?? '',
+    content: (obj['content'] as string | undefined) ?? '',
+    ...(obj['encoding'] !== undefined ? { encoding: obj['encoding'] as 'utf8' | 'base64' } : {}),
+    ...(obj['mime'] !== undefined ? { mime: obj['mime'] as string } : {}),
+    ...(obj['title'] !== undefined ? { title: obj['title'] as string } : {}),
+    ...(obj['url'] !== undefined ? { url: obj['url'] as string } : {}),
+    ...(obj['metadata'] !== undefined ? { metadata: obj['metadata'] as Readonly<Record<string, string>> } : {}),
+  }
+  return { value: doc }
+}
+
 // ---- WebhookReceiver ----
 
 /**
@@ -359,15 +472,22 @@ export class WebhookReceiver {
     }
 
     // Parse payload
-    let payload: WebhookPayload
+    let parsed: unknown
     try {
-      payload = JSON.parse(new TextDecoder().decode(body)) as WebhookPayload
+      parsed = JSON.parse(new TextDecoder().decode(body))
     } catch {
       return this.errorResponse(400, 'invalid json')
     }
 
+    // Runtime validation of payload shape.
+    const payloadResult = validatePayload(parsed)
+    if (payloadResult.error !== undefined) {
+      return this.errorResponse(400, payloadResult.error)
+    }
+    const payload = payloadResult.value
+
     // Validate document count
-    if (!Array.isArray(payload.documents) || payload.documents.length === 0) {
+    if (payload.documents.length === 0) {
       return this.errorResponse(400, 'documents array is empty')
     }
     if (payload.documents.length > this.maxDocuments) {
@@ -389,11 +509,35 @@ export class WebhookReceiver {
   }
 
   private async readLimitedBody(req: Request): Promise<Uint8Array | Response> {
-    const raw = await req.arrayBuffer()
-    if (raw.byteLength > this.maxPayloadBytes) {
-      return this.errorResponse(413, 'payload too large')
+    // Stream the body with a byte counter to abort early if the limit is
+    // exceeded. This prevents an attacker from OOM-ing the process by
+    // sending a payload larger than maxPayloadBytes.
+    if (req.body === null) {
+      return this.errorResponse(400, 'empty body')
     }
-    return new Uint8Array(raw)
+    const reader = req.body.getReader()
+    const chunks: Uint8Array[] = []
+    let totalBytes = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      }
+      totalBytes += value.byteLength
+      if (totalBytes > this.maxPayloadBytes) {
+        await reader.cancel()
+        return this.errorResponse(413, 'payload too large')
+      }
+      chunks.push(value)
+    }
+    // Concatenate chunks into a single Uint8Array.
+    const result = new Uint8Array(totalBytes)
+    let offset = 0
+    for (const chunk of chunks) {
+      result.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return result
   }
 
   private async processDocuments(

--- a/sdks/ts/memory/src/index.ts
+++ b/sdks/ts/memory/src/index.ts
@@ -48,7 +48,7 @@ export * from './connector/index.js'
 export * from './acl/index.js'
 
 // Connector framework (OAuth2, SecureTokenStore, registry, pagination,
-// rate limiting, sync state). Consumers can also import directly from
+// rate limiting, sync state, webhook). Consumers can also import directly from
 // '@jeffs-brain/memory/connector'.
 export * as connector from './connector/index.js'
 

--- a/spec/PROTOCOL.md
+++ b/spec/PROTOCOL.md
@@ -392,3 +392,124 @@ Reserved for v1.1:
 - `If-Match` preconditions on `PUT /documents` and `DELETE /documents` enabling optimistic concurrency via ETag.
 
 Clients MAY already send `If-None-Match` / `If-Match`; v1.0 servers MUST ignore them and respond as if they were absent.
+
+## Webhook receiver endpoint
+
+The webhook receiver provides a push-based ingestion path. External systems POST document payloads to the receiver, which validates authentication and schema before dispatching accepted documents to the ingestion pipeline.
+
+### `POST /webhook/ingest`
+
+Accept one or more documents for ingestion via push delivery.
+
+**Headers**
+
+| Header | Required | Description |
+| --- | --- | --- |
+| `Content-Type` | Yes | Must be `application/json`. |
+| `Authorization` | Conditional | `Bearer <token>` when the receiver is configured with bearer authentication. |
+| `X-Webhook-Signature` | Conditional | `sha256=<hex-encoded HMAC>` when the receiver is configured with HMAC authentication. The HMAC-SHA256 is computed over `<timestamp>.<body>` using the shared secret. |
+| `X-Webhook-Timestamp` | Conditional | Unix timestamp in seconds. Required when using HMAC authentication. The receiver rejects requests where `abs(now - timestamp)` exceeds the configured expiry window (default: 5 minutes). |
+| `X-Idempotency-Key` | No | Opaque string. When present and idempotency is enabled, the receiver caches the response and returns it on subsequent requests with the same key. Cached entries expire after 24 hours. |
+
+**Body**
+
+```json
+{
+  "documents": [
+    {
+      "externalId": "ext-123",
+      "content": "Document text or base64-encoded binary",
+      "encoding": "utf8",
+      "mime": "text/plain",
+      "title": "Optional title",
+      "url": "https://example.com/source",
+      "metadata": {
+        "author": "jane",
+        "source": "webhook"
+      }
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `documents` | array | Yes | Non-empty array of documents. Maximum count is configurable (default: 50). |
+| `documents[].externalId` | string | Yes | Caller-assigned unique identifier for the document. |
+| `documents[].content` | string | Yes | Document content. Interpreted according to `encoding`. |
+| `documents[].encoding` | string | No | `"utf8"` (default) or `"base64"`. |
+| `documents[].mime` | string | No | MIME type. Defaults to `"text/plain"`. |
+| `documents[].title` | string | No | Human-readable title. |
+| `documents[].url` | string | No | Source URL for provenance tracking. |
+| `documents[].metadata` | object | No | Arbitrary key-value pairs. All values must be strings. |
+
+**Response** `200 OK`
+
+```json
+{
+  "accepted": 1,
+  "rejected": 0,
+  "results": [
+    {
+      "externalId": "ext-123",
+      "status": "accepted",
+      "documentId": "doc-1"
+    }
+  ]
+}
+```
+
+Each entry in `results` corresponds positionally to the input `documents` array.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `accepted` | integer | Count of successfully dispatched documents. |
+| `rejected` | integer | Count of documents that failed validation or dispatch. |
+| `results[].externalId` | string | The `externalId` from the input document. |
+| `results[].status` | string | `"accepted"` or `"rejected"`. |
+| `results[].documentId` | string | Pipeline-assigned document ID. Present only when `status` is `"accepted"`. |
+| `results[].error` | string | Human-readable error description. Present only when `status` is `"rejected"`. |
+
+**Errors**
+
+| Status | Condition |
+| --- | --- |
+| `400` | Missing or invalid `Content-Type`, malformed JSON, empty `documents` array, document count exceeds maximum. |
+| `401` | Authentication failed or missing. Response body is empty to prevent information leakage. |
+| `405` | Request method is not `POST`. |
+| `413` | Payload exceeds the configured maximum size (default: 8 MiB). |
+| `429` | Rate limit exceeded. The receiver uses a token bucket (default: 60 tokens, 10/sec refill). |
+
+Error responses (except `401`) carry a `application/problem+json` body:
+
+```json
+{
+  "status": 413,
+  "title": "Payload Too Large",
+  "detail": "payload too large"
+}
+```
+
+### Authentication methods
+
+The receiver supports two authentication methods, configured per instance:
+
+**Bearer token** (`method: "bearer"`): The client sends `Authorization: Bearer <token>`. The receiver compares the token against the configured secret using a timing-safe comparison (SHA-256 hash of both sides followed by constant-time byte comparison) to prevent length-based side-channel attacks.
+
+**HMAC-SHA256** (`method: "hmac"`): The client computes `HMAC-SHA256(secret, "<timestamp>.<body>")` and sends it as `X-Webhook-Signature: sha256=<hex>`. The timestamp in `X-Webhook-Timestamp` binds the signature to a time window, preventing replay attacks beyond the configured expiry (default: 5 minutes). The receiver uses `hmac.Equal` (Go) or `timingSafeEqual` (TS) for constant-time comparison.
+
+### Size limits
+
+| Limit | Default | Description |
+| --- | --- | --- |
+| Maximum payload size | 8 MiB | Total request body size. Enforced at the wire level (streaming read with abort). |
+| Maximum document size | 10 MiB | Individual document content size after decoding. |
+| Maximum document count | 50 | Number of documents per request. |
+
+### Idempotency
+
+When `X-Idempotency-Key` is present and idempotency is enabled, the receiver caches the response for 24 hours. Subsequent requests with the same key return the cached response without re-processing. The in-memory idempotency store is bounded to 100,000 entries; when full, the oldest entry (by expiry time) is evicted. A background sweep removes expired entries every hour.
+
+### Rate limiting
+
+The receiver enforces a global token bucket rate limiter. Default configuration: 60 tokens maximum, refilling at 10 tokens per second. When the bucket is empty, requests receive `429 Too Many Requests`.


### PR DESCRIPTION
## What
Webhook endpoint for receiving external document pushes with cryptographic verification.

## Why
External systems need to push content to the memory pipeline. Pull-based connectors alone are insufficient.

## How
- HMAC-SHA256 signature verification (timing-safe) with timestamp binding
- Bearer token auth (SHA-256 hashed before constant-time comparison)
- 5-minute replay protection via timestamp expiry
- Streaming body read with size limit (no OOM from oversized payloads)
- Runtime payload validation (no unsafe `as` casts)
- Partial failure: 200 with per-document accepted/rejected status
- Idempotency: `X-Idempotency-Key` with 24h TTL, max 100K entries with LRU eviction
- Rate limiting: token bucket (60 tokens, 10/sec refill)
- Content encoding: utf8 (default) and base64 with validation
- `spec/PROTOCOL.md` updated with webhook endpoint contract

| Language | Tests |
|----------|-------|
| Go | `go/connector/` — webhook.go | 34 tests |
| TypeScript | `sdks/ts/memory/src/connector/` — webhook.ts | 30 tests |

## Ticket
LLE-9815