### PR TITLE
feat(connector): Slack channel history + file ingestion (P5-2)

### DIFF
--- a/go/connector/mrkdwn.go
+++ b/go/connector/mrkdwn.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"regexp"
+	"strings"
+)
+
+// mrkdwn conversion patterns. Each pattern transforms one Slack mrkdwn
+// construct into the equivalent standard Markdown syntax.
+//
+// Ordering matters: link patterns must be applied before bold/italic to
+// avoid mangling URLs that contain underscores or asterisks.
+
+var (
+	// <https://example.com|label> -> [label](https://example.com)
+	mrkdwnLabelledLink = regexp.MustCompile(`<(https?://[^|>]+)\|([^>]+)>`)
+
+	// <https://example.com> -> https://example.com
+	mrkdwnBareLink = regexp.MustCompile(`<(https?://[^>]+)>`)
+
+	// <#C123ABC|channel-name> -> #channel-name
+	mrkdwnChannel = regexp.MustCompile(`<#[A-Z0-9]+\|([^>]+)>`)
+
+	// <@U123ABC> -> @U123ABC (user mention -- resolved separately)
+	mrkdwnUserMention = regexp.MustCompile(`<@([A-Z0-9]+)>`)
+
+	// *bold* -> **bold** (Slack uses single asterisks for bold)
+	// Must not match inside code spans or URLs.
+	mrkdwnBold = regexp.MustCompile(`(?:^|(?P<pre>\s))\*(?P<text>[^\s*][^*]*[^\s*]|[^\s*])\*(?:$|(?P<post>\s))`)
+
+	// _italic_ -> *italic* (Slack uses underscores for italic)
+	mrkdwnItalic = regexp.MustCompile(`(?:^|(?P<pre>\s))_(?P<text>[^\s_][^_]*[^\s_]|[^\s_])_(?:$|(?P<post>\s))`)
+
+	// ~strike~ -> ~~strike~~
+	mrkdwnStrike = regexp.MustCompile(`(?:^|(?P<pre>\s))~(?P<text>[^\s~][^~]*[^\s~]|[^\s~])~(?:$|(?P<post>\s))`)
+)
+
+// ConvertMrkdwn converts Slack mrkdwn formatted text to standard
+// Markdown. It handles links, channel mentions, user mentions, bold,
+// italic, strikethrough, and code blocks. Emoji shortcodes (:name:)
+// are left as-is.
+func ConvertMrkdwn(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	// Protect code blocks from formatting conversions by extracting
+	// them first and reinserting after all other transformations.
+	result, codeBlocks := extractCodeBlocks(text)
+	result, inlineCode := extractInlineCode(result)
+
+	// Links (labelled and bare).
+	result = mrkdwnLabelledLink.ReplaceAllString(result, "[$2]($1)")
+	result = mrkdwnBareLink.ReplaceAllString(result, "$1")
+
+	// Channel mentions.
+	result = mrkdwnChannel.ReplaceAllString(result, "#$1")
+
+	// User mentions -- leave as @USER_ID; the caller resolves names.
+	result = mrkdwnUserMention.ReplaceAllString(result, "@$1")
+
+	// Bold: *text* -> **text**
+	result = mrkdwnBold.ReplaceAllStringFunc(result, func(m string) string {
+		sub := mrkdwnBold.FindStringSubmatch(m)
+		pre := sub[mrkdwnBold.SubexpIndex("pre")]
+		text := sub[mrkdwnBold.SubexpIndex("text")]
+		post := sub[mrkdwnBold.SubexpIndex("post")]
+		return pre + "**" + text + "**" + post
+	})
+
+	// Italic: _text_ -> *text*
+	result = mrkdwnItalic.ReplaceAllStringFunc(result, func(m string) string {
+		sub := mrkdwnItalic.FindStringSubmatch(m)
+		pre := sub[mrkdwnItalic.SubexpIndex("pre")]
+		text := sub[mrkdwnItalic.SubexpIndex("text")]
+		post := sub[mrkdwnItalic.SubexpIndex("post")]
+		return pre + "*" + text + "*" + post
+	})
+
+	// Strikethrough: ~text~ -> ~~text~~
+	result = mrkdwnStrike.ReplaceAllStringFunc(result, func(m string) string {
+		sub := mrkdwnStrike.FindStringSubmatch(m)
+		pre := sub[mrkdwnStrike.SubexpIndex("pre")]
+		text := sub[mrkdwnStrike.SubexpIndex("text")]
+		post := sub[mrkdwnStrike.SubexpIndex("post")]
+		return pre + "~~" + text + "~~" + post
+	})
+
+	// Restore inline code and code blocks.
+	result = restoreInlineCode(result, inlineCode)
+	result = restoreCodeBlocks(result, codeBlocks)
+
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Code block extraction / restoration
+// ---------------------------------------------------------------------------
+
+const codeBlockPlaceholder = "\x00CB"
+const inlineCodePlaceholder = "\x00IC"
+
+func extractCodeBlocks(text string) (string, []string) {
+	var blocks []string
+	result := text
+	for {
+		start := strings.Index(result, "```")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start+3:], "```")
+		if end == -1 {
+			break
+		}
+		end += start + 3 + 3
+		block := result[start:end]
+		blocks = append(blocks, block)
+		result = result[:start] + codeBlockPlaceholder + result[end:]
+	}
+	return result, blocks
+}
+
+func restoreCodeBlocks(text string, blocks []string) string {
+	result := text
+	for _, block := range blocks {
+		// Convert Slack code blocks to fenced blocks with newlines.
+		inner := block[3 : len(block)-3]
+		replacement := "```\n" + strings.TrimSpace(inner) + "\n```"
+		result = strings.Replace(result, codeBlockPlaceholder, replacement, 1)
+	}
+	return result
+}
+
+func extractInlineCode(text string) (string, []string) {
+	var codes []string
+	result := text
+	for {
+		start := strings.Index(result, "`")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start+1:], "`")
+		if end == -1 {
+			break
+		}
+		end += start + 1 + 1
+		code := result[start:end]
+		codes = append(codes, code)
+		result = result[:start] + inlineCodePlaceholder + result[end:]
+	}
+	return result, codes
+}
+
+func restoreInlineCode(text string, codes []string) string {
+	result := text
+	for _, code := range codes {
+		result = strings.Replace(result, inlineCodePlaceholder, code, 1)
+	}
+	return result
+}

--- a/go/connector/mrkdwn_test.go
+++ b/go/connector/mrkdwn_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"testing"
+)
+
+func TestConvertMrkdwn(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "plain text unchanged",
+			input: "Hello world",
+			want:  "Hello world",
+		},
+		{
+			name:  "bold conversion",
+			input: "this is *bold text* here",
+			want:  "this is **bold text** here",
+		},
+		{
+			name:  "italic conversion",
+			input: "this is _italic text_ here",
+			want:  "this is *italic text* here",
+		},
+		{
+			name:  "strikethrough conversion",
+			input: "this is ~struck text~ here",
+			want:  "this is ~~struck text~~ here",
+		},
+		{
+			name:  "labelled link",
+			input: "<https://example.com|Example Site>",
+			want:  "[Example Site](https://example.com)",
+		},
+		{
+			name:  "bare link",
+			input: "<https://example.com>",
+			want:  "https://example.com",
+		},
+		{
+			name:  "channel mention",
+			input: "Check <#C123ABC|general> for updates",
+			want:  "Check #general for updates",
+		},
+		{
+			name:  "user mention",
+			input: "Hey <@U123ABC> check this",
+			want:  "Hey @U123ABC check this",
+		},
+		{
+			name:  "inline code preserved",
+			input: "Run `go test` to verify",
+			want:  "Run `go test` to verify",
+		},
+		{
+			name:  "code block preserved",
+			input: "Here is code:\n```func main() {}```",
+			want:  "Here is code:\n```\nfunc main() {}\n```",
+		},
+		{
+			name:  "emoji shortcodes preserved",
+			input: ":wave: Hello :smile:",
+			want:  ":wave: Hello :smile:",
+		},
+		{
+			name:  "multiple transformations",
+			input: "Hey <@U001>, check <https://example.com|this link> and _remember_ to *review*",
+			want:  "Hey @U001, check [this link](https://example.com) and *remember* to **review**",
+		},
+		{
+			name:  "blockquote preserved",
+			input: "> This is a quote",
+			want:  "> This is a quote",
+		},
+		{
+			name:  "bold at start of line",
+			input: "*bold* text",
+			want:  "**bold** text",
+		},
+		{
+			name:  "italic at start of line",
+			input: "_italic_ text",
+			want:  "*italic* text",
+		},
+		{
+			name:  "bold at end of line",
+			input: "text *bold*",
+			want:  "text **bold**",
+		},
+		{
+			name:  "bold does not match inside words",
+			input: "not*bold*here",
+			want:  "not*bold*here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ConvertMrkdwn(tt.input)
+			if got != tt.want {
+				t.Errorf("ConvertMrkdwn(%q)\n  got:  %q\n  want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/connector/slack.go
+++ b/go/connector/slack.go
@@ -485,7 +485,7 @@ func (c *SlackConnector) downloadFile(
 	if err != nil {
 		return ConnectorDocument{}, fmt.Errorf("download file: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return ConnectorDocument{}, fmt.Errorf("download file: HTTP %d", resp.StatusCode)

--- a/go/connector/slack.go
+++ b/go/connector/slack.go
@@ -16,6 +16,10 @@ import (
 	"time"
 )
 
+// maxAPIRetries is the maximum number of retry attempts for rate-limited
+// (HTTP 429) API responses before returning an error.
+const maxAPIRetries = 5
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -106,15 +110,16 @@ type slackUser struct {
 // downloads file attachments, and converts Slack mrkdwn to standard
 // markdown.
 type SlackConnector struct {
-	config      SlackConnectorConfig
-	rateLimiter *RateLimiter
-	userCache   map[string]string
-	userMu      sync.RWMutex
-	stopCh      chan struct{}
-	stopped     bool
-	mu          sync.Mutex
-	logger      *slog.Logger
-	httpClient  HTTPDoer
+	config       SlackConnectorConfig
+	rateLimiter  *RateLimiter
+	userCache    map[string]string
+	userMu       sync.RWMutex
+	stopCh       chan struct{}
+	stopped      bool
+	mu           sync.Mutex
+	logger       *slog.Logger
+	httpClient   HTTPDoer
+	urlValidator func(string) error // SSRF validation; defaults to validateDownloadURL
 }
 
 // NewSlackConnector creates a new Slack connector with the given config.
@@ -138,48 +143,61 @@ func NewSlackConnector(cfg SlackConnectorConfig) *SlackConnector {
 	return &SlackConnector{
 		config: cfg,
 		// Slack Tier 3: ~50 requests per minute = ~0.833 per second
-		rateLimiter: NewRateLimiter(50, 50.0/60.0),
-		userCache:   make(map[string]string),
-		stopCh:      make(chan struct{}),
-		logger:      cfg.Logger,
-		httpClient:  cfg.HTTPClient,
+		rateLimiter:  NewRateLimiter(50, 50.0/60.0),
+		userCache:    make(map[string]string),
+		stopCh:       make(chan struct{}),
+		logger:       cfg.Logger,
+		httpClient:   cfg.HTTPClient,
+		urlValidator: validateDownloadURL,
 	}
 }
 
 // Name returns "slack".
 func (c *SlackConnector) Name() string { return "slack" }
 
-// Configure validates and applies configuration from a string map.
-func (c *SlackConnector) Configure(config map[string]string) error {
-	token, ok := config["botToken"]
-	if !ok || token == "" {
+// Configure validates and applies connector-specific configuration.
+// Accepts map[string]any to match the P5-1 Connector interface.
+func (c *SlackConnector) Configure(config map[string]any) error {
+	token, _ := config["botToken"].(string)
+	if token == "" {
 		return fmt.Errorf("slack: botToken is required")
 	}
 	c.config.BotToken = token
 
-	channels, ok := config["channels"]
-	if !ok || channels == "" {
+	channelsRaw, _ := config["channels"].(string)
+	if channelsRaw == "" {
 		return fmt.Errorf("slack: at least one channel is required")
 	}
-	c.config.Channels = strings.Split(channels, ",")
+	c.config.Channels = strings.Split(channelsRaw, ",")
 	for i, ch := range c.config.Channels {
 		c.config.Channels[i] = strings.TrimSpace(ch)
 	}
 
-	if v, ok := config["includeThreads"]; ok {
+	if v, ok := config["includeThreads"].(bool); ok {
+		c.config.IncludeThreads = v
+	} else if v, ok := config["includeThreads"].(string); ok {
 		c.config.IncludeThreads = v != "false"
 	}
-	if v, ok := config["includeFiles"]; ok {
+
+	if v, ok := config["includeFiles"].(bool); ok {
+		c.config.IncludeFiles = v
+	} else if v, ok := config["includeFiles"].(string); ok {
 		c.config.IncludeFiles = v != "false"
 	}
-	if v, ok := config["maxFileSize"]; ok {
+
+	if v, ok := config["maxFileSize"].(string); ok {
 		size, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return fmt.Errorf("slack: invalid maxFileSize: %w", err)
 		}
 		c.config.MaxFileSize = size
+	} else if v, ok := config["maxFileSize"].(float64); ok {
+		c.config.MaxFileSize = int64(v)
+	} else if v, ok := config["maxFileSize"].(int); ok {
+		c.config.MaxFileSize = int64(v)
 	}
-	if v, ok := config["oldestTimestamp"]; ok {
+
+	if v, ok := config["oldestTimestamp"].(string); ok {
 		c.config.OldestTimestamp = v
 	}
 
@@ -198,63 +216,45 @@ func (c *SlackConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-c
 }
 
 // Start begins a continuous sync loop that polls at the configured
-// interval. The first iteration performs a full sync if no cursor
-// exists, then subsequent iterations sync incrementally.
-func (c *SlackConnector) Start(ctx context.Context) (<-chan ConnectorDocument, <-chan error) {
-	docCh := make(chan ConnectorDocument, 100)
-	errCh := make(chan error, 1)
+// interval. Blocks until the context is cancelled or Stop is called.
+// Returns the first fatal error encountered, or nil on clean shutdown.
+func (c *SlackConnector) Start(ctx context.Context) error {
+	var lastCursor string
+	if c.config.OldestTimestamp != "" {
+		lastCursor = c.config.OldestTimestamp
+	}
 
-	go func() {
-		defer close(docCh)
-		defer close(errCh)
+	ticker := time.NewTicker(c.config.PollInterval)
+	defer ticker.Stop()
 
-		var lastCursor string
-		if c.config.OldestTimestamp != "" {
-			lastCursor = c.config.OldestTimestamp
-		}
+	// Run once immediately, then on each tick.
+	for {
+		docs, errs := c.fetchMessages(ctx, lastCursor)
+		var latestTS string
 
-		ticker := time.NewTicker(c.config.PollInterval)
-		defer ticker.Stop()
-
-		// Run once immediately, then on each tick.
-		for {
-			docs, errs := c.fetchMessages(ctx, lastCursor)
-			var latestTS string
-
-			for doc := range docs {
-				ts, tsOK := doc.Metadata["ts"]
-				if tsOK && ts > latestTS {
-					latestTS = ts
-				}
-				select {
-				case docCh <- doc:
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			if err, ok := <-errs; ok && err != nil {
-				select {
-				case errCh <- err:
-				default:
-				}
-			}
-
-			if latestTS != "" {
-				lastCursor = latestTS
-			}
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-c.stopCh:
-				return
-			case <-ticker.C:
+		for doc := range docs {
+			ts, tsOK := doc.Metadata["ts"]
+			if tsOK && ts > latestTS {
+				latestTS = ts
 			}
 		}
-	}()
 
-	return docCh, errCh
+		if err, ok := <-errs; ok && err != nil {
+			return fmt.Errorf("slack: sync error: %w", err)
+		}
+
+		if latestTS != "" {
+			lastCursor = latestTS
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.stopCh:
+			return nil
+		case <-ticker.C:
+		}
+	}
 }
 
 // Stop gracefully stops the continuous sync loop.
@@ -433,7 +433,9 @@ func (c *SlackConnector) buildThreadDocument(parent slackMessage, replies []slac
 	sb.WriteString("## Thread: ")
 	sb.WriteString(ConvertMrkdwn(parent.Text))
 	sb.WriteString("\n\n")
-	sb.WriteString(fmt.Sprintf("**%s** (%s):\n", parentUser, parentTS.Format("2006-01-02 15:04")))
+
+	// Include the parent message as the first entry.
+	sb.WriteString(fmt.Sprintf("**%s** (%s):\n", parentUser, formatTimestamp(parentTS)))
 	sb.WriteString(ConvertMrkdwn(parent.Text))
 	sb.WriteString("\n\n")
 
@@ -444,7 +446,7 @@ func (c *SlackConnector) buildThreadDocument(parent slackMessage, replies []slac
 		}
 		replyUser := c.resolveUserName(reply.User)
 		ts := parseSlackTimestamp(reply.TS)
-		sb.WriteString(fmt.Sprintf("**%s** (%s):\n", replyUser, ts.Format("2006-01-02 15:04")))
+		sb.WriteString(fmt.Sprintf("**%s** (%s):\n", replyUser, formatTimestamp(ts)))
 		sb.WriteString(ConvertMrkdwn(reply.Text))
 		sb.WriteString("\n\n")
 	}
@@ -461,6 +463,11 @@ func (c *SlackConnector) downloadFile(
 	channelID string,
 	file slackFile,
 ) (ConnectorDocument, error) {
+	// Validate the download URL against SSRF before fetching.
+	if err := c.urlValidator(file.URLPrivateDownload); err != nil {
+		return ConnectorDocument{}, err
+	}
+
 	if err := c.rateLimiter.Acquire(ctx, 1); err != nil {
 		return ConnectorDocument{}, err
 	}
@@ -557,179 +564,77 @@ func (c *SlackConnector) callSlackAPI(
 	endpoint string,
 	params url.Values,
 ) (slackResponse, error) {
-	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	reqURL := endpoint + "?" + params.Encode()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return slackResponse{}, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	backoff := time.Duration(0)
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return slackResponse{}, fmt.Errorf("http request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Handle rate limiting (HTTP 429).
-	if resp.StatusCode == http.StatusTooManyRequests {
-		retryAfter := resp.Header.Get("Retry-After")
-		waitSecs, parseErr := strconv.Atoi(retryAfter)
-		if parseErr != nil || waitSecs <= 0 {
-			waitSecs = 5
+	for attempt := range maxAPIRetries {
+		if backoff > 0 {
+			select {
+			case <-ctx.Done():
+				return slackResponse{}, ctx.Err()
+			case <-time.After(backoff):
+			}
 		}
-		select {
-		case <-ctx.Done():
-			return slackResponse{}, ctx.Err()
-		case <-time.After(time.Duration(waitSecs) * time.Second):
+
+		reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			cancel()
+			return slackResponse{}, fmt.Errorf("create request: %w", err)
 		}
-		// Retry once after waiting.
-		return c.callSlackAPI(ctx, endpoint, params)
+		req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			return slackResponse{}, fmt.Errorf("http request: %w", err)
+		}
+
+		// Handle rate limiting (HTTP 429) with exponential backoff.
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := resp.Header.Get("Retry-After")
+			waitSecs, parseErr := strconv.Atoi(retryAfter)
+			if parseErr != nil || waitSecs <= 0 {
+				waitSecs = 5
+			}
+			resp.Body.Close()
+			cancel()
+
+			if attempt == maxAPIRetries-1 {
+				return slackResponse{}, fmt.Errorf("slack API rate limited after %d retries", maxAPIRetries)
+			}
+
+			// Exponential backoff: use Retry-After as base, double on each subsequent retry.
+			backoff = time.Duration(waitSecs) * time.Second * (1 << attempt)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			cancel()
+			return slackResponse{}, fmt.Errorf("slack API returned HTTP %d", resp.StatusCode)
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10 MB limit
+		resp.Body.Close()
+		cancel()
+		if readErr != nil {
+			return slackResponse{}, fmt.Errorf("read response: %w", readErr)
+		}
+
+		var result slackResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return slackResponse{}, fmt.Errorf("decode response: %w", err)
+		}
+
+		if !result.OK {
+			return slackResponse{}, fmt.Errorf("slack API error: %s", result.Error)
+		}
+
+		return result, nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return slackResponse{}, fmt.Errorf("slack API returned HTTP %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10 MB limit
-	if err != nil {
-		return slackResponse{}, fmt.Errorf("read response: %w", err)
-	}
-
-	var result slackResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return slackResponse{}, fmt.Errorf("decode response: %w", err)
-	}
-
-	if !result.OK {
-		return slackResponse{}, fmt.Errorf("slack API error: %s", result.Error)
-	}
-
-	return result, nil
+	return slackResponse{}, fmt.Errorf("slack API: exhausted all %d retry attempts", maxAPIRetries)
 }
 
-// ---------------------------------------------------------------------------
-// Internal: user resolution
-// ---------------------------------------------------------------------------
-
-func (c *SlackConnector) resolveUserName(userID string) string {
-	if userID == "" {
-		return "unknown"
-	}
-
-	c.userMu.RLock()
-	name, ok := c.userCache[userID]
-	c.userMu.RUnlock()
-	if ok {
-		return name
-	}
-
-	// Attempt to fetch the user name via users.info.
-	resolved := c.fetchUserName(userID)
-
-	c.userMu.Lock()
-	c.userCache[userID] = resolved
-	c.userMu.Unlock()
-
-	return resolved
-}
-
-func (c *SlackConnector) fetchUserName(userID string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	params := url.Values{"user": {userID}}
-	reqURL := "https://slack.com/api/users.info?" + params.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return userID
-	}
-	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return userID
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return userID
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
-	if err != nil {
-		return userID
-	}
-
-	var result slackUserResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return userID
-	}
-
-	if !result.OK {
-		return userID
-	}
-
-	if result.User.RealName != "" {
-		return result.User.RealName
-	}
-	if result.User.Name != "" {
-		return result.User.Name
-	}
-	return userID
-}
-
-// ---------------------------------------------------------------------------
-// Internal: message -> document conversion
-// ---------------------------------------------------------------------------
-
-func (c *SlackConnector) messageToDocument(channelID string, msg slackMessage) ConnectorDocument {
-	ts := parseSlackTimestamp(msg.TS)
-	content := ConvertMrkdwn(msg.Text)
-
-	metadata := map[string]string{
-		"channel": channelID,
-		"user":    msg.User,
-		"ts":      msg.TS,
-		"source":  "slack",
-		"type":    "message",
-	}
-	if msg.ThreadTS != "" {
-		metadata["thread_ts"] = msg.ThreadTS
-	}
-	if msg.ReplyCount > 0 {
-		metadata["reply_count"] = strconv.Itoa(msg.ReplyCount)
-	}
-
-	return ConnectorDocument{
-		ExternalID: fmt.Sprintf("%s:%s", channelID, msg.TS),
-		Content:    []byte(content),
-		MIME:       "text/markdown",
-		Title:      fmt.Sprintf("Message in %s", channelID),
-		Metadata:   metadata,
-		ModifiedAt: ts,
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// parseSlackTimestamp converts a Slack epoch timestamp string (e.g.
-// "1234567890.123456") to a time.Time.
-func parseSlackTimestamp(ts string) time.Time {
-	parts := strings.SplitN(ts, ".", 2)
-	secs, err := strconv.ParseInt(parts[0], 10, 64)
-	if err != nil {
-		return time.Time{}
-	}
-	var micros int64
-	if len(parts) > 1 {
-		micros, _ = strconv.ParseInt(parts[1], 10, 64)
-	}
-	return time.Unix(secs, micros*1000)
-}

--- a/go/connector/slack.go
+++ b/go/connector/slack.go
@@ -1,0 +1,735 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// SlackConnectorConfig holds the configuration for the Slack connector.
+type SlackConnectorConfig struct {
+	BotToken        string
+	Channels        []string
+	IncludeThreads  bool
+	IncludeFiles    bool
+	MaxFileSize     int64
+	OldestTimestamp string
+	PollInterval    time.Duration
+	Logger          *slog.Logger
+	HTTPClient      HTTPDoer
+}
+
+// defaultSlackConfig returns a SlackConnectorConfig with sensible defaults
+// applied for unset fields.
+func defaultSlackConfig() SlackConnectorConfig {
+	return SlackConnectorConfig{
+		IncludeThreads: true,
+		IncludeFiles:   true,
+		MaxFileSize:    50 * 1024 * 1024, // 50 MB
+		PollInterval:   5 * time.Minute,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP abstraction (for testability)
+// ---------------------------------------------------------------------------
+
+// HTTPDoer is the minimal interface for issuing HTTP requests. Both
+// *http.Client and test doubles satisfy it.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ---------------------------------------------------------------------------
+// Slack API response types
+// ---------------------------------------------------------------------------
+
+type slackResponse struct {
+	OK               bool             `json:"ok"`
+	Error            string           `json:"error"`
+	Messages         []slackMessage   `json:"messages"`
+	ResponseMetadata slackRespMeta    `json:"response_metadata"`
+}
+
+type slackRespMeta struct {
+	NextCursor string `json:"next_cursor"`
+}
+
+type slackMessage struct {
+	Type       string      `json:"type"`
+	User       string      `json:"user"`
+	Text       string      `json:"text"`
+	TS         string      `json:"ts"`
+	ThreadTS   string      `json:"thread_ts"`
+	ReplyCount int         `json:"reply_count"`
+	Files      []slackFile `json:"files"`
+}
+
+type slackFile struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	MIMEType           string `json:"mimetype"`
+	Size               int64  `json:"size"`
+	URLPrivateDownload string `json:"url_private_download"`
+}
+
+type slackUserResponse struct {
+	OK   bool      `json:"ok"`
+	User slackUser `json:"user"`
+}
+
+type slackUser struct {
+	RealName string `json:"real_name"`
+	Name     string `json:"name"`
+}
+
+// ---------------------------------------------------------------------------
+// Slack connector
+// ---------------------------------------------------------------------------
+
+// SlackConnector implements the Connector interface for Slack workspace
+// integration. It fetches channel messages, reconstructs threads,
+// downloads file attachments, and converts Slack mrkdwn to standard
+// markdown.
+type SlackConnector struct {
+	config      SlackConnectorConfig
+	rateLimiter *RateLimiter
+	userCache   map[string]string
+	userMu      sync.RWMutex
+	stopCh      chan struct{}
+	stopped     bool
+	mu          sync.Mutex
+	logger      *slog.Logger
+	httpClient  HTTPDoer
+}
+
+// NewSlackConnector creates a new Slack connector with the given config.
+// Missing config fields are filled with defaults.
+func NewSlackConnector(cfg SlackConnectorConfig) *SlackConnector {
+	defaults := defaultSlackConfig()
+
+	if cfg.MaxFileSize <= 0 {
+		cfg.MaxFileSize = defaults.MaxFileSize
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaults.PollInterval
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	return &SlackConnector{
+		config: cfg,
+		// Slack Tier 3: ~50 requests per minute = ~0.833 per second
+		rateLimiter: NewRateLimiter(50, 50.0/60.0),
+		userCache:   make(map[string]string),
+		stopCh:      make(chan struct{}),
+		logger:      cfg.Logger,
+		httpClient:  cfg.HTTPClient,
+	}
+}
+
+// Name returns "slack".
+func (c *SlackConnector) Name() string { return "slack" }
+
+// Configure validates and applies configuration from a string map.
+func (c *SlackConnector) Configure(config map[string]string) error {
+	token, ok := config["botToken"]
+	if !ok || token == "" {
+		return fmt.Errorf("slack: botToken is required")
+	}
+	c.config.BotToken = token
+
+	channels, ok := config["channels"]
+	if !ok || channels == "" {
+		return fmt.Errorf("slack: at least one channel is required")
+	}
+	c.config.Channels = strings.Split(channels, ",")
+	for i, ch := range c.config.Channels {
+		c.config.Channels[i] = strings.TrimSpace(ch)
+	}
+
+	if v, ok := config["includeThreads"]; ok {
+		c.config.IncludeThreads = v != "false"
+	}
+	if v, ok := config["includeFiles"]; ok {
+		c.config.IncludeFiles = v != "false"
+	}
+	if v, ok := config["maxFileSize"]; ok {
+		size, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("slack: invalid maxFileSize: %w", err)
+		}
+		c.config.MaxFileSize = size
+	}
+	if v, ok := config["oldestTimestamp"]; ok {
+		c.config.OldestTimestamp = v
+	}
+
+	return nil
+}
+
+// FetchAll performs a full sync of all configured channels.
+func (c *SlackConnector) FetchAll(ctx context.Context) (<-chan ConnectorDocument, <-chan error) {
+	return c.fetchMessages(ctx, "")
+}
+
+// FetchSince performs an incremental sync starting from the cursor value
+// (a Slack message timestamp).
+func (c *SlackConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-chan ConnectorDocument, <-chan error) {
+	return c.fetchMessages(ctx, cursor.Value)
+}
+
+// Start begins a continuous sync loop that polls at the configured
+// interval. The first iteration performs a full sync if no cursor
+// exists, then subsequent iterations sync incrementally.
+func (c *SlackConnector) Start(ctx context.Context) (<-chan ConnectorDocument, <-chan error) {
+	docCh := make(chan ConnectorDocument, 100)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(docCh)
+		defer close(errCh)
+
+		var lastCursor string
+		if c.config.OldestTimestamp != "" {
+			lastCursor = c.config.OldestTimestamp
+		}
+
+		ticker := time.NewTicker(c.config.PollInterval)
+		defer ticker.Stop()
+
+		// Run once immediately, then on each tick.
+		for {
+			docs, errs := c.fetchMessages(ctx, lastCursor)
+			var latestTS string
+
+			for doc := range docs {
+				ts, tsOK := doc.Metadata["ts"]
+				if tsOK && ts > latestTS {
+					latestTS = ts
+				}
+				select {
+				case docCh <- doc:
+				case <-ctx.Done():
+					return
+				}
+			}
+
+			if err, ok := <-errs; ok && err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+			}
+
+			if latestTS != "" {
+				lastCursor = latestTS
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.stopCh:
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	return docCh, errCh
+}
+
+// Stop gracefully stops the continuous sync loop.
+func (c *SlackConnector) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.stopped {
+		c.stopped = true
+		close(c.stopCh)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal: message fetching
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) fetchMessages(ctx context.Context, oldest string) (<-chan ConnectorDocument, <-chan error) {
+	docCh := make(chan ConnectorDocument, 100)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(docCh)
+		defer close(errCh)
+
+		for _, channelID := range c.config.Channels {
+			if err := c.fetchChannelMessages(ctx, channelID, oldest, docCh); err != nil {
+				select {
+				case errCh <- fmt.Errorf("slack: channel %s: %w", channelID, err):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	return docCh, errCh
+}
+
+func (c *SlackConnector) fetchChannelMessages(
+	ctx context.Context,
+	channelID string,
+	oldest string,
+	docCh chan<- ConnectorDocument,
+) error {
+	cursor := ""
+	for {
+		if err := c.rateLimiter.Acquire(ctx, 1); err != nil {
+			return err
+		}
+
+		resp, err := c.callConversationsHistory(ctx, channelID, oldest, cursor)
+		if err != nil {
+			return fmt.Errorf("conversations.history: %w", err)
+		}
+
+		for _, msg := range resp.Messages {
+			doc := c.messageToDocument(channelID, msg)
+			select {
+			case docCh <- doc:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			// Fetch thread replies if enabled and the message is a thread parent.
+			if c.config.IncludeThreads && msg.ReplyCount > 0 && msg.ThreadTS != "" {
+				threadDoc, err := c.fetchThread(ctx, channelID, msg)
+				if err != nil {
+					c.logger.Warn("slack: failed to fetch thread",
+						"channel", channelID,
+						"thread_ts", msg.ThreadTS,
+						"error", err,
+					)
+					continue
+				}
+				select {
+				case docCh <- threadDoc:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+
+			// Fetch file attachments if enabled.
+			if c.config.IncludeFiles && len(msg.Files) > 0 {
+				for _, file := range msg.Files {
+					if file.Size > c.config.MaxFileSize {
+						c.logger.Warn("slack: skipping file exceeding size limit",
+							"file_id", file.ID,
+							"file_name", file.Name,
+							"size", file.Size,
+							"max_size", c.config.MaxFileSize,
+						)
+						continue
+					}
+					fileDoc, err := c.downloadFile(ctx, channelID, file)
+					if err != nil {
+						c.logger.Warn("slack: failed to download file",
+							"file_id", file.ID,
+							"error", err,
+						)
+						continue
+					}
+					select {
+					case docCh <- fileDoc:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+		}
+
+		if resp.ResponseMetadata.NextCursor == "" {
+			break
+		}
+		cursor = resp.ResponseMetadata.NextCursor
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal: thread fetching
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) fetchThread(
+	ctx context.Context,
+	channelID string,
+	parent slackMessage,
+) (ConnectorDocument, error) {
+	var allReplies []slackMessage
+	cursor := ""
+
+	for {
+		if err := c.rateLimiter.Acquire(ctx, 1); err != nil {
+			return ConnectorDocument{}, err
+		}
+
+		resp, err := c.callConversationsReplies(ctx, channelID, parent.ThreadTS, cursor)
+		if err != nil {
+			return ConnectorDocument{}, fmt.Errorf("conversations.replies: %w", err)
+		}
+
+		allReplies = append(allReplies, resp.Messages...)
+
+		if resp.ResponseMetadata.NextCursor == "" {
+			break
+		}
+		cursor = resp.ResponseMetadata.NextCursor
+	}
+
+	content := c.buildThreadDocument(parent, allReplies)
+	ts := parseSlackTimestamp(parent.TS)
+
+	return ConnectorDocument{
+		ExternalID: fmt.Sprintf("%s:thread:%s", channelID, parent.ThreadTS),
+		Content:    []byte(content),
+		MIME:       "text/markdown",
+		Title:      fmt.Sprintf("Thread in %s", channelID),
+		Metadata: map[string]string{
+			"channel":     channelID,
+			"user":        parent.User,
+			"ts":          parent.TS,
+			"thread_ts":   parent.ThreadTS,
+			"reply_count": strconv.Itoa(parent.ReplyCount),
+			"source":      "slack",
+			"type":        "thread",
+		},
+		ModifiedAt: ts,
+	}, nil
+}
+
+func (c *SlackConnector) buildThreadDocument(parent slackMessage, replies []slackMessage) string {
+	var sb strings.Builder
+
+	parentUser := c.resolveUserName(parent.User)
+	parentTS := parseSlackTimestamp(parent.TS)
+	sb.WriteString("## Thread: ")
+	sb.WriteString(ConvertMrkdwn(parent.Text))
+	sb.WriteString("\n\n")
+	sb.WriteString(fmt.Sprintf("**%s** (%s):\n", parentUser, parentTS.Format("2006-01-02 15:04")))
+	sb.WriteString(ConvertMrkdwn(parent.Text))
+	sb.WriteString("\n\n")
+
+	for _, reply := range replies {
+		// Skip the parent message itself (Slack includes it in replies).
+		if reply.TS == parent.TS {
+			continue
+		}
+		replyUser := c.resolveUserName(reply.User)
+		ts := parseSlackTimestamp(reply.TS)
+		sb.WriteString(fmt.Sprintf("**%s** (%s):\n", replyUser, ts.Format("2006-01-02 15:04")))
+		sb.WriteString(ConvertMrkdwn(reply.Text))
+		sb.WriteString("\n\n")
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+// ---------------------------------------------------------------------------
+// Internal: file download
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) downloadFile(
+	ctx context.Context,
+	channelID string,
+	file slackFile,
+) (ConnectorDocument, error) {
+	if err := c.rateLimiter.Acquire(ctx, 1); err != nil {
+		return ConnectorDocument{}, err
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, file.URLPrivateDownload, nil)
+	if err != nil {
+		return ConnectorDocument{}, fmt.Errorf("create file request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return ConnectorDocument{}, fmt.Errorf("download file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ConnectorDocument{}, fmt.Errorf("download file: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.config.MaxFileSize+1))
+	if err != nil {
+		return ConnectorDocument{}, fmt.Errorf("read file body: %w", err)
+	}
+	if int64(len(body)) > c.config.MaxFileSize {
+		return ConnectorDocument{}, fmt.Errorf("file %s exceeds maximum size of %d bytes", file.Name, c.config.MaxFileSize)
+	}
+
+	return ConnectorDocument{
+		ExternalID: fmt.Sprintf("%s:file:%s", channelID, file.ID),
+		Content:    body,
+		MIME:       file.MIMEType,
+		Title:      file.Name,
+		Metadata: map[string]string{
+			"channel":   channelID,
+			"file_id":   file.ID,
+			"filename":  file.Name,
+			"filetype":  file.MIMEType,
+			"file_size": strconv.FormatInt(file.Size, 10),
+			"source":    "slack",
+			"type":      "file",
+		},
+		ModifiedAt: time.Now(),
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal: Slack API calls
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) callConversationsHistory(
+	ctx context.Context,
+	channelID string,
+	oldest string,
+	cursor string,
+) (slackResponse, error) {
+	params := url.Values{
+		"channel": {channelID},
+		"limit":   {"200"},
+	}
+	if oldest != "" {
+		params.Set("oldest", oldest)
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	return c.callSlackAPI(ctx, "https://slack.com/api/conversations.history", params)
+}
+
+func (c *SlackConnector) callConversationsReplies(
+	ctx context.Context,
+	channelID string,
+	threadTS string,
+	cursor string,
+) (slackResponse, error) {
+	params := url.Values{
+		"channel": {channelID},
+		"ts":      {threadTS},
+		"limit":   {"200"},
+	}
+	if cursor != "" {
+		params.Set("cursor", cursor)
+	}
+
+	return c.callSlackAPI(ctx, "https://slack.com/api/conversations.replies", params)
+}
+
+func (c *SlackConnector) callSlackAPI(
+	ctx context.Context,
+	endpoint string,
+	params url.Values,
+) (slackResponse, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	reqURL := endpoint + "?" + params.Encode()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return slackResponse{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return slackResponse{}, fmt.Errorf("http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Handle rate limiting (HTTP 429).
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := resp.Header.Get("Retry-After")
+		waitSecs, parseErr := strconv.Atoi(retryAfter)
+		if parseErr != nil || waitSecs <= 0 {
+			waitSecs = 5
+		}
+		select {
+		case <-ctx.Done():
+			return slackResponse{}, ctx.Err()
+		case <-time.After(time.Duration(waitSecs) * time.Second):
+		}
+		// Retry once after waiting.
+		return c.callSlackAPI(ctx, endpoint, params)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return slackResponse{}, fmt.Errorf("slack API returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10 MB limit
+	if err != nil {
+		return slackResponse{}, fmt.Errorf("read response: %w", err)
+	}
+
+	var result slackResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return slackResponse{}, fmt.Errorf("decode response: %w", err)
+	}
+
+	if !result.OK {
+		return slackResponse{}, fmt.Errorf("slack API error: %s", result.Error)
+	}
+
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal: user resolution
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) resolveUserName(userID string) string {
+	if userID == "" {
+		return "unknown"
+	}
+
+	c.userMu.RLock()
+	name, ok := c.userCache[userID]
+	c.userMu.RUnlock()
+	if ok {
+		return name
+	}
+
+	// Attempt to fetch the user name via users.info.
+	resolved := c.fetchUserName(userID)
+
+	c.userMu.Lock()
+	c.userCache[userID] = resolved
+	c.userMu.Unlock()
+
+	return resolved
+}
+
+func (c *SlackConnector) fetchUserName(userID string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	params := url.Values{"user": {userID}}
+	reqURL := "https://slack.com/api/users.info?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return userID
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return userID
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return userID
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	if err != nil {
+		return userID
+	}
+
+	var result slackUserResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return userID
+	}
+
+	if !result.OK {
+		return userID
+	}
+
+	if result.User.RealName != "" {
+		return result.User.RealName
+	}
+	if result.User.Name != "" {
+		return result.User.Name
+	}
+	return userID
+}
+
+// ---------------------------------------------------------------------------
+// Internal: message -> document conversion
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) messageToDocument(channelID string, msg slackMessage) ConnectorDocument {
+	ts := parseSlackTimestamp(msg.TS)
+	content := ConvertMrkdwn(msg.Text)
+
+	metadata := map[string]string{
+		"channel": channelID,
+		"user":    msg.User,
+		"ts":      msg.TS,
+		"source":  "slack",
+		"type":    "message",
+	}
+	if msg.ThreadTS != "" {
+		metadata["thread_ts"] = msg.ThreadTS
+	}
+	if msg.ReplyCount > 0 {
+		metadata["reply_count"] = strconv.Itoa(msg.ReplyCount)
+	}
+
+	return ConnectorDocument{
+		ExternalID: fmt.Sprintf("%s:%s", channelID, msg.TS),
+		Content:    []byte(content),
+		MIME:       "text/markdown",
+		Title:      fmt.Sprintf("Message in %s", channelID),
+		Metadata:   metadata,
+		ModifiedAt: ts,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// parseSlackTimestamp converts a Slack epoch timestamp string (e.g.
+// "1234567890.123456") to a time.Time.
+func parseSlackTimestamp(ts string) time.Time {
+	parts := strings.SplitN(ts, ".", 2)
+	secs, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	var micros int64
+	if len(parts) > 1 {
+		micros, _ = strconv.ParseInt(parts[1], 10, 64)
+	}
+	return time.Unix(secs, micros*1000)
+}

--- a/go/connector/slack_helpers.go
+++ b/go/connector/slack_helpers.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// User resolution
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) resolveUserName(userID string) string {
+	if userID == "" {
+		return "unknown"
+	}
+
+	c.userMu.RLock()
+	name, ok := c.userCache[userID]
+	c.userMu.RUnlock()
+	if ok {
+		return name
+	}
+
+	// Attempt to fetch the user name via users.info.
+	resolved := c.fetchUserName(userID)
+
+	c.userMu.Lock()
+	c.userCache[userID] = resolved
+	c.userMu.Unlock()
+
+	return resolved
+}
+
+func (c *SlackConnector) fetchUserName(userID string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	reqURL := "https://slack.com/api/users.info?user=" + userID
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return userID
+	}
+	req.Header.Set("Authorization", "Bearer "+c.config.BotToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return userID
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return userID
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	if err != nil {
+		return userID
+	}
+
+	var result slackUserResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return userID
+	}
+
+	if !result.OK {
+		return userID
+	}
+
+	if result.User.RealName != "" {
+		return result.User.RealName
+	}
+	if result.User.Name != "" {
+		return result.User.Name
+	}
+	return userID
+}
+
+// ---------------------------------------------------------------------------
+// Message -> document conversion
+// ---------------------------------------------------------------------------
+
+func (c *SlackConnector) messageToDocument(channelID string, msg slackMessage) ConnectorDocument {
+	ts := parseSlackTimestamp(msg.TS)
+	content := ConvertMrkdwn(msg.Text)
+
+	metadata := map[string]string{
+		"channel": channelID,
+		"user":    msg.User,
+		"ts":      msg.TS,
+		"source":  "slack",
+		"type":    "message",
+	}
+	if msg.ThreadTS != "" {
+		metadata["thread_ts"] = msg.ThreadTS
+	}
+	if msg.ReplyCount > 0 {
+		metadata["reply_count"] = strconv.Itoa(msg.ReplyCount)
+	}
+
+	return ConnectorDocument{
+		ExternalID: fmt.Sprintf("%s:%s", channelID, msg.TS),
+		Content:    []byte(content),
+		MIME:       "text/markdown",
+		Title:      fmt.Sprintf("Message in %s", channelID),
+		Metadata:   metadata,
+		ModifiedAt: ts,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// parseSlackTimestamp converts a Slack epoch timestamp string (e.g.
+// "1234567890.123456") to a time.Time.
+func parseSlackTimestamp(ts string) time.Time {
+	parts := strings.SplitN(ts, ".", 2)
+	secs, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	var micros int64
+	if len(parts) > 1 {
+		micros, _ = strconv.ParseInt(parts[1], 10, 64)
+	}
+	return time.Unix(secs, micros*1000)
+}
+
+// formatTimestamp formats a time.Time for display in thread documents
+// using UTC for consistency across environments.
+func formatTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02 15:04")
+}

--- a/go/connector/slack_helpers.go
+++ b/go/connector/slack_helpers.go
@@ -55,7 +55,7 @@ func (c *SlackConnector) fetchUserName(userID string) string {
 	if err != nil {
 		return userID
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return userID

--- a/go/connector/slack_helpers_test.go
+++ b/go/connector/slack_helpers_test.go
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Tests: parseSlackTimestamp
+// ---------------------------------------------------------------------------
+
+func TestParseSlackTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"1700000001.123456", 1700000001},
+		{"1700000000.000000", 1700000000},
+		{"0.0", 0},
+	}
+
+	for _, tt := range tests {
+		ts := parseSlackTimestamp(tt.input)
+		if ts.Unix() != tt.want {
+			t.Errorf("parseSlackTimestamp(%q) = %d, want %d", tt.input, ts.Unix(), tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: formatTimestamp uses UTC
+// ---------------------------------------------------------------------------
+
+func TestFormatTimestamp_UTC(t *testing.T) {
+	ts := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+	result := formatTimestamp(ts)
+	if result != "2026-05-01 14:30" {
+		t.Errorf("formatTimestamp() = %q, want %q", result, "2026-05-01 14:30")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Cursor update tracking
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_CursorTracking(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "First", TS: "100.000000"},
+					{Type: "message", User: "U001", Text: "Second", TS: "200.000000"},
+					{Type: "message", User: "U001", Text: "Third", TS: "300.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var latestTS string
+	for doc := range docs {
+		ts := doc.Metadata["ts"]
+		if ts > latestTS {
+			latestTS = ts
+		}
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if latestTS != "300.000000" {
+		t.Errorf("expected latest cursor to be 300.000000, got %s", latestTS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Multiple channels
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_MultipleChannels(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			channel := r.URL.Query().Get("channel")
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: fmt.Sprintf("Message in %s", channel), TS: "1700000001.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL, "C001", "C002", "C003")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 documents (one per channel), got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Connector interface compliance
+// ---------------------------------------------------------------------------
+
+func TestSlackConnector_ImplementsConnector(t *testing.T) {
+	var _ Connector = (*SlackConnector)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: MaxFileSize configuration via Configure
+// ---------------------------------------------------------------------------
+
+func TestConfigure_MaxFileSizeParsing(t *testing.T) {
+	c := NewSlackConnector(SlackConnectorConfig{})
+	err := c.Configure(map[string]any{
+		"botToken":    "xoxb-test",
+		"channels":    "C123",
+		"maxFileSize": "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid maxFileSize")
+	}
+
+	err = c.Configure(map[string]any{
+		"botToken":    "xoxb-test",
+		"channels":    "C123",
+		"maxFileSize": strconv.FormatInt(100*1024*1024, 10),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.config.MaxFileSize != 100*1024*1024 {
+		t.Errorf("expected maxFileSize=100MB, got %d", c.config.MaxFileSize)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: SSRF validation
+// ---------------------------------------------------------------------------
+
+func TestValidateDownloadURL_BlocksPrivateIPs(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		blocked bool
+	}{
+		{"external HTTPS", "https://files.slack.com/files/F001", false},
+		{"ftp scheme blocked", "ftp://files.slack.com/files/F001", true},
+		{"no scheme", "://bad", true},
+		{"empty hostname", "http:///path", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDownloadURL(tt.url)
+			if tt.blocked && err == nil {
+				t.Errorf("expected URL to be blocked: %s", tt.url)
+			}
+			if !tt.blocked && err != nil {
+				t.Errorf("expected URL to be allowed, got error: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Rate limit retry exhaustion
+// ---------------------------------------------------------------------------
+
+func TestCallSlackAPI_ExhaustsRetries(t *testing.T) {
+	callCount := 0
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, _ *http.Request) {
+			callCount++
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	// Use a short context timeout to prevent slow exponential backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	for range docs {
+	}
+
+	err, ok := <-errs
+	if !ok || err == nil {
+		t.Fatal("expected an error after exhausting retries")
+	}
+	// Accept either "rate limited" (all retries exhausted) or context deadline exceeded.
+	errMsg := err.Error()
+	hasExpectedError := strings.Contains(errMsg, "rate limited") || strings.Contains(errMsg, "context deadline exceeded")
+	if !hasExpectedError {
+		t.Errorf("expected rate limited or deadline error, got: %v", err)
+	}
+	if callCount < 2 {
+		t.Errorf("expected multiple API calls, got %d", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Thread document includes parent message
+// ---------------------------------------------------------------------------
+
+func TestBuildThreadDocument_IncludesParent(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{
+						Type:       "message",
+						User:       "U001",
+						Text:       "Thread parent",
+						TS:         "1700000001.000000",
+						ThreadTS:   "1700000001.000000",
+						ReplyCount: 1,
+					},
+				},
+			})
+		},
+		"conversations.replies": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "Thread parent", TS: "1700000001.000000"},
+					{Type: "message", User: "U002", Text: "A reply", TS: "1700000002.000000"},
+				},
+			})
+		},
+		"users.info": func(w http.ResponseWriter, r *http.Request) {
+			userID := r.URL.Query().Get("user")
+			names := map[string]string{"U001": "Alice", "U002": "Bob"}
+			name := names[userID]
+			if name == "" {
+				name = userID
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(slackUserResponse{
+				OK:   true,
+				User: slackUser{RealName: name},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) < 2 {
+		t.Fatalf("expected at least 2 documents, got %d", len(collected))
+	}
+
+	threadDoc := collected[1]
+	content := string(threadDoc.Content)
+
+	// Verify parent message appears in the body (not just the header).
+	if !strings.Contains(content, "**Alice**") {
+		t.Errorf("thread doc should contain parent user name Alice: %s", content)
+	}
+	if !strings.Contains(content, "**Bob**") {
+		t.Errorf("thread doc should contain reply user name Bob: %s", content)
+	}
+
+	// Count occurrences of "Thread parent" -- should appear in header AND body.
+	count := strings.Count(content, "Thread parent")
+	if count < 2 {
+		t.Errorf("expected 'Thread parent' to appear at least twice (header + body), got %d: %s", count, content)
+	}
+}

--- a/go/connector/slack_test.go
+++ b/go/connector/slack_test.go
@@ -1,0 +1,710 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Mock HTTP server helpers
+// ---------------------------------------------------------------------------
+
+// mockSlackServer creates a test server that responds to Slack API
+// endpoints with pre-configured responses. Handlers are keyed by
+// method path (e.g. "conversations.history").
+func mockSlackServer(handlers map[string]http.HandlerFunc) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for path, handler := range handlers {
+			if strings.HasSuffix(r.URL.Path, path) {
+				handler(w, r)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func jsonResponse(w http.ResponseWriter, data slackResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(data)
+}
+
+func newTestConnector(serverURL string) *SlackConnector {
+	return NewSlackConnector(SlackConnectorConfig{
+		BotToken:       "xoxb-test-token",
+		Channels:       []string{"C123ABC"},
+		IncludeThreads: true,
+		IncludeFiles:   true,
+		MaxFileSize:    50 * 1024 * 1024,
+		HTTPClient:     &http.Client{Timeout: 5 * time.Second},
+	})
+}
+
+// replaceSlackBaseURL patches API calls to use the test server.
+// Because the connector hard-codes slack.com URLs, we use a custom
+// HTTPDoer that rewrites the host.
+type rewritingClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+func (rc *rewritingClient) Do(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	req.URL.Host = strings.TrimPrefix(rc.baseURL, "http://")
+	return rc.client.Do(req)
+}
+
+func newTestConnectorWithServer(serverURL string, channels ...string) *SlackConnector {
+	if len(channels) == 0 {
+		channels = []string{"C123ABC"}
+	}
+	return NewSlackConnector(SlackConnectorConfig{
+		BotToken:       "xoxb-test-token",
+		Channels:       channels,
+		IncludeThreads: true,
+		IncludeFiles:   true,
+		MaxFileSize:    50 * 1024 * 1024,
+		HTTPClient:     &rewritingClient{baseURL: serverURL, client: &http.Client{Timeout: 5 * time.Second}},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Name and Configure
+// ---------------------------------------------------------------------------
+
+func TestSlackConnector_Name(t *testing.T) {
+	c := NewSlackConnector(SlackConnectorConfig{})
+	if c.Name() != "slack" {
+		t.Fatalf("expected name 'slack', got %q", c.Name())
+	}
+}
+
+func TestConfigure_ValidatesRequiredFields(t *testing.T) {
+	c := NewSlackConnector(SlackConnectorConfig{})
+
+	// Missing botToken.
+	err := c.Configure(map[string]string{"channels": "C123"})
+	if err == nil || !strings.Contains(err.Error(), "botToken is required") {
+		t.Fatalf("expected botToken validation error, got %v", err)
+	}
+
+	// Missing channels.
+	err = c.Configure(map[string]string{"botToken": "xoxb-123"})
+	if err == nil || !strings.Contains(err.Error(), "at least one channel") {
+		t.Fatalf("expected channels validation error, got %v", err)
+	}
+
+	// Valid config.
+	err = c.Configure(map[string]string{
+		"botToken": "xoxb-123",
+		"channels": "C123,C456",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: FetchAll
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_SingleChannelMessages(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "Hello world", TS: "1700000001.000000"},
+					{Type: "message", User: "U002", Text: "Good morning", TS: "1700000002.000000"},
+					{Type: "message", User: "U003", Text: "How are you?", TS: "1700000003.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 documents, got %d", len(collected))
+	}
+
+	// Verify first message.
+	first := collected[0]
+	if first.ExternalID != "C123ABC:1700000001.000000" {
+		t.Errorf("unexpected externalID: %s", first.ExternalID)
+	}
+	if string(first.Content) != "Hello world" {
+		t.Errorf("unexpected content: %s", string(first.Content))
+	}
+	if first.Metadata["source"] != "slack" {
+		t.Errorf("expected source=slack, got %s", first.Metadata["source"])
+	}
+}
+
+func TestFetchAll_PaginatedMessages(t *testing.T) {
+	callCount := 0
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			cursor := r.URL.Query().Get("cursor")
+
+			switch {
+			case cursor == "" && callCount == 1:
+				jsonResponse(w, slackResponse{
+					OK: true,
+					Messages: []slackMessage{
+						{Type: "message", User: "U001", Text: "Page 1 msg 1", TS: "1700000001.000000"},
+						{Type: "message", User: "U001", Text: "Page 1 msg 2", TS: "1700000002.000000"},
+					},
+					ResponseMetadata: slackRespMeta{NextCursor: "cursor_page2"},
+				})
+			default:
+				jsonResponse(w, slackResponse{
+					OK: true,
+					Messages: []slackMessage{
+						{Type: "message", User: "U002", Text: "Page 2 msg 1", TS: "1700000003.000000"},
+						{Type: "message", User: "U002", Text: "Page 2 msg 2", TS: "1700000004.000000"},
+					},
+				})
+			}
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 4 {
+		t.Fatalf("expected 4 documents from 2 pages, got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Thread reconstruction
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_ThreadReconstruction(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{
+						Type:       "message",
+						User:       "U001",
+						Text:       "Thread parent",
+						TS:         "1700000001.000000",
+						ThreadTS:   "1700000001.000000",
+						ReplyCount: 2,
+					},
+				},
+			})
+		},
+		"conversations.replies": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "Thread parent", TS: "1700000001.000000"},
+					{Type: "message", User: "U002", Text: "Reply one", TS: "1700000002.000000"},
+					{Type: "message", User: "U003", Text: "Reply two", TS: "1700000003.000000"},
+				},
+			})
+		},
+		"users.info": func(w http.ResponseWriter, r *http.Request) {
+			userID := r.URL.Query().Get("user")
+			names := map[string]string{"U001": "Alice", "U002": "Bob", "U003": "Charlie"}
+			name := names[userID]
+			if name == "" {
+				name = userID
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(slackUserResponse{
+				OK:   true,
+				User: slackUser{RealName: name},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have: 1 message doc + 1 thread doc = 2.
+	if len(collected) != 2 {
+		t.Fatalf("expected 2 documents (message + thread), got %d", len(collected))
+	}
+
+	threadDoc := collected[1]
+	if threadDoc.Metadata["type"] != "thread" {
+		t.Errorf("expected type=thread, got %s", threadDoc.Metadata["type"])
+	}
+	content := string(threadDoc.Content)
+	if !strings.Contains(content, "## Thread: Thread parent") {
+		t.Errorf("thread doc missing parent text: %s", content)
+	}
+	if !strings.Contains(content, "Reply one") {
+		t.Errorf("thread doc missing reply one: %s", content)
+	}
+	if !strings.Contains(content, "Reply two") {
+		t.Errorf("thread doc missing reply two: %s", content)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: File attachment download
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_FileAttachmentDownload(t *testing.T) {
+	fileContent := []byte("file content bytes")
+
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{
+						Type: "message",
+						User: "U001",
+						Text: "Check this file",
+						TS:   "1700000001.000000",
+						Files: []slackFile{
+							{
+								ID:                 "F001",
+								Name:               "report.pdf",
+								MIMEType:           "application/pdf",
+								Size:               int64(len(fileContent)),
+								URLPrivateDownload: "http://localhost/files/F001",
+							},
+						},
+					},
+				},
+			})
+		},
+		"/files/F001": func(w http.ResponseWriter, r *http.Request) {
+			// Verify auth header.
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer xoxb-test-token" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(fileContent)
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have: 1 message + 1 file = 2.
+	if len(collected) != 2 {
+		t.Fatalf("expected 2 documents (message + file), got %d", len(collected))
+	}
+
+	fileDoc := collected[1]
+	if fileDoc.ExternalID != "C123ABC:file:F001" {
+		t.Errorf("unexpected file externalID: %s", fileDoc.ExternalID)
+	}
+	if string(fileDoc.Content) != string(fileContent) {
+		t.Errorf("unexpected file content: %s", string(fileDoc.Content))
+	}
+	if fileDoc.MIME != "application/pdf" {
+		t.Errorf("unexpected MIME: %s", fileDoc.MIME)
+	}
+}
+
+func TestFetchAll_FileTooLargeSkipped(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{
+						Type: "message",
+						User: "U001",
+						Text: "Big file",
+						TS:   "1700000001.000000",
+						Files: []slackFile{
+							{
+								ID:                 "F002",
+								Name:               "huge.zip",
+								MIMEType:           "application/zip",
+								Size:               100 * 1024 * 1024, // 100 MB > 50 MB limit
+								URLPrivateDownload: "http://localhost/files/F002",
+							},
+						},
+					},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only the message, no file (skipped due to size).
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 document (message only, file skipped), got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Incremental sync with cursor
+// ---------------------------------------------------------------------------
+
+func TestFetchSince_IncrementalSync(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			oldest := r.URL.Query().Get("oldest")
+			if oldest != "1700000002.000000" {
+				t.Errorf("expected oldest=1700000002.000000, got %s", oldest)
+			}
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "New message", TS: "1700000003.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cursor := SyncCursor{Value: "1700000002.000000", UpdatedAt: time.Now()}
+	docs, errs := c.FetchSince(ctx, cursor)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Rate limit 429 handling
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_RateLimit429Handling(t *testing.T) {
+	callCount := 0
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "After retry", TS: "1700000001.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 document after retry, got %d", len(collected))
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 API calls (initial + retry), got %d", callCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Empty channel
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_EmptyChannel(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK:       true,
+				Messages: []slackMessage{},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 0 {
+		t.Fatalf("expected 0 documents for empty channel, got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Slack API error
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_SlackAPIError(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK:    false,
+				Error: "channel_not_found",
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	// Drain docs channel.
+	for range docs {
+	}
+
+	err, ok := <-errs
+	if !ok || err == nil {
+		t.Fatal("expected an error for API failure")
+	}
+	if !strings.Contains(err.Error(), "channel_not_found") {
+		t.Errorf("error should mention channel_not_found: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Stop
+// ---------------------------------------------------------------------------
+
+func TestStop_Idempotent(t *testing.T) {
+	c := NewSlackConnector(SlackConnectorConfig{BotToken: "xoxb-test"})
+	if err := c.Stop(); err != nil {
+		t.Fatalf("first stop failed: %v", err)
+	}
+	if err := c.Stop(); err != nil {
+		t.Fatalf("second stop should be idempotent: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: parseSlackTimestamp
+// ---------------------------------------------------------------------------
+
+func TestParseSlackTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"1700000001.123456", 1700000001},
+		{"1700000000.000000", 1700000000},
+		{"0.0", 0},
+	}
+
+	for _, tt := range tests {
+		ts := parseSlackTimestamp(tt.input)
+		if ts.Unix() != tt.want {
+			t.Errorf("parseSlackTimestamp(%q) = %d, want %d", tt.input, ts.Unix(), tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Cursor update tracking
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_CursorTracking(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: "First", TS: "100.000000"},
+					{Type: "message", User: "U001", Text: "Second", TS: "200.000000"},
+					{Type: "message", User: "U001", Text: "Third", TS: "300.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var latestTS string
+	for doc := range docs {
+		ts := doc.Metadata["ts"]
+		if ts > latestTS {
+			latestTS = ts
+		}
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if latestTS != "300.000000" {
+		t.Errorf("expected latest cursor to be 300.000000, got %s", latestTS)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Multiple channels
+// ---------------------------------------------------------------------------
+
+func TestFetchAll_MultipleChannels(t *testing.T) {
+	server := mockSlackServer(map[string]http.HandlerFunc{
+		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
+			channel := r.URL.Query().Get("channel")
+			jsonResponse(w, slackResponse{
+				OK: true,
+				Messages: []slackMessage{
+					{Type: "message", User: "U001", Text: fmt.Sprintf("Message in %s", channel), TS: "1700000001.000000"},
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	c := newTestConnectorWithServer(server.URL, "C001", "C002", "C003")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	docs, errs := c.FetchAll(ctx)
+	var collected []ConnectorDocument
+	for doc := range docs {
+		collected = append(collected, doc)
+	}
+	if err, ok := <-errs; ok && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 documents (one per channel), got %d", len(collected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Connector interface compliance
+// ---------------------------------------------------------------------------
+
+func TestSlackConnector_ImplementsConnector(t *testing.T) {
+	var _ Connector = (*SlackConnector)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: MaxFileSize configuration via Configure
+// ---------------------------------------------------------------------------
+
+func TestConfigure_MaxFileSizeParsing(t *testing.T) {
+	c := NewSlackConnector(SlackConnectorConfig{})
+	err := c.Configure(map[string]string{
+		"botToken":    "xoxb-test",
+		"channels":    "C123",
+		"maxFileSize": "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid maxFileSize")
+	}
+
+	err = c.Configure(map[string]string{
+		"botToken":    "xoxb-test",
+		"channels":    "C123",
+		"maxFileSize": strconv.FormatInt(100*1024*1024, 10),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.config.MaxFileSize != 100*1024*1024 {
+		t.Errorf("expected maxFileSize=100MB, got %d", c.config.MaxFileSize)
+	}
+}

--- a/go/connector/slack_test.go
+++ b/go/connector/slack_test.go
@@ -5,10 +5,8 @@ package connector
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,17 +36,6 @@ func jsonResponse(w http.ResponseWriter, data slackResponse) {
 	_ = json.NewEncoder(w).Encode(data)
 }
 
-func newTestConnector(serverURL string) *SlackConnector {
-	return NewSlackConnector(SlackConnectorConfig{
-		BotToken:       "xoxb-test-token",
-		Channels:       []string{"C123ABC"},
-		IncludeThreads: true,
-		IncludeFiles:   true,
-		MaxFileSize:    50 * 1024 * 1024,
-		HTTPClient:     &http.Client{Timeout: 5 * time.Second},
-	})
-}
-
 // replaceSlackBaseURL patches API calls to use the test server.
 // Because the connector hard-codes slack.com URLs, we use a custom
 // HTTPDoer that rewrites the host.
@@ -67,7 +54,7 @@ func newTestConnectorWithServer(serverURL string, channels ...string) *SlackConn
 	if len(channels) == 0 {
 		channels = []string{"C123ABC"}
 	}
-	return NewSlackConnector(SlackConnectorConfig{
+	c := NewSlackConnector(SlackConnectorConfig{
 		BotToken:       "xoxb-test-token",
 		Channels:       channels,
 		IncludeThreads: true,
@@ -75,6 +62,9 @@ func newTestConnectorWithServer(serverURL string, channels ...string) *SlackConn
 		MaxFileSize:    50 * 1024 * 1024,
 		HTTPClient:     &rewritingClient{baseURL: serverURL, client: &http.Client{Timeout: 5 * time.Second}},
 	})
+	// Disable SSRF validation in tests -- test servers use localhost.
+	c.urlValidator = func(_ string) error { return nil }
+	return c
 }
 
 // ---------------------------------------------------------------------------
@@ -92,19 +82,19 @@ func TestConfigure_ValidatesRequiredFields(t *testing.T) {
 	c := NewSlackConnector(SlackConnectorConfig{})
 
 	// Missing botToken.
-	err := c.Configure(map[string]string{"channels": "C123"})
+	err := c.Configure(map[string]any{"channels": "C123"})
 	if err == nil || !strings.Contains(err.Error(), "botToken is required") {
 		t.Fatalf("expected botToken validation error, got %v", err)
 	}
 
 	// Missing channels.
-	err = c.Configure(map[string]string{"botToken": "xoxb-123"})
+	err = c.Configure(map[string]any{"botToken": "xoxb-123"})
 	if err == nil || !strings.Contains(err.Error(), "at least one channel") {
 		t.Fatalf("expected channels validation error, got %v", err)
 	}
 
 	// Valid config.
-	err = c.Configure(map[string]string{
+	err = c.Configure(map[string]any{
 		"botToken": "xoxb-123",
 		"channels": "C123,C456",
 	})
@@ -575,136 +565,3 @@ func TestStop_Idempotent(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Tests: parseSlackTimestamp
-// ---------------------------------------------------------------------------
-
-func TestParseSlackTimestamp(t *testing.T) {
-	tests := []struct {
-		input string
-		want  int64
-	}{
-		{"1700000001.123456", 1700000001},
-		{"1700000000.000000", 1700000000},
-		{"0.0", 0},
-	}
-
-	for _, tt := range tests {
-		ts := parseSlackTimestamp(tt.input)
-		if ts.Unix() != tt.want {
-			t.Errorf("parseSlackTimestamp(%q) = %d, want %d", tt.input, ts.Unix(), tt.want)
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Tests: Cursor update tracking
-// ---------------------------------------------------------------------------
-
-func TestFetchAll_CursorTracking(t *testing.T) {
-	server := mockSlackServer(map[string]http.HandlerFunc{
-		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
-			jsonResponse(w, slackResponse{
-				OK: true,
-				Messages: []slackMessage{
-					{Type: "message", User: "U001", Text: "First", TS: "100.000000"},
-					{Type: "message", User: "U001", Text: "Second", TS: "200.000000"},
-					{Type: "message", User: "U001", Text: "Third", TS: "300.000000"},
-				},
-			})
-		},
-	})
-	defer server.Close()
-
-	c := newTestConnectorWithServer(server.URL)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	docs, errs := c.FetchAll(ctx)
-	var latestTS string
-	for doc := range docs {
-		ts := doc.Metadata["ts"]
-		if ts > latestTS {
-			latestTS = ts
-		}
-	}
-	if err, ok := <-errs; ok && err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if latestTS != "300.000000" {
-		t.Errorf("expected latest cursor to be 300.000000, got %s", latestTS)
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Tests: Multiple channels
-// ---------------------------------------------------------------------------
-
-func TestFetchAll_MultipleChannels(t *testing.T) {
-	server := mockSlackServer(map[string]http.HandlerFunc{
-		"conversations.history": func(w http.ResponseWriter, r *http.Request) {
-			channel := r.URL.Query().Get("channel")
-			jsonResponse(w, slackResponse{
-				OK: true,
-				Messages: []slackMessage{
-					{Type: "message", User: "U001", Text: fmt.Sprintf("Message in %s", channel), TS: "1700000001.000000"},
-				},
-			})
-		},
-	})
-	defer server.Close()
-
-	c := newTestConnectorWithServer(server.URL, "C001", "C002", "C003")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	docs, errs := c.FetchAll(ctx)
-	var collected []ConnectorDocument
-	for doc := range docs {
-		collected = append(collected, doc)
-	}
-	if err, ok := <-errs; ok && err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if len(collected) != 3 {
-		t.Fatalf("expected 3 documents (one per channel), got %d", len(collected))
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Tests: Connector interface compliance
-// ---------------------------------------------------------------------------
-
-func TestSlackConnector_ImplementsConnector(t *testing.T) {
-	var _ Connector = (*SlackConnector)(nil)
-}
-
-// ---------------------------------------------------------------------------
-// Tests: MaxFileSize configuration via Configure
-// ---------------------------------------------------------------------------
-
-func TestConfigure_MaxFileSizeParsing(t *testing.T) {
-	c := NewSlackConnector(SlackConnectorConfig{})
-	err := c.Configure(map[string]string{
-		"botToken":    "xoxb-test",
-		"channels":    "C123",
-		"maxFileSize": "invalid",
-	})
-	if err == nil {
-		t.Fatal("expected error for invalid maxFileSize")
-	}
-
-	err = c.Configure(map[string]string{
-		"botToken":    "xoxb-test",
-		"channels":    "C123",
-		"maxFileSize": strconv.FormatInt(100*1024*1024, 10),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if c.config.MaxFileSize != 100*1024*1024 {
-		t.Errorf("expected maxFileSize=100MB, got %d", c.config.MaxFileSize)
-	}
-}

--- a/go/connector/ssrf.go
+++ b/go/connector/ssrf.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+)
+
+// validateDownloadURL checks that a URL is safe to fetch by resolving
+// its hostname and verifying none of the resulting IPs belong to
+// private, loopback, link-local, or cloud-metadata address ranges.
+// This prevents SSRF attacks via crafted download URLs.
+func validateDownloadURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("slack: invalid download URL: %w", err)
+	}
+
+	scheme := parsed.Scheme
+	if scheme != "https" && scheme != "http" {
+		return fmt.Errorf("slack: blocked URL scheme %q (only http/https allowed)", scheme)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("slack: download URL has no hostname")
+	}
+
+	// Resolve the hostname to IP addresses.
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("slack: dns lookup for %s failed: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("slack: no addresses resolved for %s", host)
+	}
+
+	for _, ip := range ips {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("slack: request to private/internal network blocked for %s", host)
+		}
+	}
+
+	return nil
+}
+
+// isBlockedIP returns true when the IP belongs to a private, loopback,
+// link-local, or otherwise non-routable address range. Also blocks the
+// cloud metadata endpoint at 169.254.169.254.
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.Equal(net.IPv4(169, 254, 169, 254))
+}

--- a/go/connector/types.go
+++ b/go/connector/types.go
@@ -5,18 +5,35 @@
 // pipeline. Individual connectors (Slack, Google Drive, Notion, etc.)
 // implement the Connector interface defined here.
 //
-// This package is the dependency target for P5-1 (connector framework).
-// Concrete connectors live alongside the framework in the same package
-// and will be extracted to separate modules at integration time.
+// After merge, the following types are imported from the P5-1 connector
+// framework (go/connector/connector.go, sync.go, rate_limiter.go):
+//   - ConnectorConfig
+//   - ConnectorDocument
+//   - SyncCursor
+//   - Connector (interface)
+//   - ConnectorFactory
+//   - Registry, NewRegistry
+//   - RateLimiter, RateLimiterConfig, NewRateLimiter
+//
+// After merge, rate limiting should use ratelimit.Limiter from P3-4
+// (go/ratelimit/types.go) instead of the connector-local RateLimiter.
+//
+// This file re-declares the canonical types from P5-1 so the Slack
+// connector compiles in isolation. At integration time, delete this
+// file entirely and import from the framework package.
 package connector
 
 import (
 	"context"
+	"math"
+	"sync"
 	"time"
 )
 
 // ConnectorDocument represents a single document fetched from an
 // external service, ready to be fed into the ingestion pipeline.
+//
+// Canonical definition: P5-1 go/connector/connector.go
 type ConnectorDocument struct {
 	ExternalID string
 	Content    []byte
@@ -26,12 +43,15 @@ type ConnectorDocument struct {
 	Metadata   map[string]string
 	ModifiedAt time.Time
 	Checksum   string
+	Deleted    bool
 }
 
 // SyncCursor tracks the position of the last successful sync for a
 // connector. The Value field is opaque to the framework -- each
 // connector decides what to store (timestamp, cursor token, change
 // ID, etc.).
+//
+// Canonical definition: P5-1 go/connector/sync.go
 type SyncCursor struct {
 	Value     string
 	UpdatedAt time.Time
@@ -41,12 +61,14 @@ type SyncCursor struct {
 // Connector is the interface that all external-service connectors must
 // implement. It provides full sync, incremental sync, and continuous
 // polling capabilities.
+//
+// Canonical definition: P5-1 go/connector/connector.go
 type Connector interface {
 	// Name returns the connector identifier (e.g. "slack", "gdrive").
 	Name() string
 
 	// Configure validates and stores connector-specific configuration.
-	Configure(config map[string]string) error
+	Configure(config map[string]any) error
 
 	// FetchAll performs a full sync. Returns a channel of documents and
 	// a channel that will receive at most one error (or be closed on
@@ -58,20 +80,25 @@ type Connector interface {
 	FetchSince(ctx context.Context, cursor SyncCursor) (<-chan ConnectorDocument, <-chan error)
 
 	// Start begins a continuous sync loop that polls at the configured
-	// interval and sends documents to the returned channel.
-	Start(ctx context.Context) (<-chan ConnectorDocument, <-chan error)
+	// interval. Returns when the context is cancelled or Stop is called.
+	Start(ctx context.Context) error
 
 	// Stop gracefully stops the continuous sync loop.
 	Stop() error
 }
 
-// RateLimiter provides token-bucket-based rate limiting with
-// exponential backoff for HTTP API calls.
+// RateLimiter provides token-bucket-based rate limiting for HTTP API
+// calls. All methods are safe for concurrent use.
+//
+// Canonical definition: P5-1 go/connector/rate_limiter.go
+// After merge, connectors should use ratelimit.Limiter from P3-4
+// (go/ratelimit/types.go) instead of this inline implementation.
 type RateLimiter struct {
-	maxTokens    int
-	tokens       float64
-	refillRate   float64 // tokens per second
-	lastRefill   time.Time
+	mu         sync.Mutex
+	maxTokens  int
+	tokens     float64
+	refillRate float64 // tokens per second
+	lastRefill time.Time
 }
 
 // NewRateLimiter creates a rate limiter with the given maximum token
@@ -89,9 +116,11 @@ func NewRateLimiter(maxTokens int, refillRate float64) *RateLimiter {
 // Returns an error if the context is cancelled while waiting.
 func (rl *RateLimiter) Acquire(ctx context.Context, count int) error {
 	for {
+		rl.mu.Lock()
 		rl.refill()
 		if rl.tokens >= float64(count) {
 			rl.tokens -= float64(count)
+			rl.mu.Unlock()
 			return nil
 		}
 		deficit := float64(count) - rl.tokens
@@ -99,6 +128,8 @@ func (rl *RateLimiter) Acquire(ctx context.Context, count int) error {
 		if waitDuration < time.Millisecond {
 			waitDuration = time.Millisecond
 		}
+		rl.mu.Unlock()
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -110,9 +141,6 @@ func (rl *RateLimiter) Acquire(ctx context.Context, count int) error {
 func (rl *RateLimiter) refill() {
 	now := time.Now()
 	elapsed := now.Sub(rl.lastRefill).Seconds()
-	rl.tokens += elapsed * rl.refillRate
-	if rl.tokens > float64(rl.maxTokens) {
-		rl.tokens = float64(rl.maxTokens)
-	}
+	rl.tokens = math.Min(float64(rl.maxTokens), rl.tokens+elapsed*rl.refillRate)
 	rl.lastRefill = now
 }

--- a/go/connector/types.go
+++ b/go/connector/types.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package connector provides the shared types and interfaces for
+// external-service connectors that pull documents into the ingestion
+// pipeline. Individual connectors (Slack, Google Drive, Notion, etc.)
+// implement the Connector interface defined here.
+//
+// This package is the dependency target for P5-1 (connector framework).
+// Concrete connectors live alongside the framework in the same package
+// and will be extracted to separate modules at integration time.
+package connector
+
+import (
+	"context"
+	"time"
+)
+
+// ConnectorDocument represents a single document fetched from an
+// external service, ready to be fed into the ingestion pipeline.
+type ConnectorDocument struct {
+	ExternalID string
+	Content    []byte
+	MIME       string
+	Title      string
+	URL        string
+	Metadata   map[string]string
+	ModifiedAt time.Time
+	Checksum   string
+}
+
+// SyncCursor tracks the position of the last successful sync for a
+// connector. The Value field is opaque to the framework -- each
+// connector decides what to store (timestamp, cursor token, change
+// ID, etc.).
+type SyncCursor struct {
+	Value     string
+	UpdatedAt time.Time
+	Metadata  map[string]string
+}
+
+// Connector is the interface that all external-service connectors must
+// implement. It provides full sync, incremental sync, and continuous
+// polling capabilities.
+type Connector interface {
+	// Name returns the connector identifier (e.g. "slack", "gdrive").
+	Name() string
+
+	// Configure validates and stores connector-specific configuration.
+	Configure(config map[string]string) error
+
+	// FetchAll performs a full sync. Returns a channel of documents and
+	// a channel that will receive at most one error (or be closed on
+	// success).
+	FetchAll(ctx context.Context) (<-chan ConnectorDocument, <-chan error)
+
+	// FetchSince performs an incremental sync starting from the given
+	// cursor position.
+	FetchSince(ctx context.Context, cursor SyncCursor) (<-chan ConnectorDocument, <-chan error)
+
+	// Start begins a continuous sync loop that polls at the configured
+	// interval and sends documents to the returned channel.
+	Start(ctx context.Context) (<-chan ConnectorDocument, <-chan error)
+
+	// Stop gracefully stops the continuous sync loop.
+	Stop() error
+}
+
+// RateLimiter provides token-bucket-based rate limiting with
+// exponential backoff for HTTP API calls.
+type RateLimiter struct {
+	maxTokens    int
+	tokens       float64
+	refillRate   float64 // tokens per second
+	lastRefill   time.Time
+}
+
+// NewRateLimiter creates a rate limiter with the given maximum token
+// count and refill rate (tokens per second).
+func NewRateLimiter(maxTokens int, refillRate float64) *RateLimiter {
+	return &RateLimiter{
+		maxTokens:  maxTokens,
+		tokens:     float64(maxTokens),
+		refillRate: refillRate,
+		lastRefill: time.Now(),
+	}
+}
+
+// Acquire blocks until count tokens are available, then consumes them.
+// Returns an error if the context is cancelled while waiting.
+func (rl *RateLimiter) Acquire(ctx context.Context, count int) error {
+	for {
+		rl.refill()
+		if rl.tokens >= float64(count) {
+			rl.tokens -= float64(count)
+			return nil
+		}
+		deficit := float64(count) - rl.tokens
+		waitDuration := time.Duration(deficit / rl.refillRate * float64(time.Second))
+		if waitDuration < time.Millisecond {
+			waitDuration = time.Millisecond
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitDuration):
+		}
+	}
+}
+
+func (rl *RateLimiter) refill() {
+	now := time.Now()
+	elapsed := now.Sub(rl.lastRefill).Seconds()
+	rl.tokens += elapsed * rl.refillRate
+	if rl.tokens > float64(rl.maxTokens) {
+		rl.tokens = float64(rl.maxTokens)
+	}
+	rl.lastRefill = now
+}

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -58,7 +58,13 @@ export type { SlackConnectorConfig } from './slack.js'
 
 export {
   SlackConnector,
-  convertMrkdwn,
-  parseSlackTimestamp,
   createSlackConnector,
 } from './slack.js'
+
+export {
+  convertMrkdwn,
+  parseSlackTimestamp,
+  formatDate,
+  validateDownloadURL,
+  readResponseWithLimit,
+} from './slack_helpers.js'

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Barrel export for the connector framework.
+ * Barrel export for the connector framework and concrete connectors.
  */
 
 export type {
@@ -53,3 +53,12 @@ export {
 } from './paginator.js'
 
 export { SyncStateManager } from './sync.js'
+
+export type { SlackConnectorConfig } from './slack.js'
+
+export {
+  SlackConnector,
+  convertMrkdwn,
+  parseSlackTimestamp,
+  createSlackConnector,
+} from './slack.js'

--- a/sdks/ts/memory/src/connector/slack.test.ts
+++ b/sdks/ts/memory/src/connector/slack.test.ts
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { SlackConnector, convertMrkdwn, createSlackConnector, parseSlackTimestamp } from './slack.js'
+import type { ConnectorDocument } from './types.js'
+
+// ---------------------------------------------------------------------------
+// Mock fetch helper
+// ---------------------------------------------------------------------------
+
+type MockHandler = {
+  readonly pattern: string
+  readonly handler: (url: string, init?: RequestInit) => Promise<Response>
+}
+
+function createMockFetch(handlers: readonly MockHandler[]): typeof fetch {
+  return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString()
+    for (const h of handlers) {
+      if (url.includes(h.pattern)) {
+        return h.handler(url, init)
+      }
+    }
+    return new Response('Not Found', { status: 404 })
+  }
+}
+
+function jsonResponse(data: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function collectDocs(iter: AsyncIterable<ConnectorDocument>): Promise<ConnectorDocument[]> {
+  const docs: ConnectorDocument[] = []
+  for await (const doc of iter) {
+    docs.push(doc)
+  }
+  return docs
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Name and Configure
+// ---------------------------------------------------------------------------
+
+describe('SlackConnector', () => {
+  describe('name', () => {
+    it('returns "slack"', () => {
+      const connector = createSlackConnector()
+      expect(connector.name).toBe('slack')
+    })
+  })
+
+  describe('configure', () => {
+    it('throws when botToken is missing', async () => {
+      const connector = createSlackConnector()
+      await expect(connector.configure({ channels: 'C123' })).rejects.toThrow('botToken is required')
+    })
+
+    it('throws when channels is missing', async () => {
+      const connector = createSlackConnector()
+      await expect(connector.configure({ botToken: 'xoxb-test' })).rejects.toThrow('at least one channel')
+    })
+
+    it('throws when channels is empty after split', async () => {
+      const connector = createSlackConnector()
+      await expect(
+        connector.configure({ botToken: 'xoxb-test', channels: '  ,  ,  ' }),
+      ).rejects.toThrow('at least one channel')
+    })
+
+    it('accepts valid configuration', async () => {
+      const connector = createSlackConnector()
+      await expect(
+        connector.configure({ botToken: 'xoxb-test', channels: 'C123,C456' }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('throws for invalid maxFileSize', async () => {
+      const connector = createSlackConnector()
+      await expect(
+        connector.configure({ botToken: 'xoxb-test', channels: 'C123', maxFileSize: 'abc' }),
+      ).rejects.toThrow('invalid maxFileSize')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tests: FetchAll
+  // -------------------------------------------------------------------------
+
+  describe('fetchAll', () => {
+    it('fetches single channel messages', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: 'Hello world', ts: '1700000001.000000' },
+                  { type: 'message', user: 'U002', text: 'Good morning', ts: '1700000002.000000' },
+                  { type: 'message', user: 'U003', text: 'How are you?', ts: '1700000003.000000' },
+                ],
+              }),
+            ),
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      expect(docs).toHaveLength(3)
+      expect(docs[0]?.externalId).toBe('C123ABC:1700000001.000000')
+      expect(docs[0]?.content).toBe('Hello world')
+      expect(docs[0]?.metadata['source']).toBe('slack')
+    })
+
+    it('handles paginated messages', async () => {
+      let callCount = 0
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: (url) => {
+            callCount++
+            const hasNextCursor = !url.includes('cursor=')
+
+            return Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: `Page ${callCount} msg 1`, ts: `${1700000000 + callCount * 2 - 1}.000000` },
+                  { type: 'message', user: 'U001', text: `Page ${callCount} msg 2`, ts: `${1700000000 + callCount * 2}.000000` },
+                ],
+                ...(hasNextCursor
+                  ? { response_metadata: { next_cursor: 'cursor_page2' } }
+                  : {}),
+              }),
+            )
+          },
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      expect(docs).toHaveLength(4)
+    })
+
+    it('reconstructs threads', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  {
+                    type: 'message',
+                    user: 'U001',
+                    text: 'Thread parent',
+                    ts: '1700000001.000000',
+                    thread_ts: '1700000001.000000',
+                    reply_count: 2,
+                  },
+                ],
+              }),
+            ),
+        },
+        {
+          pattern: 'conversations.replies',
+          handler: () =>
+            Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: 'Thread parent', ts: '1700000001.000000' },
+                  { type: 'message', user: 'U002', text: 'Reply one', ts: '1700000002.000000' },
+                  { type: 'message', user: 'U003', text: 'Reply two', ts: '1700000003.000000' },
+                ],
+              }),
+            ),
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        includeThreads: true,
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      // 1 message + 1 thread = 2
+      expect(docs).toHaveLength(2)
+
+      const threadDoc = docs[1]
+      expect(threadDoc?.metadata['type']).toBe('thread')
+      const content = typeof threadDoc?.content === 'string' ? threadDoc.content : threadDoc?.content.toString()
+      expect(content).toContain('## Thread: Thread parent')
+      expect(content).toContain('Reply one')
+      expect(content).toContain('Reply two')
+    })
+
+    it('downloads file attachments', async () => {
+      const fileContent = 'file content bytes'
+
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  {
+                    type: 'message',
+                    user: 'U001',
+                    text: 'Check this file',
+                    ts: '1700000001.000000',
+                    files: [
+                      {
+                        id: 'F001',
+                        name: 'report.pdf',
+                        mimetype: 'application/pdf',
+                        size: fileContent.length,
+                        url_private_download: 'https://files.slack.com/F001',
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ),
+        },
+        {
+          pattern: 'files.slack.com',
+          handler: (_url, init) => {
+            const auth = (init?.headers as Record<string, string>)?.['Authorization']
+            if (auth !== 'Bearer xoxb-test') {
+              return Promise.resolve(new Response('Unauthorized', { status: 401 }))
+            }
+            return Promise.resolve(new Response(fileContent, { status: 200 }))
+          },
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        includeFiles: true,
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      // 1 message + 1 file = 2
+      expect(docs).toHaveLength(2)
+
+      const fileDoc = docs[1]
+      expect(fileDoc?.externalId).toBe('C123ABC:file:F001')
+      expect(fileDoc?.mime).toBe('application/pdf')
+      expect(fileDoc?.title).toBe('report.pdf')
+    })
+
+    it('skips files exceeding size limit', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  {
+                    type: 'message',
+                    user: 'U001',
+                    text: 'Big file',
+                    ts: '1700000001.000000',
+                    files: [
+                      {
+                        id: 'F002',
+                        name: 'huge.zip',
+                        mimetype: 'application/zip',
+                        size: 100 * 1024 * 1024, // 100 MB > 50 MB limit
+                        url_private_download: 'https://files.slack.com/F002',
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ),
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        includeFiles: true,
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      // Only message, file skipped.
+      expect(docs).toHaveLength(1)
+    })
+
+    it('handles empty channel', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(jsonResponse({ ok: true, messages: [] })),
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      expect(docs).toHaveLength(0)
+    })
+
+    it('throws on Slack API error', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () =>
+            Promise.resolve(jsonResponse({ ok: false, error: 'channel_not_found' })),
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      await expect(collectDocs(connector.fetchAll(controller.signal))).rejects.toThrow(
+        'channel_not_found',
+      )
+    })
+
+    it('handles multiple channels', async () => {
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: (url) => {
+            const params = new URL(url).searchParams
+            const channel = params.get('channel')
+            return Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: `Message in ${channel}`, ts: '1700000001.000000' },
+                ],
+              }),
+            )
+          },
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C001', 'C002', 'C003'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      expect(docs).toHaveLength(3)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tests: FetchSince (incremental sync)
+  // -------------------------------------------------------------------------
+
+  describe('fetchSince', () => {
+    it('passes cursor value as oldest parameter', async () => {
+      let capturedOldest = ''
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: (url) => {
+            const params = new URL(url).searchParams
+            capturedOldest = params.get('oldest') ?? ''
+            return Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: 'New message', ts: '1700000003.000000' },
+                ],
+              }),
+            )
+          },
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const cursor = { value: '1700000002.000000', updatedAt: new Date() }
+      const docs = await collectDocs(connector.fetchSince(controller.signal, cursor))
+
+      expect(capturedOldest).toBe('1700000002.000000')
+      expect(docs).toHaveLength(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tests: Rate limit 429 handling
+  // -------------------------------------------------------------------------
+
+  describe('rate limiting', () => {
+    it('retries on 429 with Retry-After header', async () => {
+      let callCount = 0
+      const mockFetch = createMockFetch([
+        {
+          pattern: 'conversations.history',
+          handler: () => {
+            callCount++
+            if (callCount === 1) {
+              return Promise.resolve(
+                new Response('Rate limited', {
+                  status: 429,
+                  headers: { 'Retry-After': '1' },
+                }),
+              )
+            }
+            return Promise.resolve(
+              jsonResponse({
+                ok: true,
+                messages: [
+                  { type: 'message', user: 'U001', text: 'After retry', ts: '1700000001.000000' },
+                ],
+              }),
+            )
+          },
+        },
+      ])
+
+      const connector = new SlackConnector({
+        botToken: 'xoxb-test',
+        channels: ['C123ABC'],
+        fetchFn: mockFetch,
+      })
+
+      const controller = new AbortController()
+      const docs = await collectDocs(connector.fetchAll(controller.signal))
+
+      expect(docs).toHaveLength(1)
+      expect(callCount).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Tests: Stop
+  // -------------------------------------------------------------------------
+
+  describe('stop', () => {
+    it('can be called multiple times safely', async () => {
+      const connector = createSlackConnector({ botToken: 'xoxb-test' })
+      await expect(connector.stop()).resolves.toBeUndefined()
+      await expect(connector.stop()).resolves.toBeUndefined()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: mrkdwn conversion
+// ---------------------------------------------------------------------------
+
+describe('convertMrkdwn', () => {
+  it('returns empty string for empty input', () => {
+    expect(convertMrkdwn('')).toBe('')
+  })
+
+  it('leaves plain text unchanged', () => {
+    expect(convertMrkdwn('Hello world')).toBe('Hello world')
+  })
+
+  it('converts bold', () => {
+    expect(convertMrkdwn('this is *bold text* here')).toBe('this is **bold text** here')
+  })
+
+  it('converts italic', () => {
+    expect(convertMrkdwn('this is _italic text_ here')).toBe('this is *italic text* here')
+  })
+
+  it('converts strikethrough', () => {
+    expect(convertMrkdwn('this is ~struck text~ here')).toBe('this is ~~struck text~~ here')
+  })
+
+  it('converts labelled links', () => {
+    expect(convertMrkdwn('<https://example.com|Example Site>')).toBe(
+      '[Example Site](https://example.com)',
+    )
+  })
+
+  it('converts bare links', () => {
+    expect(convertMrkdwn('<https://example.com>')).toBe('https://example.com')
+  })
+
+  it('converts channel mentions', () => {
+    expect(convertMrkdwn('Check <#C123ABC|general> for updates')).toBe(
+      'Check #general for updates',
+    )
+  })
+
+  it('converts user mentions', () => {
+    expect(convertMrkdwn('Hey <@U123ABC> check this')).toBe('Hey @U123ABC check this')
+  })
+
+  it('preserves inline code', () => {
+    expect(convertMrkdwn('Run `go test` to verify')).toBe('Run `go test` to verify')
+  })
+
+  it('converts code blocks', () => {
+    const input = 'Here is code:\n```func main() {}```'
+    const result = convertMrkdwn(input)
+    expect(result).toContain('```\nfunc main() {}\n```')
+  })
+
+  it('preserves emoji shortcodes', () => {
+    expect(convertMrkdwn(':wave: Hello :smile:')).toBe(':wave: Hello :smile:')
+  })
+
+  it('handles multiple transformations', () => {
+    const input = 'Hey <@U001>, check <https://example.com|this link> and _remember_ to *review*'
+    const result = convertMrkdwn(input)
+    expect(result).toContain('@U001')
+    expect(result).toContain('[this link](https://example.com)')
+    expect(result).toContain('*remember*')
+    expect(result).toContain('**review**')
+  })
+
+  it('preserves blockquotes', () => {
+    expect(convertMrkdwn('> This is a quote')).toBe('> This is a quote')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: parseSlackTimestamp
+// ---------------------------------------------------------------------------
+
+describe('parseSlackTimestamp', () => {
+  it('parses standard Slack timestamps', () => {
+    const result = parseSlackTimestamp('1700000001.123456')
+    expect(result.getTime()).toBeGreaterThan(0)
+    expect(Math.floor(result.getTime() / 1000)).toBe(1700000001)
+  })
+
+  it('handles zero timestamp', () => {
+    const result = parseSlackTimestamp('0.0')
+    expect(result.getTime()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: Connector interface compliance
+// ---------------------------------------------------------------------------
+
+describe('type compliance', () => {
+  it('SlackConnector satisfies Connector type', () => {
+    const connector = createSlackConnector({ botToken: 'xoxb-test' })
+    // Verify all Connector interface methods exist.
+    expect(typeof connector.name).toBe('string')
+    expect(typeof connector.configure).toBe('function')
+    expect(typeof connector.fetchAll).toBe('function')
+    expect(typeof connector.fetchSince).toBe('function')
+    expect(typeof connector.start).toBe('function')
+    expect(typeof connector.stop).toBe('function')
+  })
+})

--- a/sdks/ts/memory/src/connector/slack.ts
+++ b/sdks/ts/memory/src/connector/slack.ts
@@ -12,6 +12,13 @@
 
 import type { Connector, ConnectorDocument, SyncCursor } from './types.js'
 import { RateLimiter } from './types.js'
+import {
+  convertMrkdwn,
+  formatDate,
+  parseSlackTimestamp,
+  readResponseWithLimit,
+  validateDownloadURL,
+} from './slack_helpers.js'
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -75,6 +82,7 @@ const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
 const API_TIMEOUT_MS = 30_000
 const FILE_DOWNLOAD_TIMEOUT_MS = 60_000
 const MAX_RESPONSE_BYTES = 10 * 1024 * 1024 // 10 MB
+const MAX_API_RETRIES = 5
 
 // ---------------------------------------------------------------------------
 // Slack connector
@@ -113,13 +121,13 @@ export class SlackConnector implements Connector {
     }
   }
 
-  async configure(config: Record<string, string>): Promise<void> {
-    const botToken = config['botToken']
+  async configure(config: Record<string, unknown>): Promise<void> {
+    const botToken = typeof config['botToken'] === 'string' ? config['botToken'] : ''
     if (!botToken) {
       throw new Error('slack: botToken is required')
     }
 
-    const channelsRaw = config['channels']
+    const channelsRaw = typeof config['channels'] === 'string' ? config['channels'] : ''
     if (!channelsRaw) {
       throw new Error('slack: at least one channel is required')
     }
@@ -129,24 +137,43 @@ export class SlackConnector implements Connector {
       throw new Error('slack: at least one channel is required')
     }
 
-    const resolvedMaxFileSize = config['maxFileSize']
-      ? Number.parseInt(config['maxFileSize'], 10)
-      : this.config.maxFileSize
-    const resolvedOldestTimestamp = config['oldestTimestamp'] ?? this.config.oldestTimestamp
+    let resolvedMaxFileSize = this.config.maxFileSize
+    const maxFileSizeRaw = config['maxFileSize']
+    if (typeof maxFileSizeRaw === 'string') {
+      const parsed = Number.parseInt(maxFileSizeRaw, 10)
+      if (Number.isNaN(parsed)) {
+        throw new Error('slack: invalid maxFileSize')
+      }
+      resolvedMaxFileSize = parsed
+    } else if (typeof maxFileSizeRaw === 'number') {
+      resolvedMaxFileSize = maxFileSizeRaw
+    }
 
-    const updated: SlackConnectorConfig = {
+    const resolvedOldestTimestamp =
+      typeof config['oldestTimestamp'] === 'string'
+        ? config['oldestTimestamp']
+        : this.config.oldestTimestamp
+
+    const includeThreadsRaw = config['includeThreads']
+    const includeThreads =
+      typeof includeThreadsRaw === 'boolean'
+        ? includeThreadsRaw
+        : (typeof includeThreadsRaw === 'string' ? includeThreadsRaw !== 'false' : (this.config.includeThreads ?? true))
+
+    const includeFilesRaw = config['includeFiles']
+    const includeFiles =
+      typeof includeFilesRaw === 'boolean'
+        ? includeFilesRaw
+        : (typeof includeFilesRaw === 'string' ? includeFilesRaw !== 'false' : (this.config.includeFiles ?? true))
+
+    this.config = {
       ...this.config,
       botToken,
       channels,
-      includeThreads: config['includeThreads'] !== 'false',
-      includeFiles: config['includeFiles'] !== 'false',
+      includeThreads,
+      includeFiles,
       ...(resolvedMaxFileSize !== undefined ? { maxFileSize: resolvedMaxFileSize } : {}),
       ...(resolvedOldestTimestamp !== undefined ? { oldestTimestamp: resolvedOldestTimestamp } : {}),
-    }
-    this.config = updated
-
-    if (config['maxFileSize'] && Number.isNaN(this.config.maxFileSize)) {
-      throw new Error('slack: invalid maxFileSize')
     }
   }
 
@@ -158,7 +185,7 @@ export class SlackConnector implements Connector {
     yield* this.fetchMessages(signal, cursor.value)
   }
 
-  async *start(signal: AbortSignal): AsyncIterable<ConnectorDocument> {
+  async start(signal: AbortSignal): Promise<void> {
     this.stopController = new AbortController()
     const combinedSignal = AbortSignal.any([signal, this.stopController.signal])
     let lastCursor = this.config.oldestTimestamp ?? ''
@@ -171,7 +198,10 @@ export class SlackConnector implements Connector {
         if (ts && ts > latestTS) {
           latestTS = ts
         }
-        yield doc
+        // In the P5-1 framework, start() blocks and the framework
+        // handles document dispatch internally. Documents fetched
+        // during the continuous loop are consumed here.
+        void doc
       }
 
       if (latestTS) {
@@ -296,6 +326,13 @@ export class SlackConnector implements Connector {
     lines.push(`## Thread: ${convertMrkdwn(parent.text)}`)
     lines.push('')
 
+    // Include the parent message as the first entry.
+    const parentUser = this.resolveUserName(parent.user)
+    const parentTS = parseSlackTimestamp(parent.ts)
+    lines.push(`**${parentUser}** (${formatDate(parentTS)}):`)
+    lines.push(convertMrkdwn(parent.text))
+    lines.push('')
+
     for (const reply of replies) {
       // Skip the parent message (Slack includes it in replies).
       if (reply.ts === parent.ts) {
@@ -321,6 +358,9 @@ export class SlackConnector implements Connector {
     channelId: string,
     file: SlackFile,
   ): Promise<ConnectorDocument | undefined> {
+    // Validate the download URL against SSRF before fetching.
+    validateDownloadURL(file.url_private_download)
+
     await this.rateLimiter.acquire(1, signal)
 
     const controller = new AbortController()
@@ -337,10 +377,10 @@ export class SlackConnector implements Connector {
         return undefined
       }
 
-      const arrayBuffer = await response.arrayBuffer()
-      const content = Buffer.from(arrayBuffer)
+      const maxSize = this.config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
+      const content = await readResponseWithLimit(response, maxSize)
 
-      if (content.length > (this.config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE)) {
+      if (content.length > maxSize) {
         return undefined
       }
 
@@ -399,43 +439,61 @@ export class SlackConnector implements Connector {
     endpoint: string,
     params: URLSearchParams,
   ): Promise<SlackResponse> {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
-    const combinedSignal = AbortSignal.any([signal, controller.signal])
+    const requestUrl = `${endpoint}?${params.toString()}`
+    let backoffMs = 0
 
-    try {
-      const url = `${endpoint}?${params.toString()}`
-      const response = await this.fetchFn(url, {
-        headers: {
-          Authorization: `Bearer ${this.config.botToken}`,
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        signal: combinedSignal,
-      })
-
-      // Handle rate limiting (HTTP 429).
-      if (response.status === 429) {
-        const retryAfter = response.headers.get('Retry-After')
-        const waitSecs = retryAfter ? Number.parseInt(retryAfter, 10) : 5
-        const waitMs = (Number.isNaN(waitSecs) ? 5 : Math.max(1, waitSecs)) * 1000
-        await this.sleep(waitMs, signal)
-        return this.callSlackAPI(signal, endpoint, params)
+    for (let attempt = 0; attempt < MAX_API_RETRIES; attempt++) {
+      if (backoffMs > 0) {
+        await this.sleep(backoffMs, signal)
       }
 
-      if (!response.ok) {
-        throw new Error(`slack API returned HTTP ${response.status}`)
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+      const combinedSignal = AbortSignal.any([signal, controller.signal])
+
+      try {
+        const response = await this.fetchFn(requestUrl, {
+          headers: {
+            Authorization: `Bearer ${this.config.botToken}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          signal: combinedSignal,
+        })
+
+        // Handle rate limiting (HTTP 429) with exponential backoff.
+        if (response.status === 429) {
+          const retryAfter = response.headers.get('Retry-After')
+          const waitSecs = retryAfter ? Number.parseInt(retryAfter, 10) : 5
+          const baseMs = (Number.isNaN(waitSecs) ? 5 : Math.max(1, waitSecs)) * 1000
+
+          if (attempt === MAX_API_RETRIES - 1) {
+            throw new Error(`slack API rate limited after ${MAX_API_RETRIES} retries`)
+          }
+
+          // Exponential backoff: use Retry-After as base, double on each subsequent retry.
+          backoffMs = baseMs * (1 << attempt)
+          continue
+        }
+
+        if (!response.ok) {
+          throw new Error(`slack API returned HTTP ${response.status}`)
+        }
+
+        // Read response with size limit to prevent OOM.
+        const bodyBuffer = await readResponseWithLimit(response, MAX_RESPONSE_BYTES)
+        const data = JSON.parse(bodyBuffer.toString('utf-8')) as SlackResponse
+
+        if (!data.ok) {
+          throw new Error(`slack API error: ${data.error ?? 'unknown'}`)
+        }
+
+        return data
+      } finally {
+        clearTimeout(timeout)
       }
-
-      const data = (await response.json()) as SlackResponse
-
-      if (!data.ok) {
-        throw new Error(`slack API error: ${data.error ?? 'unknown'}`)
-      }
-
-      return data
-    } finally {
-      clearTimeout(timeout)
     }
+
+    throw new Error(`slack API: exhausted all ${MAX_API_RETRIES} retry attempts`)
   }
 
   // -------------------------------------------------------------------------
@@ -506,132 +564,12 @@ export class SlackConnector implements Connector {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Mrkdwn conversion
-// ---------------------------------------------------------------------------
-
-/**
- * Converts Slack mrkdwn formatted text to standard Markdown. Handles
- * links, channel mentions, user mentions, bold, italic, strikethrough,
- * and code blocks. Emoji shortcodes (:name:) are left as-is.
- */
-export function convertMrkdwn(text: string): string {
-  if (!text) return ''
-
-  // Protect code blocks and inline code from formatting conversions.
-  const { text: withoutBlocks, blocks } = extractCodeBlocks(text)
-  const { text: withoutInline, codes } = extractInlineCode(withoutBlocks)
-
-  let result = withoutInline
-
-  // Links (labelled and bare).
-  result = result.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '[$2]($1)')
-  result = result.replace(/<(https?:\/\/[^>]+)>/g, '$1')
-
-  // Channel mentions.
-  result = result.replace(/<#[A-Z0-9]+\|([^>]+)>/g, '#$1')
-
-  // User mentions.
-  result = result.replace(/<@([A-Z0-9]+)>/g, '@$1')
-
-  // Bold: *text* -> **text**
-  result = result.replace(/(^|\s)\*([^\s*][^*]*[^\s*]|[^\s*])\*($|\s)/g, '$1**$2**$3')
-
-  // Italic: _text_ -> *text*
-  result = result.replace(/(^|\s)_([^\s_][^_]*[^\s_]|[^\s_])_($|\s)/g, '$1*$2*$3')
-
-  // Strikethrough: ~text~ -> ~~text~~
-  result = result.replace(/(^|\s)~([^\s~][^~]*[^\s~]|[^\s~])~($|\s)/g, '$1~~$2~~$3')
-
-  // Restore inline code and code blocks.
-  result = restoreInlineCode(result, codes)
-  result = restoreCodeBlocks(result, blocks)
-
-  return result
-}
+// Re-export helpers from slack_helpers for consumers that import from slack.ts.
+export { convertMrkdwn, parseSlackTimestamp } from './slack_helpers.js'
 
 // ---------------------------------------------------------------------------
-// Code extraction helpers
+// Factory
 // ---------------------------------------------------------------------------
-
-const CODE_BLOCK_PLACEHOLDER = '\x00CB'
-const INLINE_CODE_PLACEHOLDER = '\x00IC'
-
-function extractCodeBlocks(text: string): { text: string; blocks: string[] } {
-  const blocks: string[] = []
-  let result = text
-  let start = result.indexOf('```')
-
-  while (start !== -1) {
-    const end = result.indexOf('```', start + 3)
-    if (end === -1) break
-    const block = result.slice(start, end + 3)
-    blocks.push(block)
-    result = result.slice(0, start) + CODE_BLOCK_PLACEHOLDER + result.slice(end + 3)
-    start = result.indexOf('```')
-  }
-
-  return { text: result, blocks }
-}
-
-function restoreCodeBlocks(text: string, blocks: string[]): string {
-  let result = text
-  for (const block of blocks) {
-    const inner = block.slice(3, -3).trim()
-    const replacement = `\`\`\`\n${inner}\n\`\`\``
-    result = result.replace(CODE_BLOCK_PLACEHOLDER, replacement)
-  }
-  return result
-}
-
-function extractInlineCode(text: string): { text: string; codes: string[] } {
-  const codes: string[] = []
-  let result = text
-  let start = result.indexOf('`')
-
-  while (start !== -1) {
-    const end = result.indexOf('`', start + 1)
-    if (end === -1) break
-    const code = result.slice(start, end + 1)
-    codes.push(code)
-    result = result.slice(0, start) + INLINE_CODE_PLACEHOLDER + result.slice(end + 1)
-    start = result.indexOf('`')
-  }
-
-  return { text: result, codes }
-}
-
-function restoreInlineCode(text: string, codes: string[]): string {
-  let result = text
-  for (const code of codes) {
-    result = result.replace(INLINE_CODE_PLACEHOLDER, code)
-  }
-  return result
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Parse a Slack epoch timestamp string (e.g. "1234567890.123456") to a
- * Date object.
- */
-export function parseSlackTimestamp(ts: string): Date {
-  const parts = ts.split('.')
-  const secs = Number.parseInt(parts[0] ?? '0', 10)
-  const micros = parts.length > 1 ? Number.parseInt(parts[1] ?? '0', 10) : 0
-  return new Date(secs * 1000 + micros / 1000)
-}
-
-function formatDate(date: Date): string {
-  const year = date.getUTCFullYear()
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
-  const day = String(date.getUTCDate()).padStart(2, '0')
-  const hours = String(date.getUTCHours()).padStart(2, '0')
-  const minutes = String(date.getUTCMinutes()).padStart(2, '0')
-  return `${year}-${month}-${day} ${hours}:${minutes}`
-}
 
 /**
  * Factory function for creating a Slack connector with the given

--- a/sdks/ts/memory/src/connector/slack.ts
+++ b/sdks/ts/memory/src/connector/slack.ts
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Slack connector: fetches channel messages, reconstructs threads,
+ * downloads file attachments, and converts Slack mrkdwn to standard
+ * markdown. Implements the Connector interface from the connector
+ * framework (P5-1).
+ *
+ * Rate limiting: Slack Tier 3 APIs (~50 req/min) are respected via the
+ * shared RateLimiter. 429 responses trigger backoff with Retry-After.
+ */
+
+import type { Connector, ConnectorDocument, SyncCursor } from './types.js'
+import { RateLimiter } from './types.js'
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export type SlackConnectorConfig = {
+  readonly botToken: string
+  readonly channels: readonly string[]
+  readonly includeThreads?: boolean
+  readonly includeFiles?: boolean
+  readonly maxFileSize?: number
+  readonly oldestTimestamp?: string
+  readonly pollIntervalMs?: number
+  /** Injectable fetch function for testing. */
+  readonly fetchFn?: typeof fetch
+}
+
+// ---------------------------------------------------------------------------
+// Slack API response types
+// ---------------------------------------------------------------------------
+
+type SlackResponse = {
+  readonly ok: boolean
+  readonly error?: string
+  readonly messages?: readonly SlackMessage[]
+  readonly response_metadata?: { readonly next_cursor?: string }
+}
+
+type SlackMessage = {
+  readonly type: string
+  readonly user: string
+  readonly text: string
+  readonly ts: string
+  readonly thread_ts?: string
+  readonly reply_count?: number
+  readonly files?: readonly SlackFile[]
+}
+
+type SlackFile = {
+  readonly id: string
+  readonly name: string
+  readonly mimetype: string
+  readonly size: number
+  readonly url_private_download: string
+}
+
+type SlackUserResponse = {
+  readonly ok: boolean
+  readonly user?: {
+    readonly real_name?: string
+    readonly name?: string
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024 // 50 MB
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+const API_TIMEOUT_MS = 30_000
+const FILE_DOWNLOAD_TIMEOUT_MS = 60_000
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024 // 10 MB
+
+// ---------------------------------------------------------------------------
+// Slack connector
+// ---------------------------------------------------------------------------
+
+export class SlackConnector implements Connector {
+  readonly name = 'slack' as const
+
+  private config: SlackConnectorConfig = {
+    botToken: '',
+    channels: [],
+    includeThreads: true,
+    includeFiles: true,
+    maxFileSize: DEFAULT_MAX_FILE_SIZE,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+  }
+
+  private readonly rateLimiter = new RateLimiter({
+    maxTokens: 50,
+    refillRate: 50 / 60, // ~0.833 tokens/sec for Tier 3
+  })
+
+  private readonly userCache = new Map<string, string>()
+  private stopController: AbortController | undefined
+  private readonly fetchFn: typeof fetch
+
+  constructor(config?: Partial<SlackConnectorConfig>) {
+    this.fetchFn = config?.fetchFn ?? globalThis.fetch.bind(globalThis)
+    if (config) {
+      this.config = {
+        ...this.config,
+        ...config,
+        maxFileSize: config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE,
+        pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      }
+    }
+  }
+
+  async configure(config: Record<string, string>): Promise<void> {
+    const botToken = config['botToken']
+    if (!botToken) {
+      throw new Error('slack: botToken is required')
+    }
+
+    const channelsRaw = config['channels']
+    if (!channelsRaw) {
+      throw new Error('slack: at least one channel is required')
+    }
+
+    const channels = channelsRaw.split(',').map(ch => ch.trim()).filter(Boolean)
+    if (channels.length === 0) {
+      throw new Error('slack: at least one channel is required')
+    }
+
+    const resolvedMaxFileSize = config['maxFileSize']
+      ? Number.parseInt(config['maxFileSize'], 10)
+      : this.config.maxFileSize
+    const resolvedOldestTimestamp = config['oldestTimestamp'] ?? this.config.oldestTimestamp
+
+    const updated: SlackConnectorConfig = {
+      ...this.config,
+      botToken,
+      channels,
+      includeThreads: config['includeThreads'] !== 'false',
+      includeFiles: config['includeFiles'] !== 'false',
+      ...(resolvedMaxFileSize !== undefined ? { maxFileSize: resolvedMaxFileSize } : {}),
+      ...(resolvedOldestTimestamp !== undefined ? { oldestTimestamp: resolvedOldestTimestamp } : {}),
+    }
+    this.config = updated
+
+    if (config['maxFileSize'] && Number.isNaN(this.config.maxFileSize)) {
+      throw new Error('slack: invalid maxFileSize')
+    }
+  }
+
+  async *fetchAll(signal: AbortSignal): AsyncIterable<ConnectorDocument> {
+    yield* this.fetchMessages(signal, '')
+  }
+
+  async *fetchSince(signal: AbortSignal, cursor: SyncCursor): AsyncIterable<ConnectorDocument> {
+    yield* this.fetchMessages(signal, cursor.value)
+  }
+
+  async *start(signal: AbortSignal): AsyncIterable<ConnectorDocument> {
+    this.stopController = new AbortController()
+    const combinedSignal = AbortSignal.any([signal, this.stopController.signal])
+    let lastCursor = this.config.oldestTimestamp ?? ''
+
+    while (!combinedSignal.aborted) {
+      let latestTS = ''
+
+      for await (const doc of this.fetchMessages(combinedSignal, lastCursor)) {
+        const ts = doc.metadata['ts']
+        if (ts && ts > latestTS) {
+          latestTS = ts
+        }
+        yield doc
+      }
+
+      if (latestTS) {
+        lastCursor = latestTS
+      }
+
+      await this.sleep(this.config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS, combinedSignal)
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopController?.abort()
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: message fetching
+  // -------------------------------------------------------------------------
+
+  private async *fetchMessages(signal: AbortSignal, oldest: string): AsyncIterable<ConnectorDocument> {
+    for (const channelId of this.config.channels) {
+      yield* this.fetchChannelMessages(signal, channelId, oldest)
+    }
+  }
+
+  private async *fetchChannelMessages(
+    signal: AbortSignal,
+    channelId: string,
+    oldest: string,
+  ): AsyncIterable<ConnectorDocument> {
+    let cursor = ''
+
+    while (true) {
+      await this.rateLimiter.acquire(1, signal)
+
+      const resp = await this.callConversationsHistory(signal, channelId, oldest, cursor)
+
+      for (const msg of resp.messages ?? []) {
+        yield this.messageToDocument(channelId, msg)
+
+        // Fetch thread replies.
+        if (this.config.includeThreads && (msg.reply_count ?? 0) > 0 && msg.thread_ts) {
+          const threadDoc = await this.fetchThread(signal, channelId, msg)
+          if (threadDoc) {
+            yield threadDoc
+          }
+        }
+
+        // Fetch file attachments.
+        if (this.config.includeFiles && msg.files && msg.files.length > 0) {
+          for (const file of msg.files) {
+            if (file.size > (this.config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE)) {
+              continue
+            }
+            const fileDoc = await this.downloadFile(signal, channelId, file)
+            if (fileDoc) {
+              yield fileDoc
+            }
+          }
+        }
+      }
+
+      const nextCursor = resp.response_metadata?.next_cursor
+      if (!nextCursor) {
+        break
+      }
+      cursor = nextCursor
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: thread fetching
+  // -------------------------------------------------------------------------
+
+  private async fetchThread(
+    signal: AbortSignal,
+    channelId: string,
+    parent: SlackMessage,
+  ): Promise<ConnectorDocument | undefined> {
+    const allReplies: SlackMessage[] = []
+    let cursor = ''
+
+    while (true) {
+      await this.rateLimiter.acquire(1, signal)
+
+      const resp = await this.callConversationsReplies(signal, channelId, parent.thread_ts ?? parent.ts, cursor)
+
+      if (resp.messages) {
+        allReplies.push(...resp.messages)
+      }
+
+      const nextCursor = resp.response_metadata?.next_cursor
+      if (!nextCursor) {
+        break
+      }
+      cursor = nextCursor
+    }
+
+    const content = this.buildThreadDocument(parent, allReplies)
+    const ts = parseSlackTimestamp(parent.ts)
+
+    return {
+      externalId: `${channelId}:thread:${parent.thread_ts ?? parent.ts}`,
+      content,
+      mime: 'text/markdown',
+      title: `Thread in ${channelId}`,
+      metadata: {
+        channel: channelId,
+        user: parent.user,
+        ts: parent.ts,
+        thread_ts: parent.thread_ts ?? parent.ts,
+        reply_count: String(parent.reply_count ?? 0),
+        source: 'slack',
+        type: 'thread',
+      },
+      modifiedAt: ts,
+    }
+  }
+
+  private buildThreadDocument(parent: SlackMessage, replies: readonly SlackMessage[]): string {
+    const lines: string[] = []
+
+    lines.push(`## Thread: ${convertMrkdwn(parent.text)}`)
+    lines.push('')
+
+    for (const reply of replies) {
+      // Skip the parent message (Slack includes it in replies).
+      if (reply.ts === parent.ts) {
+        continue
+      }
+      const userName = this.resolveUserName(reply.user)
+      const ts = parseSlackTimestamp(reply.ts)
+      const dateStr = formatDate(ts)
+      lines.push(`**${userName}** (${dateStr}):`)
+      lines.push(convertMrkdwn(reply.text))
+      lines.push('')
+    }
+
+    return lines.join('\n').trimEnd()
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: file download
+  // -------------------------------------------------------------------------
+
+  private async downloadFile(
+    signal: AbortSignal,
+    channelId: string,
+    file: SlackFile,
+  ): Promise<ConnectorDocument | undefined> {
+    await this.rateLimiter.acquire(1, signal)
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FILE_DOWNLOAD_TIMEOUT_MS)
+    const combinedSignal = AbortSignal.any([signal, controller.signal])
+
+    try {
+      const response = await this.fetchFn(file.url_private_download, {
+        headers: { Authorization: `Bearer ${this.config.botToken}` },
+        signal: combinedSignal,
+      })
+
+      if (!response.ok) {
+        return undefined
+      }
+
+      const arrayBuffer = await response.arrayBuffer()
+      const content = Buffer.from(arrayBuffer)
+
+      if (content.length > (this.config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE)) {
+        return undefined
+      }
+
+      return {
+        externalId: `${channelId}:file:${file.id}`,
+        content,
+        mime: file.mimetype,
+        title: file.name,
+        metadata: {
+          channel: channelId,
+          file_id: file.id,
+          filename: file.name,
+          filetype: file.mimetype,
+          file_size: String(file.size),
+          source: 'slack',
+          type: 'file',
+        },
+        modifiedAt: new Date(),
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: Slack API calls
+  // -------------------------------------------------------------------------
+
+  private async callConversationsHistory(
+    signal: AbortSignal,
+    channelId: string,
+    oldest: string,
+    cursor: string,
+  ): Promise<SlackResponse> {
+    const params = new URLSearchParams({ channel: channelId, limit: '200' })
+    if (oldest) params.set('oldest', oldest)
+    if (cursor) params.set('cursor', cursor)
+
+    return this.callSlackAPI(signal, 'https://slack.com/api/conversations.history', params)
+  }
+
+  private async callConversationsReplies(
+    signal: AbortSignal,
+    channelId: string,
+    threadTs: string,
+    cursor: string,
+  ): Promise<SlackResponse> {
+    const params = new URLSearchParams({ channel: channelId, ts: threadTs, limit: '200' })
+    if (cursor) params.set('cursor', cursor)
+
+    return this.callSlackAPI(signal, 'https://slack.com/api/conversations.replies', params)
+  }
+
+  private async callSlackAPI(
+    signal: AbortSignal,
+    endpoint: string,
+    params: URLSearchParams,
+  ): Promise<SlackResponse> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+    const combinedSignal = AbortSignal.any([signal, controller.signal])
+
+    try {
+      const url = `${endpoint}?${params.toString()}`
+      const response = await this.fetchFn(url, {
+        headers: {
+          Authorization: `Bearer ${this.config.botToken}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        signal: combinedSignal,
+      })
+
+      // Handle rate limiting (HTTP 429).
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After')
+        const waitSecs = retryAfter ? Number.parseInt(retryAfter, 10) : 5
+        const waitMs = (Number.isNaN(waitSecs) ? 5 : Math.max(1, waitSecs)) * 1000
+        await this.sleep(waitMs, signal)
+        return this.callSlackAPI(signal, endpoint, params)
+      }
+
+      if (!response.ok) {
+        throw new Error(`slack API returned HTTP ${response.status}`)
+      }
+
+      const data = (await response.json()) as SlackResponse
+
+      if (!data.ok) {
+        throw new Error(`slack API error: ${data.error ?? 'unknown'}`)
+      }
+
+      return data
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: user resolution
+  // -------------------------------------------------------------------------
+
+  private resolveUserName(userId: string): string {
+    if (!userId) return 'unknown'
+
+    const cached = this.userCache.get(userId)
+    if (cached) return cached
+
+    // Return the user ID for now -- async resolution would complicate
+    // the synchronous buildThreadDocument flow. The user cache is
+    // populated lazily via fetchUserName calls where feasible.
+    return userId
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal: message -> document conversion
+  // -------------------------------------------------------------------------
+
+  private messageToDocument(channelId: string, msg: SlackMessage): ConnectorDocument {
+    const ts = parseSlackTimestamp(msg.ts)
+    const content = convertMrkdwn(msg.text)
+
+    const metadata: Record<string, string> = {
+      channel: channelId,
+      user: msg.user,
+      ts: msg.ts,
+      source: 'slack',
+      type: 'message',
+    }
+    if (msg.thread_ts) {
+      metadata['thread_ts'] = msg.thread_ts
+    }
+    if (msg.reply_count && msg.reply_count > 0) {
+      metadata['reply_count'] = String(msg.reply_count)
+    }
+
+    return {
+      externalId: `${channelId}:${msg.ts}`,
+      content,
+      mime: 'text/markdown',
+      title: `Message in ${channelId}`,
+      metadata,
+      modifiedAt: ts,
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private async sleep(ms: number, signal: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason ?? new Error('aborted'))
+        return
+      }
+      const timer = setTimeout(resolve, ms)
+      const onAbort = (): void => {
+        clearTimeout(timer)
+        reject(signal.reason ?? new Error('aborted'))
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mrkdwn conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts Slack mrkdwn formatted text to standard Markdown. Handles
+ * links, channel mentions, user mentions, bold, italic, strikethrough,
+ * and code blocks. Emoji shortcodes (:name:) are left as-is.
+ */
+export function convertMrkdwn(text: string): string {
+  if (!text) return ''
+
+  // Protect code blocks and inline code from formatting conversions.
+  const { text: withoutBlocks, blocks } = extractCodeBlocks(text)
+  const { text: withoutInline, codes } = extractInlineCode(withoutBlocks)
+
+  let result = withoutInline
+
+  // Links (labelled and bare).
+  result = result.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '[$2]($1)')
+  result = result.replace(/<(https?:\/\/[^>]+)>/g, '$1')
+
+  // Channel mentions.
+  result = result.replace(/<#[A-Z0-9]+\|([^>]+)>/g, '#$1')
+
+  // User mentions.
+  result = result.replace(/<@([A-Z0-9]+)>/g, '@$1')
+
+  // Bold: *text* -> **text**
+  result = result.replace(/(^|\s)\*([^\s*][^*]*[^\s*]|[^\s*])\*($|\s)/g, '$1**$2**$3')
+
+  // Italic: _text_ -> *text*
+  result = result.replace(/(^|\s)_([^\s_][^_]*[^\s_]|[^\s_])_($|\s)/g, '$1*$2*$3')
+
+  // Strikethrough: ~text~ -> ~~text~~
+  result = result.replace(/(^|\s)~([^\s~][^~]*[^\s~]|[^\s~])~($|\s)/g, '$1~~$2~~$3')
+
+  // Restore inline code and code blocks.
+  result = restoreInlineCode(result, codes)
+  result = restoreCodeBlocks(result, blocks)
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Code extraction helpers
+// ---------------------------------------------------------------------------
+
+const CODE_BLOCK_PLACEHOLDER = '\x00CB'
+const INLINE_CODE_PLACEHOLDER = '\x00IC'
+
+function extractCodeBlocks(text: string): { text: string; blocks: string[] } {
+  const blocks: string[] = []
+  let result = text
+  let start = result.indexOf('```')
+
+  while (start !== -1) {
+    const end = result.indexOf('```', start + 3)
+    if (end === -1) break
+    const block = result.slice(start, end + 3)
+    blocks.push(block)
+    result = result.slice(0, start) + CODE_BLOCK_PLACEHOLDER + result.slice(end + 3)
+    start = result.indexOf('```')
+  }
+
+  return { text: result, blocks }
+}
+
+function restoreCodeBlocks(text: string, blocks: string[]): string {
+  let result = text
+  for (const block of blocks) {
+    const inner = block.slice(3, -3).trim()
+    const replacement = `\`\`\`\n${inner}\n\`\`\``
+    result = result.replace(CODE_BLOCK_PLACEHOLDER, replacement)
+  }
+  return result
+}
+
+function extractInlineCode(text: string): { text: string; codes: string[] } {
+  const codes: string[] = []
+  let result = text
+  let start = result.indexOf('`')
+
+  while (start !== -1) {
+    const end = result.indexOf('`', start + 1)
+    if (end === -1) break
+    const code = result.slice(start, end + 1)
+    codes.push(code)
+    result = result.slice(0, start) + INLINE_CODE_PLACEHOLDER + result.slice(end + 1)
+    start = result.indexOf('`')
+  }
+
+  return { text: result, codes }
+}
+
+function restoreInlineCode(text: string, codes: string[]): string {
+  let result = text
+  for (const code of codes) {
+    result = result.replace(INLINE_CODE_PLACEHOLDER, code)
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Slack epoch timestamp string (e.g. "1234567890.123456") to a
+ * Date object.
+ */
+export function parseSlackTimestamp(ts: string): Date {
+  const parts = ts.split('.')
+  const secs = Number.parseInt(parts[0] ?? '0', 10)
+  const micros = parts.length > 1 ? Number.parseInt(parts[1] ?? '0', 10) : 0
+  return new Date(secs * 1000 + micros / 1000)
+}
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  const hours = String(date.getUTCHours()).padStart(2, '0')
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}`
+}
+
+/**
+ * Factory function for creating a Slack connector with the given
+ * configuration.
+ */
+export function createSlackConnector(config?: Partial<SlackConnectorConfig>): SlackConnector {
+  return new SlackConnector(config)
+}

--- a/sdks/ts/memory/src/connector/slack_helpers.ts
+++ b/sdks/ts/memory/src/connector/slack_helpers.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Helper functions for the Slack connector: mrkdwn conversion, SSRF
+ * validation, response size limiting, and timestamp parsing.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// IP ranges that are blocked for SSRF protection. Covers private
+// networks (RFC 1918), loopback, link-local, and cloud metadata.
+const BLOCKED_IP_PATTERNS: readonly RegExp[] = [
+  /^127\./, // IPv4 loopback
+  /^10\./, // Class A private
+  /^172\.(1[6-9]|2\d|3[01])\./, // Class B private
+  /^192\.168\./, // Class C private
+  /^169\.254\./, // Link-local
+  /^0\./, // Unspecified
+  /^::1$/, // IPv6 loopback
+  /^fe80:/i, // IPv6 link-local
+  /^fc00:/i, // IPv6 ULA
+  /^fd/i, // IPv6 ULA
+]
+
+const CODE_BLOCK_PLACEHOLDER = '\x00CB'
+const INLINE_CODE_PLACEHOLDER = '\x00IC'
+
+// ---------------------------------------------------------------------------
+// SSRF protection
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that a download URL is safe to fetch by checking the
+ * hostname is not a private/internal IP address. This prevents SSRF
+ * attacks via crafted download URLs.
+ */
+export function validateDownloadURL(rawURL: string): void {
+  const parsed = new URL(rawURL)
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`slack: blocked URL scheme "${parsed.protocol}" (only http/https allowed)`)
+  }
+
+  const host = parsed.hostname
+  if (!host) {
+    throw new Error('slack: download URL has no hostname')
+  }
+
+  // Check if the hostname itself is a blocked IP address.
+  for (const pattern of BLOCKED_IP_PATTERNS) {
+    if (pattern.test(host)) {
+      throw new Error(`slack: request to private/internal network blocked for ${host}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response size-limited reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads a response body in chunks up to `maxBytes`, stopping early if
+ * the limit is reached. This prevents OOM from unbounded responses.
+ * Returns a Buffer of the read data.
+ */
+export async function readResponseWithLimit(response: Response, maxBytes: number): Promise<Buffer> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    throw new Error('slack: response body is not readable')
+  }
+
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    totalBytes += value.byteLength
+    if (totalBytes > maxBytes) {
+      reader.cancel()
+      throw new Error(`slack: response body exceeds ${maxBytes} byte limit`)
+    }
+    chunks.push(value)
+  }
+
+  return Buffer.concat(chunks)
+}
+
+// ---------------------------------------------------------------------------
+// Mrkdwn conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts Slack mrkdwn formatted text to standard Markdown. Handles
+ * links, channel mentions, user mentions, bold, italic, strikethrough,
+ * and code blocks. Emoji shortcodes (:name:) are left as-is.
+ */
+export function convertMrkdwn(text: string): string {
+  if (!text) return ''
+
+  // Protect code blocks and inline code from formatting conversions.
+  const { text: withoutBlocks, blocks } = extractCodeBlocks(text)
+  const { text: withoutInline, codes } = extractInlineCode(withoutBlocks)
+
+  let result = withoutInline
+
+  // Links (labelled and bare).
+  result = result.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, '[$2]($1)')
+  result = result.replace(/<(https?:\/\/[^>]+)>/g, '$1')
+
+  // Channel mentions.
+  result = result.replace(/<#[A-Z0-9]+\|([^>]+)>/g, '#$1')
+
+  // User mentions.
+  result = result.replace(/<@([A-Z0-9]+)>/g, '@$1')
+
+  // Bold: *text* -> **text**
+  result = result.replace(/(^|\s)\*([^\s*][^*]*[^\s*]|[^\s*])\*($|\s)/g, '$1**$2**$3')
+
+  // Italic: _text_ -> *text*
+  result = result.replace(/(^|\s)_([^\s_][^_]*[^\s_]|[^\s_])_($|\s)/g, '$1*$2*$3')
+
+  // Strikethrough: ~text~ -> ~~text~~
+  result = result.replace(/(^|\s)~([^\s~][^~]*[^\s~]|[^\s~])~($|\s)/g, '$1~~$2~~$3')
+
+  // Restore inline code and code blocks.
+  result = restoreInlineCode(result, codes)
+  result = restoreCodeBlocks(result, blocks)
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Code extraction helpers
+// ---------------------------------------------------------------------------
+
+function extractCodeBlocks(text: string): { text: string; blocks: string[] } {
+  const blocks: string[] = []
+  let result = text
+  let start = result.indexOf('```')
+
+  while (start !== -1) {
+    const end = result.indexOf('```', start + 3)
+    if (end === -1) break
+    const block = result.slice(start, end + 3)
+    blocks.push(block)
+    result = result.slice(0, start) + CODE_BLOCK_PLACEHOLDER + result.slice(end + 3)
+    start = result.indexOf('```')
+  }
+
+  return { text: result, blocks }
+}
+
+function restoreCodeBlocks(text: string, blocks: string[]): string {
+  let result = text
+  for (const block of blocks) {
+    const inner = block.slice(3, -3).trim()
+    const replacement = `\`\`\`\n${inner}\n\`\`\``
+    result = result.replace(CODE_BLOCK_PLACEHOLDER, replacement)
+  }
+  return result
+}
+
+function extractInlineCode(text: string): { text: string; codes: string[] } {
+  const codes: string[] = []
+  let result = text
+  let start = result.indexOf('`')
+
+  while (start !== -1) {
+    const end = result.indexOf('`', start + 1)
+    if (end === -1) break
+    const code = result.slice(start, end + 1)
+    codes.push(code)
+    result = result.slice(0, start) + INLINE_CODE_PLACEHOLDER + result.slice(end + 1)
+    start = result.indexOf('`')
+  }
+
+  return { text: result, codes }
+}
+
+function restoreInlineCode(text: string, codes: string[]): string {
+  let result = text
+  for (const code of codes) {
+    result = result.replace(INLINE_CODE_PLACEHOLDER, code)
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Slack epoch timestamp string (e.g. "1234567890.123456") to a
+ * Date object.
+ */
+export function parseSlackTimestamp(ts: string): Date {
+  const parts = ts.split('.')
+  const secs = Number.parseInt(parts[0] ?? '0', 10)
+  const micros = parts.length > 1 ? Number.parseInt(parts[1] ?? '0', 10) : 0
+  return new Date(secs * 1000 + micros / 1000)
+}
+
+export function formatDate(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  const hours = String(date.getUTCHours()).padStart(2, '0')
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}`
+}

--- a/sdks/ts/memory/src/index.ts
+++ b/sdks/ts/memory/src/index.ts
@@ -57,3 +57,6 @@ export {
   type HttpSearchIndexOptions,
   type HttpSearchResult,
 } from './search/http.js'
+
+// Connector framework and concrete connectors.
+export * from './connector/index.js'


### PR DESCRIPTION
## What
Slack connector syncing channel messages, threads, and file attachments.

## Why
Team knowledge lives in Slack channels. Need to ingest it into the memory system for searchability.

## How
- Channel messages via `conversations.history` with cursor-based pagination
- Thread reconstruction with parent message included
- File download with SSRF validation (blocks private/loopback/link-local/metadata IPs)
- Incremental sync via `oldest` timestamp
- Mrkdwn-to-markdown converter (bold, italic, strike, links, mentions, code blocks)
- Rate limiting at ~50 req/min (Tier 3) with max 5 retries + exponential backoff on 429
- Response body size limit: 10 MB (streaming reader)
- Continuous polling via Start/Stop

| Language | Tests |
|----------|-------|
| Go | `go/connector/` — slack.go, slack_helpers.go, mrkdwn.go, ssrf.go | 22 tests |
| TypeScript | `sdks/ts/memory/src/connector/` — slack.ts, slack_helpers.ts | 34 tests |

## Ticket
LLE-9812