### PR TITLE
feat(connector): Notion page/database sync with block rendering (P5-4)

### DIFF
--- a/go/connector/notion.go
+++ b/go/connector/notion.go
@@ -6,42 +6,46 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 )
 
-// notionAPIVersion is the Notion API version header value.
-const notionAPIVersion = "2022-06-28"
-
-// notionBaseURL is the root endpoint for the Notion API.
-const notionBaseURL = "https://api.notion.com/v1"
-
-// notionDefaultMaxDepth caps recursive page traversal.
-const notionDefaultMaxDepth = 10
-
-// notionDefaultPollInterval is the default continuous sync interval.
-const notionDefaultPollInterval = 15 * time.Minute
-
-// notionDefaultTimeout is the per-request HTTP timeout for Notion
-// API calls.
-const notionDefaultTimeout = 30 * time.Second
-
-// notionDefaultPageSize is the default page size for paginated
-// Notion API requests.
-const notionDefaultPageSize = 100
+const (
+	notionAPIVersion        = "2022-06-28"
+	notionBaseURL           = "https://api.notion.com/v1"
+	notionDefaultMaxDepth   = 10
+	notionDefaultPollInterval = 15 * time.Minute
+	notionDefaultTimeout    = 30 * time.Second
+	notionDefaultPageSize   = 100
+	notionDefaultRateLimit  = 3
+	notionMaxRetryAttempts  = 5
+	notionMaxResponseSize   = 10 * 1024 * 1024 // 10 MiB
+)
 
 // NotionConnectorConfig holds Notion-specific configuration.
 type NotionConnectorConfig struct {
 	APIToken          string
 	RootPageIDs       []string
 	DatabaseIDs       []string
-	IncludeChildPages bool // default: true
-	IncludeDatabases  bool // default: true
-	MaxDepth          int  // default: 10
+	IncludeChildPages bool              // default: true
+	IncludeDatabases  bool              // default: true
+	MaxDepth          int               // default: 10
+	BlockTypeFilter   map[string]struct{} // when non-empty, only these block types are rendered
+
+	// OAuth2 fields: used when the connector authenticates via
+	// Notion's public OAuth integration rather than an internal
+	// integration token (which does not expire).
+	OAuth2         *NotionOAuth2Config
+	RefreshToken   string
+	TokenExpiresAt time.Time
+}
+
+// NotionOAuth2Config holds Notion OAuth2-specific credentials.
+type NotionOAuth2Config struct {
+	ClientID     string
+	ClientSecret string
 }
 
 // NotionPage represents a Notion page object from the API.
@@ -53,66 +57,6 @@ type NotionPage struct {
 	ParentID       string
 }
 
-// notionSearchResponse models the Notion search API response.
-type notionSearchResponse struct {
-	Results    []json.RawMessage `json:"results"`
-	NextCursor string            `json:"next_cursor"`
-	HasMore    bool              `json:"has_more"`
-}
-
-// notionDatabaseQueryResponse models the database query response.
-type notionDatabaseQueryResponse struct {
-	Results    []json.RawMessage `json:"results"`
-	NextCursor string            `json:"next_cursor"`
-	HasMore    bool              `json:"has_more"`
-}
-
-// notionBlockChildrenResponse models the block children response.
-type notionBlockChildrenResponse struct {
-	Results    []notionBlock `json:"results"`
-	NextCursor string       `json:"next_cursor"`
-	HasMore    bool         `json:"has_more"`
-}
-
-// notionBlock represents a single Notion block.
-type notionBlock struct {
-	ID          string          `json:"id"`
-	Type        string          `json:"type"`
-	HasChildren bool            `json:"has_children"`
-	RawData     json.RawMessage `json:"-"`
-}
-
-// UnmarshalJSON implements custom unmarshalling for notionBlock to
-// capture the full raw data alongside parsed fields.
-func (b *notionBlock) UnmarshalJSON(data []byte) error {
-	type alias notionBlock
-	var a alias
-	if err := json.Unmarshal(data, &a); err != nil {
-		return err
-	}
-	a.RawData = data
-	*b = notionBlock(a)
-	return nil
-}
-
-// notionRichText represents a Notion rich text object.
-type notionRichText struct {
-	Type      string                 `json:"type"`
-	PlainText string                 `json:"plain_text"`
-	Href      string                 `json:"href"`
-	Annotations notionAnnotations    `json:"annotations"`
-}
-
-// notionAnnotations contains formatting flags for rich text.
-type notionAnnotations struct {
-	Bold          bool   `json:"bold"`
-	Italic        bool   `json:"italic"`
-	Strikethrough bool   `json:"strikethrough"`
-	Underline     bool   `json:"underline"`
-	Code          bool   `json:"code"`
-	Colour        string `json:"color"`
-}
-
 // NotionHTTPClient abstracts HTTP calls so tests can inject a mock.
 type NotionHTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -120,31 +64,75 @@ type NotionHTTPClient interface {
 
 // NotionConnector implements [Connector] for Notion workspaces.
 type NotionConnector struct {
-	deps        ConnectorConfig
-	config      NotionConnectorConfig
-	httpClient  NotionHTTPClient
-	stopCh      chan struct{}
-	stopOnce    sync.Once
-	configured  bool
+	deps         ConnectorConfig
+	config       NotionConnectorConfig
+	httpClient   NotionHTTPClient
+	rateLimiter  *RateLimiter
+	stopCh       chan struct{}
+	stopOnce     sync.Once
+	configured   bool
+	oauth2Client *NotionOAuth2Client
+	tokenStore   TokenStore
+	mu           sync.Mutex
+	lastSyncAt   time.Time
+	errorCount   int64
 }
 
 // NewNotionConnector creates a Notion connector with the given base
-// dependencies and an HTTP client for API calls.
+// dependencies and an HTTP client for API calls. A default rate
+// limiter of 3 req/sec is created if none is provided via deps.
 func NewNotionConnector(deps ConnectorConfig, httpClient NotionHTTPClient) *NotionConnector {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: notionDefaultTimeout}
 	}
+
+	rl := deps.RateLimiter
+	if rl == nil {
+		rl = NewRateLimiter(RateLimiterConfig{
+			MaxTokens:  notionDefaultRateLimit,
+			RefillRate: notionDefaultRateLimit,
+		})
+	}
+
 	return &NotionConnector{
-		deps:       deps,
-		httpClient: httpClient,
-		stopCh:     make(chan struct{}),
+		deps:        deps,
+		httpClient:  httpClient,
+		rateLimiter: rl,
+		stopCh:      make(chan struct{}),
 	}
 }
 
 // Name returns "notion".
 func (c *NotionConnector) Name() string { return "notion" }
 
+// parseBlockTypeFilter converts a raw config value to a block type filter set.
+func parseBlockTypeFilter(raw any) map[string]struct{} {
+	if raw == nil {
+		return nil
+	}
+	if strs, ok := raw.([]string); ok && len(strs) > 0 {
+		m := make(map[string]struct{}, len(strs))
+		for _, s := range strs {
+			m[s] = struct{}{}
+		}
+		return m
+	}
+	if arr, ok := raw.([]any); ok && len(arr) > 0 {
+		m := make(map[string]struct{}, len(arr))
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				m[s] = struct{}{}
+			}
+		}
+		if len(m) > 0 {
+			return m
+		}
+	}
+	return nil
+}
+
 // Configure validates and stores Notion-specific configuration.
+// Accepts map[string]any to match the P5-1 Connector interface.
 func (c *NotionConnector) Configure(config map[string]any) error {
 	token, _ := config["apiToken"].(string)
 	if strings.TrimSpace(token) == "" {
@@ -193,8 +181,46 @@ func (c *NotionConnector) Configure(config map[string]any) error {
 		cfg.MaxDepth = int(v)
 	}
 
+	cfg.BlockTypeFilter = parseBlockTypeFilter(config["blockTypeFilter"])
+
+	// OAuth2: Notion public integrations use OAuth2 tokens that expire.
+	// Internal integration tokens do not expire.
+	if clientID, ok := config["oauth2_client_id"].(string); ok && clientID != "" {
+		clientSecret, _ := config["oauth2_client_secret"].(string)
+		cfg.OAuth2 = &NotionOAuth2Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}
+	}
+	if rt, ok := config["refresh_token"].(string); ok && rt != "" {
+		cfg.RefreshToken = rt
+	}
+	if expiresAt, ok := config["token_expires_at"].(string); ok && expiresAt != "" {
+		if parsed, parseErr := time.Parse(time.RFC3339, expiresAt); parseErr == nil {
+			cfg.TokenExpiresAt = parsed
+		}
+	}
+
 	c.config = cfg
 	c.configured = true
+
+	// Set up OAuth2Client for token refresh when credentials are complete.
+	if cfg.OAuth2 != nil && cfg.RefreshToken != "" {
+		exchanger, _ := config["token_exchanger"].(NotionTokenExchanger)
+		if exchanger == nil {
+			exchanger = &notionHTTPTokenExchanger{
+				clientID:     cfg.OAuth2.ClientID,
+				clientSecret: cfg.OAuth2.ClientSecret,
+				httpClient:   c.httpClient,
+			}
+		}
+		c.oauth2Client = NewNotionOAuth2Client(cfg.OAuth2.ClientID, cfg.OAuth2.ClientSecret, exchanger)
+	}
+
+	if ts, ok := config["token_store"].(TokenStore); ok {
+		c.tokenStore = ts
+	}
+
 	return nil
 }
 
@@ -209,6 +235,11 @@ func (c *NotionConnector) FetchAll(ctx context.Context) (<-chan ConnectorDocumen
 
 		if !c.configured {
 			errs <- fmt.Errorf("connector/notion: not configured, call Configure first")
+			return
+		}
+
+		if err := c.ensureValidToken(ctx); err != nil {
+			errs <- err
 			return
 		}
 
@@ -231,6 +262,11 @@ func (c *NotionConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-
 
 		if !c.configured {
 			errs <- fmt.Errorf("connector/notion: not configured, call Configure first")
+			return
+		}
+
+		if err := c.ensureValidToken(ctx); err != nil {
+			errs <- err
 			return
 		}
 
@@ -285,6 +321,87 @@ func (c *NotionConnector) Stop() error {
 	return nil
 }
 
+// ensureValidToken checks whether the current OAuth2 token is expired
+// (or within the 5-minute buffer) and refreshes it if an OAuth2Client
+// is configured. For internal integration tokens (which do not expire),
+// this is a no-op. Thread-safe: concurrent calls are deduplicated by
+// the NotionOAuth2Client's pendingRefresh mechanism.
+func (c *NotionConnector) ensureValidToken(ctx context.Context) error {
+	c.mu.Lock()
+	client := c.oauth2Client
+	refreshToken := c.config.RefreshToken
+	expiresAt := c.config.TokenExpiresAt
+	c.mu.Unlock()
+
+	// No OAuth2 client means internal integration token -- never expires.
+	if client == nil {
+		return nil
+	}
+
+	// Check if token is still valid (with 5-minute buffer).
+	if time.Now().Add(tokenExpiryBuffer).Before(expiresAt) {
+		return nil
+	}
+
+	// Token expired or within buffer -- refresh.
+	refreshed, err := client.RefreshToken(ctx, refreshToken)
+	if err != nil {
+		c.mu.Lock()
+		c.errorCount++
+		c.mu.Unlock()
+		return fmt.Errorf("connector/notion: token refresh failed: %w", err)
+	}
+
+	c.mu.Lock()
+	c.config.APIToken = refreshed.AccessToken
+	c.config.TokenExpiresAt = refreshed.ExpiresAt
+	if refreshed.RefreshToken != "" {
+		c.config.RefreshToken = refreshed.RefreshToken
+	}
+	c.mu.Unlock()
+
+	// Persist refreshed token if a token store is available.
+	if c.tokenStore != nil {
+		tok := OAuth2Token{
+			AccessToken:  refreshed.AccessToken,
+			RefreshToken: refreshed.RefreshToken,
+			ExpiresAt:    refreshed.ExpiresAt,
+			TokenType:    "Bearer",
+		}
+		if storeErr := c.tokenStore.Save(ctx, "notion", c.deps.BrainID, tok); storeErr != nil {
+			// Log-and-continue: failure to persist is not fatal.
+			_ = storeErr
+		}
+	}
+
+	return nil
+}
+
+// Health returns the current health status of the connector.
+func (c *NotionConnector) Health() HealthStatus {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	status := StatusConnected
+	var message string
+
+	if !c.configured {
+		status = StatusDisconnected
+		message = "connector not configured"
+	} else if c.errorCount > 0 {
+		status = StatusDegraded
+		message = fmt.Sprintf("%d errors since last successful sync", c.errorCount)
+	}
+
+	return HealthStatus{
+		Status:             status,
+		LastSyncAt:         c.lastSyncAt,
+		ErrorCount:         c.errorCount,
+		RateLimitRemaining: -1,
+		Message:            message,
+	}
+}
+
 // syncPages fetches pages and databases, optionally filtering by
 // sinceISO for incremental sync.
 func (c *NotionConnector) syncPages(ctx context.Context, sinceISO string, docs chan<- ConnectorDocument, errs chan<- error) error {
@@ -316,27 +433,56 @@ func (c *NotionConnector) syncPages(ctx context.Context, sinceISO string, docs c
 	return nil
 }
 
+// notionSearchRequestBody is the typed request body for the Notion
+// search API endpoint.
+type notionSearchRequestBody struct {
+	PageSize    int               `json:"page_size"`
+	Sort        *notionSearchSort `json:"sort,omitempty"`
+	StartCursor string            `json:"start_cursor,omitempty"`
+}
+
+// notionSearchSort represents the sort parameter for search requests.
+type notionSearchSort struct {
+	Direction string `json:"direction"`
+	Timestamp string `json:"timestamp"`
+}
+
+// notionDatabaseQueryBody is the typed request body for the Notion
+// database query API endpoint.
+type notionDatabaseQueryBody struct {
+	PageSize    int                       `json:"page_size"`
+	StartCursor string                    `json:"start_cursor,omitempty"`
+	Filter      *notionDatabaseTimeFilter `json:"filter,omitempty"`
+}
+
+// notionDatabaseTimeFilter represents a last_edited_time filter.
+type notionDatabaseTimeFilter struct {
+	Timestamp      string                   `json:"timestamp"`
+	LastEditedTime notionTimestampCondition  `json:"last_edited_time"`
+}
+
+// notionTimestampCondition holds the condition for timestamp filters.
+type notionTimestampCondition struct {
+	OnOrAfter string `json:"on_or_after,omitempty"`
+}
+
 // searchWorkspace uses the Notion search API to discover all
 // accessible pages and databases.
 func (c *NotionConnector) searchWorkspace(ctx context.Context, sinceISO string, visited map[string]struct{}, docs chan<- ConnectorDocument, errs chan<- error) error {
 	var cursor string
 
 	for {
-		if err := c.acquireRateLimit(ctx); err != nil {
-			return err
-		}
-
-		body := map[string]any{
-			"page_size": notionDefaultPageSize,
+		body := notionSearchRequestBody{
+			PageSize: notionDefaultPageSize,
 		}
 		if sinceISO != "" {
-			body["sort"] = map[string]string{
-				"direction": "descending",
-				"timestamp": "last_edited_time",
+			body.Sort = &notionSearchSort{
+				Direction: "descending",
+				Timestamp: "last_edited_time",
 			}
 		}
 		if cursor != "" {
-			body["start_cursor"] = cursor
+			body.StartCursor = cursor
 		}
 
 		respBody, err := c.doNotionRequest(ctx, http.MethodPost, "/search", body)
@@ -409,17 +555,13 @@ func (c *NotionConnector) fetchPageTree(ctx context.Context, pageID string, dept
 	visited[pageID] = struct{}{}
 
 	// Fetch page metadata.
-	if err := c.acquireRateLimit(ctx); err != nil {
-		return err
-	}
-
 	respBody, err := c.doNotionRequest(ctx, http.MethodGet, "/pages/"+pageID, nil)
 	if err != nil {
 		errs <- fmt.Errorf("connector/notion: fetching page %s: %w", pageID, err)
 		return nil
 	}
 
-	page, err := c.parsePageResponse(respBody)
+	page, err := parsePageResponse(respBody)
 	if err != nil {
 		errs <- fmt.Errorf("connector/notion: parsing page %s: %w", pageID, err)
 		return nil
@@ -481,10 +623,6 @@ func (c *NotionConnector) fetchPageTree(ctx context.Context, pageID string, dept
 // API first, falls back to block-by-block reconstruction.
 func (c *NotionConnector) fetchPageContent(ctx context.Context, pageID string) (string, error) {
 	// Try Markdown API.
-	if err := c.acquireRateLimit(ctx); err != nil {
-		return "", err
-	}
-
 	content, err := c.fetchMarkdownAPI(ctx, pageID)
 	if err == nil {
 		return content, nil
@@ -512,21 +650,14 @@ func (c *NotionConnector) fetchMarkdownAPI(ctx context.Context, pageID string) (
 	return mdResp.Markdown, nil
 }
 
-// fetchBlocksAsMarkdown retrieves all block children and converts
-// them to markdown recursively.
-func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID string, depth int) (string, error) {
-	if depth > c.config.MaxDepth {
-		return "", nil
-	}
-
+// fetchBlockChildren paginates through all block children of the
+// given block ID. This is the shared pagination helper used by both
+// fetchBlocksAsMarkdown and fetchChildPageIDs to avoid duplication.
+func (c *NotionConnector) fetchBlockChildren(ctx context.Context, blockID string) ([]notionBlock, error) {
 	var allBlocks []notionBlock
 	var cursor string
 
 	for {
-		if err := c.acquireRateLimit(ctx); err != nil {
-			return "", err
-		}
-
 		endpoint := fmt.Sprintf("/blocks/%s/children?page_size=%d", blockID, notionDefaultPageSize)
 		if cursor != "" {
 			endpoint += "&start_cursor=" + cursor
@@ -534,12 +665,12 @@ func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID str
 
 		respBody, err := c.doNotionRequest(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
-			return "", fmt.Errorf("connector/notion: fetching blocks for %s: %w", blockID, err)
+			return nil, fmt.Errorf("connector/notion: fetching blocks for %s: %w", blockID, err)
 		}
 
 		var blockResp notionBlockChildrenResponse
 		if err := json.Unmarshal(respBody, &blockResp); err != nil {
-			return "", fmt.Errorf("connector/notion: parsing blocks: %w", err)
+			return nil, fmt.Errorf("connector/notion: parsing blocks: %w", err)
 		}
 
 		allBlocks = append(allBlocks, blockResp.Results...)
@@ -548,6 +679,21 @@ func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID str
 			break
 		}
 		cursor = blockResp.NextCursor
+	}
+
+	return allBlocks, nil
+}
+
+// fetchBlocksAsMarkdown retrieves all block children and converts
+// them to markdown recursively.
+func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID string, depth int) (string, error) {
+	if depth > c.config.MaxDepth {
+		return "", nil
+	}
+
+	allBlocks, err := c.fetchBlockChildren(ctx, blockID)
+	if err != nil {
+		return "", err
 	}
 
 	var builder strings.Builder
@@ -562,8 +708,8 @@ func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID str
 
 		// Recursively fetch children of blocks that have them.
 		if block.HasChildren {
-			childContent, err := c.fetchBlocksAsMarkdown(ctx, block.ID, depth+1)
-			if err != nil {
+			childContent, childErr := c.fetchBlocksAsMarkdown(ctx, block.ID, depth+1)
+			if childErr != nil {
 				continue
 			}
 			if childContent != "" {
@@ -583,112 +729,22 @@ func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID str
 	return builder.String(), nil
 }
 
-// blockToMarkdown converts a single Notion block to its markdown
-// representation.
-func (c *NotionConnector) blockToMarkdown(block notionBlock) string {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(block.RawData, &raw); err != nil {
-		return ""
+// fetchChildPageIDs returns the IDs of child pages within a block.
+// Uses the shared fetchBlockChildren helper to avoid duplicating
+// the pagination loop.
+func (c *NotionConnector) fetchChildPageIDs(ctx context.Context, blockID string) ([]string, error) {
+	allBlocks, err := c.fetchBlockChildren(ctx, blockID)
+	if err != nil {
+		return nil, err
 	}
 
-	blockData, ok := raw[block.Type]
-	if !ok {
-		return ""
+	var childIDs []string
+	for _, block := range allBlocks {
+		if block.Type == "child_page" || block.Type == "child_database" {
+			childIDs = append(childIDs, block.ID)
+		}
 	}
-
-	var typed struct {
-		RichText []notionRichText `json:"rich_text"`
-		Caption  []notionRichText `json:"caption"`
-		Language string           `json:"language"`
-		URL      string           `json:"url"`
-		Checked  bool             `json:"checked"`
-		Expression string         `json:"expression"`
-	}
-	if err := json.Unmarshal(blockData, &typed); err != nil {
-		return ""
-	}
-
-	text := renderRichText(typed.RichText)
-
-	blockRenderers := map[string]func() string{
-		"paragraph":          func() string { return text + "\n" },
-		"heading_1":          func() string { return "# " + text + "\n" },
-		"heading_2":          func() string { return "## " + text + "\n" },
-		"heading_3":          func() string { return "### " + text + "\n" },
-		"bulleted_list_item": func() string { return "- " + text },
-		"numbered_list_item": func() string { return "1. " + text },
-		"to_do": func() string {
-			marker := "[ ]"
-			if typed.Checked {
-				marker = "[x]"
-			}
-			return "- " + marker + " " + text
-		},
-		"toggle":    func() string { return "- " + text },
-		"quote":     func() string { return "> " + text + "\n" },
-		"callout":   func() string { return "> " + text + "\n" },
-		"divider":   func() string { return "---\n" },
-		"code": func() string {
-			lang := typed.Language
-			return "```" + lang + "\n" + text + "\n```\n"
-		},
-		"equation": func() string {
-			return "$$\n" + typed.Expression + "\n$$\n"
-		},
-		"image": func() string {
-			caption := renderRichText(typed.Caption)
-			url := extractFileURL(blockData)
-			if caption != "" {
-				return fmt.Sprintf("![%s](%s)\n", caption, url)
-			}
-			return fmt.Sprintf("![](%s)\n", url)
-		},
-		"file": func() string {
-			url := extractFileURL(blockData)
-			caption := renderRichText(typed.Caption)
-			if caption == "" {
-				caption = "file"
-			}
-			return fmt.Sprintf("[%s](%s)\n", caption, url)
-		},
-		"bookmark": func() string {
-			caption := renderRichText(typed.Caption)
-			if typed.URL != "" {
-				if caption != "" {
-					return fmt.Sprintf("[%s](%s)\n", caption, typed.URL)
-				}
-				return typed.URL + "\n"
-			}
-			return ""
-		},
-		"embed": func() string {
-			if typed.URL != "" {
-				return typed.URL + "\n"
-			}
-			return ""
-		},
-		"table_of_contents": func() string { return "" },
-		"breadcrumb":        func() string { return "" },
-		"column_list":       func() string { return "" },
-		"column":            func() string { return "" },
-		"child_page":        func() string { return "" },
-		"child_database":    func() string { return "" },
-		"synced_block":      func() string { return "" },
-		"link_preview": func() string {
-			if typed.URL != "" {
-				return typed.URL + "\n"
-			}
-			return ""
-		},
-		"table":     func() string { return "" },
-		"table_row": func() string { return renderTableRow(blockData) },
-	}
-
-	renderer, found := blockRenderers[block.Type]
-	if !found {
-		return text
-	}
-	return renderer()
+	return childIDs, nil
 }
 
 // fetchDatabaseEntries queries a database and yields each entry as
@@ -697,22 +753,18 @@ func (c *NotionConnector) fetchDatabaseEntries(ctx context.Context, dbID string,
 	var cursor string
 
 	for {
-		if err := c.acquireRateLimit(ctx); err != nil {
-			return err
-		}
-
-		body := map[string]any{
-			"page_size": notionDefaultPageSize,
+		body := notionDatabaseQueryBody{
+			PageSize: notionDefaultPageSize,
 		}
 		if cursor != "" {
-			body["start_cursor"] = cursor
+			body.StartCursor = cursor
 		}
 
 		// For incremental sync, filter by last_edited_time.
 		if sinceISO != "" {
-			body["filter"] = map[string]any{
-				"timestamp":        "last_edited_time",
-				"last_edited_time": map[string]string{"on_or_after": sinceISO},
+			body.Filter = &notionDatabaseTimeFilter{
+				Timestamp:      "last_edited_time",
+				LastEditedTime: notionTimestampCondition{OnOrAfter: sinceISO},
 			}
 		}
 
@@ -727,7 +779,7 @@ func (c *NotionConnector) fetchDatabaseEntries(ctx context.Context, dbID string,
 		}
 
 		for _, raw := range queryResp.Results {
-			entry, parseErr := c.parseDatabaseEntry(raw)
+			entry, parseErr := parseDatabaseEntry(raw)
 			if parseErr != nil {
 				errs <- fmt.Errorf("connector/notion: parsing database entry: %w", parseErr)
 				continue
@@ -781,439 +833,3 @@ func (c *NotionConnector) fetchDatabaseEntries(ctx context.Context, dbID string,
 	return nil
 }
 
-// databaseEntryParsed holds parsed fields from a database entry.
-type databaseEntryParsed struct {
-	pageID             string
-	title              string
-	url                string
-	lastEditedTime     time.Time
-	propertiesMarkdown string
-}
-
-// parseDatabaseEntry extracts structured data from a raw database
-// entry JSON.
-func (c *NotionConnector) parseDatabaseEntry(raw json.RawMessage) (databaseEntryParsed, error) {
-	var entry struct {
-		ID             string                     `json:"id"`
-		URL            string                     `json:"url"`
-		LastEditedTime string                     `json:"last_edited_time"`
-		Properties     map[string]json.RawMessage `json:"properties"`
-	}
-	if err := json.Unmarshal(raw, &entry); err != nil {
-		return databaseEntryParsed{}, err
-	}
-
-	editedTime, _ := time.Parse(time.RFC3339, entry.LastEditedTime)
-
-	title := ""
-	var propLines []string
-
-	// Sort property keys for deterministic output.
-	keys := make([]string, 0, len(entry.Properties))
-	for k := range entry.Properties {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		propRaw := entry.Properties[key]
-		val := extractPropertyValue(propRaw)
-
-		// Detect title property.
-		var propType struct {
-			Type string `json:"type"`
-		}
-		if err := json.Unmarshal(propRaw, &propType); err == nil && propType.Type == "title" {
-			title = val
-			continue
-		}
-
-		if val != "" {
-			propLines = append(propLines, fmt.Sprintf("- **%s**: %s", key, val))
-		}
-	}
-
-	var builder strings.Builder
-	if title != "" {
-		builder.WriteString("## " + title + "\n\n")
-	}
-	if len(propLines) > 0 {
-		builder.WriteString(strings.Join(propLines, "\n"))
-		builder.WriteString("\n")
-	}
-
-	return databaseEntryParsed{
-		pageID:             entry.ID,
-		title:              title,
-		url:                entry.URL,
-		lastEditedTime:     editedTime,
-		propertiesMarkdown: builder.String(),
-	}, nil
-}
-
-// fetchChildPageIDs returns the IDs of child pages within a block.
-func (c *NotionConnector) fetchChildPageIDs(ctx context.Context, blockID string) ([]string, error) {
-	var childIDs []string
-	var cursor string
-
-	for {
-		if err := c.acquireRateLimit(ctx); err != nil {
-			return nil, err
-		}
-
-		endpoint := fmt.Sprintf("/blocks/%s/children?page_size=%d", blockID, notionDefaultPageSize)
-		if cursor != "" {
-			endpoint += "&start_cursor=" + cursor
-		}
-
-		respBody, err := c.doNotionRequest(ctx, http.MethodGet, endpoint, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		var blockResp notionBlockChildrenResponse
-		if err := json.Unmarshal(respBody, &blockResp); err != nil {
-			return nil, fmt.Errorf("connector/notion: parsing block children: %w", err)
-		}
-
-		for _, block := range blockResp.Results {
-			if block.Type == "child_page" || block.Type == "child_database" {
-				childIDs = append(childIDs, block.ID)
-			}
-		}
-
-		if !blockResp.HasMore || blockResp.NextCursor == "" {
-			break
-		}
-		cursor = blockResp.NextCursor
-	}
-
-	return childIDs, nil
-}
-
-// parsePageResponse extracts page metadata from a Notion page API
-// response.
-func (c *NotionConnector) parsePageResponse(data []byte) (NotionPage, error) {
-	var resp struct {
-		ID             string                     `json:"id"`
-		URL            string                     `json:"url"`
-		LastEditedTime string                     `json:"last_edited_time"`
-		Properties     map[string]json.RawMessage `json:"properties"`
-		Parent         struct {
-			Type   string `json:"type"`
-			PageID string `json:"page_id"`
-		} `json:"parent"`
-	}
-	if err := json.Unmarshal(data, &resp); err != nil {
-		return NotionPage{}, fmt.Errorf("parsing page: %w", err)
-	}
-
-	editedTime, _ := time.Parse(time.RFC3339, resp.LastEditedTime)
-
-	// Extract title from properties.
-	title := extractTitleFromProperties(resp.Properties)
-
-	return NotionPage{
-		ID:             resp.ID,
-		Title:          title,
-		URL:            resp.URL,
-		LastEditedTime: editedTime,
-		ParentID:       resp.Parent.PageID,
-	}, nil
-}
-
-// doNotionRequest performs a single Notion API request with proper
-// headers and timeout. Returns the response body or an error.
-func (c *NotionConnector) doNotionRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
-	var bodyReader io.Reader
-	if body != nil {
-		data, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("connector/notion: marshalling request body: %w", err)
-		}
-		bodyReader = strings.NewReader(string(data))
-	}
-
-	url := notionBaseURL + path
-	// Override base URL if set via context (for tests).
-	if baseURL, ok := ctx.Value(notionBaseURLKey{}).(string); ok {
-		url = baseURL + path
-	}
-
-	reqCtx, cancel := context.WithTimeout(ctx, notionDefaultTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, method, url, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("connector/notion: creating request: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+c.config.APIToken)
-	req.Header.Set("Notion-Version", notionAPIVersion)
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("connector/notion: request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
-	if err != nil {
-		return nil, fmt.Errorf("connector/notion: reading response: %w", err)
-	}
-
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("connector/notion: rate limited (429)")
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("connector/notion: not found (404)")
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("connector/notion: HTTP %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	return respBody, nil
-}
-
-// acquireRateLimit acquires a single rate limit token, or returns
-// immediately if no rate limiter is configured.
-func (c *NotionConnector) acquireRateLimit(ctx context.Context) error {
-	if c.deps.RateLimiter == nil {
-		return nil
-	}
-	return c.deps.RateLimiter.Acquire(ctx, 1)
-}
-
-// notionBaseURLKey is a context key for overriding the Notion API
-// base URL in tests.
-type notionBaseURLKey struct{}
-
-// WithNotionBaseURL returns a context with an overridden Notion API
-// base URL.
-func WithNotionBaseURL(ctx context.Context, baseURL string) context.Context {
-	return context.WithValue(ctx, notionBaseURLKey{}, baseURL)
-}
-
-// ---------- Helper functions ----------
-
-// renderRichText converts a slice of Notion rich text objects to a
-// markdown string with formatting annotations.
-func renderRichText(texts []notionRichText) string {
-	var builder strings.Builder
-	for _, t := range texts {
-		text := t.PlainText
-
-		if t.Annotations.Code {
-			text = "`" + text + "`"
-		}
-		if t.Annotations.Bold {
-			text = "**" + text + "**"
-		}
-		if t.Annotations.Italic {
-			text = "*" + text + "*"
-		}
-		if t.Annotations.Strikethrough {
-			text = "~~" + text + "~~"
-		}
-
-		if t.Href != "" {
-			text = "[" + text + "](" + t.Href + ")"
-		}
-
-		builder.WriteString(text)
-	}
-	return builder.String()
-}
-
-// extractFileURL pulls the URL from a file-type block's JSON data.
-func extractFileURL(data json.RawMessage) string {
-	var fileBlock struct {
-		External struct {
-			URL string `json:"url"`
-		} `json:"external"`
-		File struct {
-			URL string `json:"url"`
-		} `json:"file"`
-	}
-	if err := json.Unmarshal(data, &fileBlock); err != nil {
-		return ""
-	}
-	if fileBlock.File.URL != "" {
-		return fileBlock.File.URL
-	}
-	return fileBlock.External.URL
-}
-
-// extractTitleFromProperties finds the title property in a page's
-// properties map and returns its plain text value.
-func extractTitleFromProperties(properties map[string]json.RawMessage) string {
-	for _, propRaw := range properties {
-		var prop struct {
-			Type  string `json:"type"`
-			Title []struct {
-				PlainText string `json:"plain_text"`
-			} `json:"title"`
-		}
-		if err := json.Unmarshal(propRaw, &prop); err != nil {
-			continue
-		}
-		if prop.Type == "title" && len(prop.Title) > 0 {
-			var parts []string
-			for _, t := range prop.Title {
-				parts = append(parts, t.PlainText)
-			}
-			return strings.Join(parts, "")
-		}
-	}
-	return ""
-}
-
-// extractPropertyValue converts a Notion property value to its
-// string representation.
-func extractPropertyValue(raw json.RawMessage) string {
-	var prop struct {
-		Type           string           `json:"type"`
-		Title          []notionRichText `json:"title"`
-		RichText       []notionRichText `json:"rich_text"`
-		Number         *float64         `json:"number"`
-		Select         *struct {
-			Name string `json:"name"`
-		} `json:"select"`
-		MultiSelect []struct {
-			Name string `json:"name"`
-		} `json:"multi_select"`
-		Date *struct {
-			Start string `json:"start"`
-			End   string `json:"end"`
-		} `json:"date"`
-		Checkbox bool `json:"checkbox"`
-		URL      string `json:"url"`
-		Email    string `json:"email"`
-		Phone    string `json:"phone_number"`
-		Status   *struct {
-			Name string `json:"name"`
-		} `json:"status"`
-		People []struct {
-			Name string `json:"name"`
-		} `json:"people"`
-		Relation []struct {
-			ID string `json:"id"`
-		} `json:"relation"`
-	}
-	if err := json.Unmarshal(raw, &prop); err != nil {
-		return ""
-	}
-
-	renderers := map[string]func() string{
-		"title":    func() string { return renderPlainRichText(prop.Title) },
-		"rich_text": func() string { return renderPlainRichText(prop.RichText) },
-		"number": func() string {
-			if prop.Number == nil {
-				return ""
-			}
-			return fmt.Sprintf("%g", *prop.Number)
-		},
-		"select": func() string {
-			if prop.Select == nil {
-				return ""
-			}
-			return prop.Select.Name
-		},
-		"multi_select": func() string {
-			names := make([]string, 0, len(prop.MultiSelect))
-			for _, ms := range prop.MultiSelect {
-				names = append(names, ms.Name)
-			}
-			return strings.Join(names, ", ")
-		},
-		"date": func() string {
-			if prop.Date == nil {
-				return ""
-			}
-			if prop.Date.End != "" {
-				return prop.Date.Start + " to " + prop.Date.End
-			}
-			return prop.Date.Start
-		},
-		"checkbox": func() string {
-			if prop.Checkbox {
-				return "true"
-			}
-			return "false"
-		},
-		"url":          func() string { return prop.URL },
-		"email":        func() string { return prop.Email },
-		"phone_number": func() string { return prop.Phone },
-		"status": func() string {
-			if prop.Status == nil {
-				return ""
-			}
-			return prop.Status.Name
-		},
-		"people": func() string {
-			names := make([]string, 0, len(prop.People))
-			for _, p := range prop.People {
-				names = append(names, p.Name)
-			}
-			return strings.Join(names, ", ")
-		},
-		"relation": func() string {
-			ids := make([]string, 0, len(prop.Relation))
-			for _, r := range prop.Relation {
-				ids = append(ids, r.ID)
-			}
-			return strings.Join(ids, ", ")
-		},
-	}
-
-	renderer, found := renderers[prop.Type]
-	if !found {
-		return ""
-	}
-	return renderer()
-}
-
-// renderPlainRichText extracts plain text from a rich text array
-// without formatting.
-func renderPlainRichText(texts []notionRichText) string {
-	var parts []string
-	for _, t := range texts {
-		parts = append(parts, t.PlainText)
-	}
-	return strings.Join(parts, "")
-}
-
-// isListBlock returns true if the block type is a list item.
-func isListBlock(blockType string) bool {
-	listTypes := map[string]struct{}{
-		"bulleted_list_item": {},
-		"numbered_list_item": {},
-		"to_do":              {},
-		"toggle":             {},
-	}
-	_, ok := listTypes[blockType]
-	return ok
-}
-
-// renderTableRow converts a table_row block to a markdown table
-// row.
-func renderTableRow(data json.RawMessage) string {
-	var row struct {
-		Cells [][]notionRichText `json:"cells"`
-	}
-	if err := json.Unmarshal(data, &row); err != nil {
-		return ""
-	}
-
-	cells := make([]string, 0, len(row.Cells))
-	for _, cell := range row.Cells {
-		cells = append(cells, renderRichText(cell))
-	}
-
-	return "| " + strings.Join(cells, " | ") + " |"
-}

--- a/go/connector/notion.go
+++ b/go/connector/notion.go
@@ -1,0 +1,1219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// notionAPIVersion is the Notion API version header value.
+const notionAPIVersion = "2022-06-28"
+
+// notionBaseURL is the root endpoint for the Notion API.
+const notionBaseURL = "https://api.notion.com/v1"
+
+// notionDefaultMaxDepth caps recursive page traversal.
+const notionDefaultMaxDepth = 10
+
+// notionDefaultPollInterval is the default continuous sync interval.
+const notionDefaultPollInterval = 15 * time.Minute
+
+// notionDefaultTimeout is the per-request HTTP timeout for Notion
+// API calls.
+const notionDefaultTimeout = 30 * time.Second
+
+// notionDefaultPageSize is the default page size for paginated
+// Notion API requests.
+const notionDefaultPageSize = 100
+
+// NotionConnectorConfig holds Notion-specific configuration.
+type NotionConnectorConfig struct {
+	APIToken          string
+	RootPageIDs       []string
+	DatabaseIDs       []string
+	IncludeChildPages bool // default: true
+	IncludeDatabases  bool // default: true
+	MaxDepth          int  // default: 10
+}
+
+// NotionPage represents a Notion page object from the API.
+type NotionPage struct {
+	ID             string
+	Title          string
+	URL            string
+	LastEditedTime time.Time
+	ParentID       string
+}
+
+// notionSearchResponse models the Notion search API response.
+type notionSearchResponse struct {
+	Results    []json.RawMessage `json:"results"`
+	NextCursor string            `json:"next_cursor"`
+	HasMore    bool              `json:"has_more"`
+}
+
+// notionDatabaseQueryResponse models the database query response.
+type notionDatabaseQueryResponse struct {
+	Results    []json.RawMessage `json:"results"`
+	NextCursor string            `json:"next_cursor"`
+	HasMore    bool              `json:"has_more"`
+}
+
+// notionBlockChildrenResponse models the block children response.
+type notionBlockChildrenResponse struct {
+	Results    []notionBlock `json:"results"`
+	NextCursor string       `json:"next_cursor"`
+	HasMore    bool         `json:"has_more"`
+}
+
+// notionBlock represents a single Notion block.
+type notionBlock struct {
+	ID          string          `json:"id"`
+	Type        string          `json:"type"`
+	HasChildren bool            `json:"has_children"`
+	RawData     json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON implements custom unmarshalling for notionBlock to
+// capture the full raw data alongside parsed fields.
+func (b *notionBlock) UnmarshalJSON(data []byte) error {
+	type alias notionBlock
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	a.RawData = data
+	*b = notionBlock(a)
+	return nil
+}
+
+// notionRichText represents a Notion rich text object.
+type notionRichText struct {
+	Type      string                 `json:"type"`
+	PlainText string                 `json:"plain_text"`
+	Href      string                 `json:"href"`
+	Annotations notionAnnotations    `json:"annotations"`
+}
+
+// notionAnnotations contains formatting flags for rich text.
+type notionAnnotations struct {
+	Bold          bool   `json:"bold"`
+	Italic        bool   `json:"italic"`
+	Strikethrough bool   `json:"strikethrough"`
+	Underline     bool   `json:"underline"`
+	Code          bool   `json:"code"`
+	Colour        string `json:"color"`
+}
+
+// NotionHTTPClient abstracts HTTP calls so tests can inject a mock.
+type NotionHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// NotionConnector implements [Connector] for Notion workspaces.
+type NotionConnector struct {
+	deps        ConnectorConfig
+	config      NotionConnectorConfig
+	httpClient  NotionHTTPClient
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	configured  bool
+}
+
+// NewNotionConnector creates a Notion connector with the given base
+// dependencies and an HTTP client for API calls.
+func NewNotionConnector(deps ConnectorConfig, httpClient NotionHTTPClient) *NotionConnector {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: notionDefaultTimeout}
+	}
+	return &NotionConnector{
+		deps:       deps,
+		httpClient: httpClient,
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Name returns "notion".
+func (c *NotionConnector) Name() string { return "notion" }
+
+// Configure validates and stores Notion-specific configuration.
+func (c *NotionConnector) Configure(config map[string]any) error {
+	token, _ := config["apiToken"].(string)
+	if strings.TrimSpace(token) == "" {
+		return fmt.Errorf("connector/notion: apiToken is required")
+	}
+
+	cfg := NotionConnectorConfig{
+		APIToken:          token,
+		IncludeChildPages: true,
+		IncludeDatabases:  true,
+		MaxDepth:          notionDefaultMaxDepth,
+	}
+
+	if ids, ok := config["rootPageIds"].([]string); ok {
+		cfg.RootPageIDs = ids
+	}
+	if raw, ok := config["rootPageIds"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				cfg.RootPageIDs = append(cfg.RootPageIDs, s)
+			}
+		}
+	}
+
+	if ids, ok := config["databaseIds"].([]string); ok {
+		cfg.DatabaseIDs = ids
+	}
+	if raw, ok := config["databaseIds"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				cfg.DatabaseIDs = append(cfg.DatabaseIDs, s)
+			}
+		}
+	}
+
+	if v, ok := config["includeChildPages"].(bool); ok {
+		cfg.IncludeChildPages = v
+	}
+	if v, ok := config["includeDatabases"].(bool); ok {
+		cfg.IncludeDatabases = v
+	}
+	if v, ok := config["maxDepth"].(int); ok && v > 0 {
+		cfg.MaxDepth = v
+	}
+	if v, ok := config["maxDepth"].(float64); ok && v > 0 {
+		cfg.MaxDepth = int(v)
+	}
+
+	c.config = cfg
+	c.configured = true
+	return nil
+}
+
+// FetchAll streams all accessible pages and database entries.
+func (c *NotionConnector) FetchAll(ctx context.Context) (<-chan ConnectorDocument, <-chan error) {
+	docs := make(chan ConnectorDocument, 32)
+	errs := make(chan error, 8)
+
+	go func() {
+		defer close(docs)
+		defer close(errs)
+
+		if !c.configured {
+			errs <- fmt.Errorf("connector/notion: not configured, call Configure first")
+			return
+		}
+
+		if err := c.syncPages(ctx, "", docs, errs); err != nil {
+			errs <- err
+		}
+	}()
+
+	return docs, errs
+}
+
+// FetchSince streams documents modified since the cursor timestamp.
+func (c *NotionConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-chan ConnectorDocument, <-chan error) {
+	docs := make(chan ConnectorDocument, 32)
+	errs := make(chan error, 8)
+
+	go func() {
+		defer close(docs)
+		defer close(errs)
+
+		if !c.configured {
+			errs <- fmt.Errorf("connector/notion: not configured, call Configure first")
+			return
+		}
+
+		if err := c.syncPages(ctx, cursor.Value, docs, errs); err != nil {
+			errs <- err
+		}
+	}()
+
+	return docs, errs
+}
+
+// Start begins a continuous sync loop. Blocks until Stop is called
+// or the context is cancelled.
+func (c *NotionConnector) Start(ctx context.Context) error {
+	if !c.configured {
+		return fmt.Errorf("connector/notion: not configured, call Configure first")
+	}
+
+	interval := c.deps.PollInterval
+	if interval == 0 {
+		interval = notionDefaultPollInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.stopCh:
+			return nil
+		case <-ticker.C:
+			docsCh, errsCh := c.FetchAll(ctx)
+			// drain channels
+			for range docsCh {
+			}
+			for err := range errsCh {
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// Stop signals the continuous sync loop to stop.
+func (c *NotionConnector) Stop() error {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
+	return nil
+}
+
+// syncPages fetches pages and databases, optionally filtering by
+// sinceISO for incremental sync.
+func (c *NotionConnector) syncPages(ctx context.Context, sinceISO string, docs chan<- ConnectorDocument, errs chan<- error) error {
+	visited := make(map[string]struct{})
+
+	// Fetch specific root pages if configured.
+	for _, pageID := range c.config.RootPageIDs {
+		if err := c.fetchPageTree(ctx, pageID, 0, sinceISO, visited, docs, errs); err != nil {
+			return err
+		}
+	}
+
+	// Fetch specific databases if configured.
+	if c.config.IncludeDatabases {
+		for _, dbID := range c.config.DatabaseIDs {
+			if err := c.fetchDatabaseEntries(ctx, dbID, sinceISO, visited, docs, errs); err != nil {
+				return err
+			}
+		}
+	}
+
+	// If no specific pages or databases, search the entire workspace.
+	if len(c.config.RootPageIDs) == 0 && len(c.config.DatabaseIDs) == 0 {
+		if err := c.searchWorkspace(ctx, sinceISO, visited, docs, errs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// searchWorkspace uses the Notion search API to discover all
+// accessible pages and databases.
+func (c *NotionConnector) searchWorkspace(ctx context.Context, sinceISO string, visited map[string]struct{}, docs chan<- ConnectorDocument, errs chan<- error) error {
+	var cursor string
+
+	for {
+		if err := c.acquireRateLimit(ctx); err != nil {
+			return err
+		}
+
+		body := map[string]any{
+			"page_size": notionDefaultPageSize,
+		}
+		if sinceISO != "" {
+			body["sort"] = map[string]string{
+				"direction": "descending",
+				"timestamp": "last_edited_time",
+			}
+		}
+		if cursor != "" {
+			body["start_cursor"] = cursor
+		}
+
+		respBody, err := c.doNotionRequest(ctx, http.MethodPost, "/search", body)
+		if err != nil {
+			return fmt.Errorf("connector/notion: search: %w", err)
+		}
+
+		var searchResp notionSearchResponse
+		if err := json.Unmarshal(respBody, &searchResp); err != nil {
+			return fmt.Errorf("connector/notion: parsing search response: %w", err)
+		}
+
+		for _, raw := range searchResp.Results {
+			var obj struct {
+				ID             string `json:"id"`
+				Object         string `json:"object"`
+				LastEditedTime string `json:"last_edited_time"`
+			}
+			if err := json.Unmarshal(raw, &obj); err != nil {
+				errs <- fmt.Errorf("connector/notion: parsing search result: %w", err)
+				continue
+			}
+
+			// For incremental sync, skip items older than cursor.
+			if sinceISO != "" {
+				editedTime, parseErr := time.Parse(time.RFC3339, obj.LastEditedTime)
+				if parseErr == nil {
+					cursorTime, cursorErr := time.Parse(time.RFC3339, sinceISO)
+					if cursorErr == nil && editedTime.Before(cursorTime) {
+						// Results sorted descending; all further results are older.
+						return nil
+					}
+				}
+			}
+
+			switch obj.Object {
+			case "page":
+				if err := c.fetchPageTree(ctx, obj.ID, 0, sinceISO, visited, docs, errs); err != nil {
+					return err
+				}
+			case "database":
+				if c.config.IncludeDatabases {
+					if err := c.fetchDatabaseEntries(ctx, obj.ID, sinceISO, visited, docs, errs); err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+		if !searchResp.HasMore || searchResp.NextCursor == "" {
+			break
+		}
+		cursor = searchResp.NextCursor
+	}
+
+	return nil
+}
+
+// fetchPageTree recursively fetches a page and its children up to
+// maxDepth. Uses cycle detection via the visited set.
+func (c *NotionConnector) fetchPageTree(ctx context.Context, pageID string, depth int, sinceISO string, visited map[string]struct{}, docs chan<- ConnectorDocument, errs chan<- error) error {
+	if depth > c.config.MaxDepth {
+		return nil
+	}
+
+	// Cycle detection.
+	if _, seen := visited[pageID]; seen {
+		return nil
+	}
+	visited[pageID] = struct{}{}
+
+	// Fetch page metadata.
+	if err := c.acquireRateLimit(ctx); err != nil {
+		return err
+	}
+
+	respBody, err := c.doNotionRequest(ctx, http.MethodGet, "/pages/"+pageID, nil)
+	if err != nil {
+		errs <- fmt.Errorf("connector/notion: fetching page %s: %w", pageID, err)
+		return nil
+	}
+
+	page, err := c.parsePageResponse(respBody)
+	if err != nil {
+		errs <- fmt.Errorf("connector/notion: parsing page %s: %w", pageID, err)
+		return nil
+	}
+
+	// For incremental sync, check last_edited_time.
+	if sinceISO != "" {
+		cursorTime, parseErr := time.Parse(time.RFC3339, sinceISO)
+		if parseErr == nil && page.LastEditedTime.Before(cursorTime) {
+			return nil
+		}
+	}
+
+	// Fetch page content: try Markdown API first, fall back to blocks.
+	content, err := c.fetchPageContent(ctx, pageID)
+	if err != nil {
+		errs <- fmt.Errorf("connector/notion: fetching content for page %s: %w", pageID, err)
+		return nil
+	}
+
+	doc := ConnectorDocument{
+		ExternalID: pageID,
+		Content:    []byte(content),
+		MIME:       "text/markdown",
+		Title:      page.Title,
+		URL:        page.URL,
+		Metadata: map[string]string{
+			"source":           "notion",
+			"type":             "page",
+			"last_edited_time": page.LastEditedTime.Format(time.RFC3339),
+		},
+		ModifiedAt: page.LastEditedTime,
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case docs <- doc:
+	}
+
+	// Recursively fetch child pages.
+	if c.config.IncludeChildPages {
+		childIDs, fetchErr := c.fetchChildPageIDs(ctx, pageID)
+		if fetchErr != nil {
+			errs <- fmt.Errorf("connector/notion: fetching children of %s: %w", pageID, fetchErr)
+			return nil
+		}
+		for _, childID := range childIDs {
+			if err := c.fetchPageTree(ctx, childID, depth+1, sinceISO, visited, docs, errs); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// fetchPageContent retrieves a page's content. Tries the Markdown
+// API first, falls back to block-by-block reconstruction.
+func (c *NotionConnector) fetchPageContent(ctx context.Context, pageID string) (string, error) {
+	// Try Markdown API.
+	if err := c.acquireRateLimit(ctx); err != nil {
+		return "", err
+	}
+
+	content, err := c.fetchMarkdownAPI(ctx, pageID)
+	if err == nil {
+		return content, nil
+	}
+
+	// Fall back to block retrieval.
+	return c.fetchBlocksAsMarkdown(ctx, pageID, 0)
+}
+
+// fetchMarkdownAPI attempts to fetch page content via the Notion
+// Markdown export API (February 2026).
+func (c *NotionConnector) fetchMarkdownAPI(ctx context.Context, pageID string) (string, error) {
+	respBody, err := c.doNotionRequest(ctx, http.MethodGet, "/pages/"+pageID+"/markdown", nil)
+	if err != nil {
+		return "", err
+	}
+
+	var mdResp struct {
+		Markdown string `json:"markdown"`
+	}
+	if err := json.Unmarshal(respBody, &mdResp); err != nil {
+		return "", fmt.Errorf("connector/notion: parsing markdown response: %w", err)
+	}
+
+	return mdResp.Markdown, nil
+}
+
+// fetchBlocksAsMarkdown retrieves all block children and converts
+// them to markdown recursively.
+func (c *NotionConnector) fetchBlocksAsMarkdown(ctx context.Context, blockID string, depth int) (string, error) {
+	if depth > c.config.MaxDepth {
+		return "", nil
+	}
+
+	var allBlocks []notionBlock
+	var cursor string
+
+	for {
+		if err := c.acquireRateLimit(ctx); err != nil {
+			return "", err
+		}
+
+		endpoint := fmt.Sprintf("/blocks/%s/children?page_size=%d", blockID, notionDefaultPageSize)
+		if cursor != "" {
+			endpoint += "&start_cursor=" + cursor
+		}
+
+		respBody, err := c.doNotionRequest(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return "", fmt.Errorf("connector/notion: fetching blocks for %s: %w", blockID, err)
+		}
+
+		var blockResp notionBlockChildrenResponse
+		if err := json.Unmarshal(respBody, &blockResp); err != nil {
+			return "", fmt.Errorf("connector/notion: parsing blocks: %w", err)
+		}
+
+		allBlocks = append(allBlocks, blockResp.Results...)
+
+		if !blockResp.HasMore || blockResp.NextCursor == "" {
+			break
+		}
+		cursor = blockResp.NextCursor
+	}
+
+	var builder strings.Builder
+	for _, block := range allBlocks {
+		md := c.blockToMarkdown(block)
+		if md != "" {
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(md)
+		}
+
+		// Recursively fetch children of blocks that have them.
+		if block.HasChildren {
+			childContent, err := c.fetchBlocksAsMarkdown(ctx, block.ID, depth+1)
+			if err != nil {
+				continue
+			}
+			if childContent != "" {
+				// Indent child content for nested blocks.
+				lines := strings.Split(childContent, "\n")
+				for _, line := range lines {
+					builder.WriteString("\n")
+					if isListBlock(block.Type) {
+						builder.WriteString("  ")
+					}
+					builder.WriteString(line)
+				}
+			}
+		}
+	}
+
+	return builder.String(), nil
+}
+
+// blockToMarkdown converts a single Notion block to its markdown
+// representation.
+func (c *NotionConnector) blockToMarkdown(block notionBlock) string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(block.RawData, &raw); err != nil {
+		return ""
+	}
+
+	blockData, ok := raw[block.Type]
+	if !ok {
+		return ""
+	}
+
+	var typed struct {
+		RichText []notionRichText `json:"rich_text"`
+		Caption  []notionRichText `json:"caption"`
+		Language string           `json:"language"`
+		URL      string           `json:"url"`
+		Checked  bool             `json:"checked"`
+		Expression string         `json:"expression"`
+	}
+	if err := json.Unmarshal(blockData, &typed); err != nil {
+		return ""
+	}
+
+	text := renderRichText(typed.RichText)
+
+	blockRenderers := map[string]func() string{
+		"paragraph":          func() string { return text + "\n" },
+		"heading_1":          func() string { return "# " + text + "\n" },
+		"heading_2":          func() string { return "## " + text + "\n" },
+		"heading_3":          func() string { return "### " + text + "\n" },
+		"bulleted_list_item": func() string { return "- " + text },
+		"numbered_list_item": func() string { return "1. " + text },
+		"to_do": func() string {
+			marker := "[ ]"
+			if typed.Checked {
+				marker = "[x]"
+			}
+			return "- " + marker + " " + text
+		},
+		"toggle":    func() string { return "- " + text },
+		"quote":     func() string { return "> " + text + "\n" },
+		"callout":   func() string { return "> " + text + "\n" },
+		"divider":   func() string { return "---\n" },
+		"code": func() string {
+			lang := typed.Language
+			return "```" + lang + "\n" + text + "\n```\n"
+		},
+		"equation": func() string {
+			return "$$\n" + typed.Expression + "\n$$\n"
+		},
+		"image": func() string {
+			caption := renderRichText(typed.Caption)
+			url := extractFileURL(blockData)
+			if caption != "" {
+				return fmt.Sprintf("![%s](%s)\n", caption, url)
+			}
+			return fmt.Sprintf("![](%s)\n", url)
+		},
+		"file": func() string {
+			url := extractFileURL(blockData)
+			caption := renderRichText(typed.Caption)
+			if caption == "" {
+				caption = "file"
+			}
+			return fmt.Sprintf("[%s](%s)\n", caption, url)
+		},
+		"bookmark": func() string {
+			caption := renderRichText(typed.Caption)
+			if typed.URL != "" {
+				if caption != "" {
+					return fmt.Sprintf("[%s](%s)\n", caption, typed.URL)
+				}
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"embed": func() string {
+			if typed.URL != "" {
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"table_of_contents": func() string { return "" },
+		"breadcrumb":        func() string { return "" },
+		"column_list":       func() string { return "" },
+		"column":            func() string { return "" },
+		"child_page":        func() string { return "" },
+		"child_database":    func() string { return "" },
+		"synced_block":      func() string { return "" },
+		"link_preview": func() string {
+			if typed.URL != "" {
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"table":     func() string { return "" },
+		"table_row": func() string { return renderTableRow(blockData) },
+	}
+
+	renderer, found := blockRenderers[block.Type]
+	if !found {
+		return text
+	}
+	return renderer()
+}
+
+// fetchDatabaseEntries queries a database and yields each entry as
+// a document with property listings.
+func (c *NotionConnector) fetchDatabaseEntries(ctx context.Context, dbID string, sinceISO string, visited map[string]struct{}, docs chan<- ConnectorDocument, errs chan<- error) error {
+	var cursor string
+
+	for {
+		if err := c.acquireRateLimit(ctx); err != nil {
+			return err
+		}
+
+		body := map[string]any{
+			"page_size": notionDefaultPageSize,
+		}
+		if cursor != "" {
+			body["start_cursor"] = cursor
+		}
+
+		// For incremental sync, filter by last_edited_time.
+		if sinceISO != "" {
+			body["filter"] = map[string]any{
+				"timestamp":        "last_edited_time",
+				"last_edited_time": map[string]string{"on_or_after": sinceISO},
+			}
+		}
+
+		respBody, err := c.doNotionRequest(ctx, http.MethodPost, "/databases/"+dbID+"/query", body)
+		if err != nil {
+			return fmt.Errorf("connector/notion: querying database %s: %w", dbID, err)
+		}
+
+		var queryResp notionDatabaseQueryResponse
+		if err := json.Unmarshal(respBody, &queryResp); err != nil {
+			return fmt.Errorf("connector/notion: parsing database query: %w", err)
+		}
+
+		for _, raw := range queryResp.Results {
+			entry, parseErr := c.parseDatabaseEntry(raw)
+			if parseErr != nil {
+				errs <- fmt.Errorf("connector/notion: parsing database entry: %w", parseErr)
+				continue
+			}
+
+			// Cycle detection for database entries that are also pages.
+			if _, seen := visited[entry.pageID]; seen {
+				continue
+			}
+			visited[entry.pageID] = struct{}{}
+
+			// Optionally fetch page content for the entry.
+			var pageContent string
+			if entry.pageID != "" {
+				content, fetchErr := c.fetchPageContent(ctx, entry.pageID)
+				if fetchErr == nil && content != "" {
+					pageContent = "\n\n" + content
+				}
+			}
+
+			fullContent := entry.propertiesMarkdown + pageContent
+
+			doc := ConnectorDocument{
+				ExternalID: entry.pageID,
+				Content:    []byte(fullContent),
+				MIME:       "text/markdown",
+				Title:      entry.title,
+				URL:        entry.url,
+				Metadata: map[string]string{
+					"source":           "notion",
+					"type":             "database_entry",
+					"database_id":      dbID,
+					"last_edited_time": entry.lastEditedTime.Format(time.RFC3339),
+				},
+				ModifiedAt: entry.lastEditedTime,
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case docs <- doc:
+			}
+		}
+
+		if !queryResp.HasMore || queryResp.NextCursor == "" {
+			break
+		}
+		cursor = queryResp.NextCursor
+	}
+
+	return nil
+}
+
+// databaseEntryParsed holds parsed fields from a database entry.
+type databaseEntryParsed struct {
+	pageID             string
+	title              string
+	url                string
+	lastEditedTime     time.Time
+	propertiesMarkdown string
+}
+
+// parseDatabaseEntry extracts structured data from a raw database
+// entry JSON.
+func (c *NotionConnector) parseDatabaseEntry(raw json.RawMessage) (databaseEntryParsed, error) {
+	var entry struct {
+		ID             string                     `json:"id"`
+		URL            string                     `json:"url"`
+		LastEditedTime string                     `json:"last_edited_time"`
+		Properties     map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return databaseEntryParsed{}, err
+	}
+
+	editedTime, _ := time.Parse(time.RFC3339, entry.LastEditedTime)
+
+	title := ""
+	var propLines []string
+
+	// Sort property keys for deterministic output.
+	keys := make([]string, 0, len(entry.Properties))
+	for k := range entry.Properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		propRaw := entry.Properties[key]
+		val := extractPropertyValue(propRaw)
+
+		// Detect title property.
+		var propType struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(propRaw, &propType); err == nil && propType.Type == "title" {
+			title = val
+			continue
+		}
+
+		if val != "" {
+			propLines = append(propLines, fmt.Sprintf("- **%s**: %s", key, val))
+		}
+	}
+
+	var builder strings.Builder
+	if title != "" {
+		builder.WriteString("## " + title + "\n\n")
+	}
+	if len(propLines) > 0 {
+		builder.WriteString(strings.Join(propLines, "\n"))
+		builder.WriteString("\n")
+	}
+
+	return databaseEntryParsed{
+		pageID:             entry.ID,
+		title:              title,
+		url:                entry.URL,
+		lastEditedTime:     editedTime,
+		propertiesMarkdown: builder.String(),
+	}, nil
+}
+
+// fetchChildPageIDs returns the IDs of child pages within a block.
+func (c *NotionConnector) fetchChildPageIDs(ctx context.Context, blockID string) ([]string, error) {
+	var childIDs []string
+	var cursor string
+
+	for {
+		if err := c.acquireRateLimit(ctx); err != nil {
+			return nil, err
+		}
+
+		endpoint := fmt.Sprintf("/blocks/%s/children?page_size=%d", blockID, notionDefaultPageSize)
+		if cursor != "" {
+			endpoint += "&start_cursor=" + cursor
+		}
+
+		respBody, err := c.doNotionRequest(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var blockResp notionBlockChildrenResponse
+		if err := json.Unmarshal(respBody, &blockResp); err != nil {
+			return nil, fmt.Errorf("connector/notion: parsing block children: %w", err)
+		}
+
+		for _, block := range blockResp.Results {
+			if block.Type == "child_page" || block.Type == "child_database" {
+				childIDs = append(childIDs, block.ID)
+			}
+		}
+
+		if !blockResp.HasMore || blockResp.NextCursor == "" {
+			break
+		}
+		cursor = blockResp.NextCursor
+	}
+
+	return childIDs, nil
+}
+
+// parsePageResponse extracts page metadata from a Notion page API
+// response.
+func (c *NotionConnector) parsePageResponse(data []byte) (NotionPage, error) {
+	var resp struct {
+		ID             string                     `json:"id"`
+		URL            string                     `json:"url"`
+		LastEditedTime string                     `json:"last_edited_time"`
+		Properties     map[string]json.RawMessage `json:"properties"`
+		Parent         struct {
+			Type   string `json:"type"`
+			PageID string `json:"page_id"`
+		} `json:"parent"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return NotionPage{}, fmt.Errorf("parsing page: %w", err)
+	}
+
+	editedTime, _ := time.Parse(time.RFC3339, resp.LastEditedTime)
+
+	// Extract title from properties.
+	title := extractTitleFromProperties(resp.Properties)
+
+	return NotionPage{
+		ID:             resp.ID,
+		Title:          title,
+		URL:            resp.URL,
+		LastEditedTime: editedTime,
+		ParentID:       resp.Parent.PageID,
+	}, nil
+}
+
+// doNotionRequest performs a single Notion API request with proper
+// headers and timeout. Returns the response body or an error.
+func (c *NotionConnector) doNotionRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("connector/notion: marshalling request body: %w", err)
+		}
+		bodyReader = strings.NewReader(string(data))
+	}
+
+	url := notionBaseURL + path
+	// Override base URL if set via context (for tests).
+	if baseURL, ok := ctx.Value(notionBaseURLKey{}).(string); ok {
+		url = baseURL + path
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, notionDefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("connector/notion: creating request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.config.APIToken)
+	req.Header.Set("Notion-Version", notionAPIVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connector/notion: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("connector/notion: reading response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("connector/notion: rate limited (429)")
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("connector/notion: not found (404)")
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("connector/notion: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// acquireRateLimit acquires a single rate limit token, or returns
+// immediately if no rate limiter is configured.
+func (c *NotionConnector) acquireRateLimit(ctx context.Context) error {
+	if c.deps.RateLimiter == nil {
+		return nil
+	}
+	return c.deps.RateLimiter.Acquire(ctx, 1)
+}
+
+// notionBaseURLKey is a context key for overriding the Notion API
+// base URL in tests.
+type notionBaseURLKey struct{}
+
+// WithNotionBaseURL returns a context with an overridden Notion API
+// base URL.
+func WithNotionBaseURL(ctx context.Context, baseURL string) context.Context {
+	return context.WithValue(ctx, notionBaseURLKey{}, baseURL)
+}
+
+// ---------- Helper functions ----------
+
+// renderRichText converts a slice of Notion rich text objects to a
+// markdown string with formatting annotations.
+func renderRichText(texts []notionRichText) string {
+	var builder strings.Builder
+	for _, t := range texts {
+		text := t.PlainText
+
+		if t.Annotations.Code {
+			text = "`" + text + "`"
+		}
+		if t.Annotations.Bold {
+			text = "**" + text + "**"
+		}
+		if t.Annotations.Italic {
+			text = "*" + text + "*"
+		}
+		if t.Annotations.Strikethrough {
+			text = "~~" + text + "~~"
+		}
+
+		if t.Href != "" {
+			text = "[" + text + "](" + t.Href + ")"
+		}
+
+		builder.WriteString(text)
+	}
+	return builder.String()
+}
+
+// extractFileURL pulls the URL from a file-type block's JSON data.
+func extractFileURL(data json.RawMessage) string {
+	var fileBlock struct {
+		External struct {
+			URL string `json:"url"`
+		} `json:"external"`
+		File struct {
+			URL string `json:"url"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal(data, &fileBlock); err != nil {
+		return ""
+	}
+	if fileBlock.File.URL != "" {
+		return fileBlock.File.URL
+	}
+	return fileBlock.External.URL
+}
+
+// extractTitleFromProperties finds the title property in a page's
+// properties map and returns its plain text value.
+func extractTitleFromProperties(properties map[string]json.RawMessage) string {
+	for _, propRaw := range properties {
+		var prop struct {
+			Type  string `json:"type"`
+			Title []struct {
+				PlainText string `json:"plain_text"`
+			} `json:"title"`
+		}
+		if err := json.Unmarshal(propRaw, &prop); err != nil {
+			continue
+		}
+		if prop.Type == "title" && len(prop.Title) > 0 {
+			var parts []string
+			for _, t := range prop.Title {
+				parts = append(parts, t.PlainText)
+			}
+			return strings.Join(parts, "")
+		}
+	}
+	return ""
+}
+
+// extractPropertyValue converts a Notion property value to its
+// string representation.
+func extractPropertyValue(raw json.RawMessage) string {
+	var prop struct {
+		Type           string           `json:"type"`
+		Title          []notionRichText `json:"title"`
+		RichText       []notionRichText `json:"rich_text"`
+		Number         *float64         `json:"number"`
+		Select         *struct {
+			Name string `json:"name"`
+		} `json:"select"`
+		MultiSelect []struct {
+			Name string `json:"name"`
+		} `json:"multi_select"`
+		Date *struct {
+			Start string `json:"start"`
+			End   string `json:"end"`
+		} `json:"date"`
+		Checkbox bool `json:"checkbox"`
+		URL      string `json:"url"`
+		Email    string `json:"email"`
+		Phone    string `json:"phone_number"`
+		Status   *struct {
+			Name string `json:"name"`
+		} `json:"status"`
+		People []struct {
+			Name string `json:"name"`
+		} `json:"people"`
+		Relation []struct {
+			ID string `json:"id"`
+		} `json:"relation"`
+	}
+	if err := json.Unmarshal(raw, &prop); err != nil {
+		return ""
+	}
+
+	renderers := map[string]func() string{
+		"title":    func() string { return renderPlainRichText(prop.Title) },
+		"rich_text": func() string { return renderPlainRichText(prop.RichText) },
+		"number": func() string {
+			if prop.Number == nil {
+				return ""
+			}
+			return fmt.Sprintf("%g", *prop.Number)
+		},
+		"select": func() string {
+			if prop.Select == nil {
+				return ""
+			}
+			return prop.Select.Name
+		},
+		"multi_select": func() string {
+			names := make([]string, 0, len(prop.MultiSelect))
+			for _, ms := range prop.MultiSelect {
+				names = append(names, ms.Name)
+			}
+			return strings.Join(names, ", ")
+		},
+		"date": func() string {
+			if prop.Date == nil {
+				return ""
+			}
+			if prop.Date.End != "" {
+				return prop.Date.Start + " to " + prop.Date.End
+			}
+			return prop.Date.Start
+		},
+		"checkbox": func() string {
+			if prop.Checkbox {
+				return "true"
+			}
+			return "false"
+		},
+		"url":          func() string { return prop.URL },
+		"email":        func() string { return prop.Email },
+		"phone_number": func() string { return prop.Phone },
+		"status": func() string {
+			if prop.Status == nil {
+				return ""
+			}
+			return prop.Status.Name
+		},
+		"people": func() string {
+			names := make([]string, 0, len(prop.People))
+			for _, p := range prop.People {
+				names = append(names, p.Name)
+			}
+			return strings.Join(names, ", ")
+		},
+		"relation": func() string {
+			ids := make([]string, 0, len(prop.Relation))
+			for _, r := range prop.Relation {
+				ids = append(ids, r.ID)
+			}
+			return strings.Join(ids, ", ")
+		},
+	}
+
+	renderer, found := renderers[prop.Type]
+	if !found {
+		return ""
+	}
+	return renderer()
+}
+
+// renderPlainRichText extracts plain text from a rich text array
+// without formatting.
+func renderPlainRichText(texts []notionRichText) string {
+	var parts []string
+	for _, t := range texts {
+		parts = append(parts, t.PlainText)
+	}
+	return strings.Join(parts, "")
+}
+
+// isListBlock returns true if the block type is a list item.
+func isListBlock(blockType string) bool {
+	listTypes := map[string]struct{}{
+		"bulleted_list_item": {},
+		"numbered_list_item": {},
+		"to_do":              {},
+		"toggle":             {},
+	}
+	_, ok := listTypes[blockType]
+	return ok
+}
+
+// renderTableRow converts a table_row block to a markdown table
+// row.
+func renderTableRow(data json.RawMessage) string {
+	var row struct {
+		Cells [][]notionRichText `json:"cells"`
+	}
+	if err := json.Unmarshal(data, &row); err != nil {
+		return ""
+	}
+
+	cells := make([]string, 0, len(row.Cells))
+	for _, cell := range row.Cells {
+		cells = append(cells, renderRichText(cell))
+	}
+
+	return "| " + strings.Join(cells, " | ") + " |"
+}

--- a/go/connector/notion_blocks.go
+++ b/go/connector/notion_blocks.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// notionSearchResponse models the Notion search API response.
+type notionSearchResponse struct {
+	Results    []json.RawMessage `json:"results"`
+	NextCursor string            `json:"next_cursor"`
+	HasMore    bool              `json:"has_more"`
+}
+
+// notionDatabaseQueryResponse models the database query response.
+type notionDatabaseQueryResponse struct {
+	Results    []json.RawMessage `json:"results"`
+	NextCursor string            `json:"next_cursor"`
+	HasMore    bool              `json:"has_more"`
+}
+
+// notionBlockChildrenResponse models the block children response.
+type notionBlockChildrenResponse struct {
+	Results    []notionBlock `json:"results"`
+	NextCursor string       `json:"next_cursor"`
+	HasMore    bool         `json:"has_more"`
+}
+
+// notionBlock represents a single Notion block.
+type notionBlock struct {
+	ID          string          `json:"id"`
+	Type        string          `json:"type"`
+	HasChildren bool            `json:"has_children"`
+	RawData     json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON implements custom unmarshalling for notionBlock to
+// capture the full raw data alongside parsed fields.
+func (b *notionBlock) UnmarshalJSON(data []byte) error {
+	type alias notionBlock
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	a.RawData = data
+	*b = notionBlock(a)
+	return nil
+}
+
+// notionRichText represents a Notion rich text object.
+type notionRichText struct {
+	Type        string             `json:"type"`
+	PlainText   string             `json:"plain_text"`
+	Href        string             `json:"href"`
+	Annotations notionAnnotations  `json:"annotations"`
+}
+
+// notionAnnotations contains formatting flags for rich text.
+type notionAnnotations struct {
+	Bold          bool   `json:"bold"`
+	Italic        bool   `json:"italic"`
+	Strikethrough bool   `json:"strikethrough"`
+	Underline     bool   `json:"underline"`
+	Code          bool   `json:"code"`
+	Colour        string `json:"color"`
+}
+
+// notionListBlockTypes is the set of block types considered list items
+// for indentation purposes. Module-level constant avoids per-call
+// allocation.
+var notionListBlockTypes = map[string]struct{}{
+	"bulleted_list_item": {},
+	"numbered_list_item": {},
+	"to_do":              {},
+	"toggle":             {},
+}
+
+// isListBlock returns true if the block type is a list item.
+func isListBlock(blockType string) bool {
+	_, ok := notionListBlockTypes[blockType]
+	return ok
+}
+
+// blockToMarkdown converts a single Notion block to its markdown
+// representation.
+func (c *NotionConnector) blockToMarkdown(block notionBlock) string {
+	// Skip blocks excluded by the block type filter.
+	if len(c.config.BlockTypeFilter) > 0 {
+		if _, allowed := c.config.BlockTypeFilter[block.Type]; !allowed {
+			return ""
+		}
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(block.RawData, &raw); err != nil {
+		return ""
+	}
+
+	blockData, ok := raw[block.Type]
+	if !ok {
+		return ""
+	}
+
+	var typed struct {
+		RichText   []notionRichText `json:"rich_text"`
+		Caption    []notionRichText `json:"caption"`
+		Language   string           `json:"language"`
+		URL        string           `json:"url"`
+		Checked    bool             `json:"checked"`
+		Expression string           `json:"expression"`
+	}
+	if err := json.Unmarshal(blockData, &typed); err != nil {
+		return ""
+	}
+
+	text := renderRichText(typed.RichText)
+
+	blockRenderers := map[string]func() string{
+		"paragraph":          func() string { return text + "\n" },
+		"heading_1":          func() string { return "# " + text + "\n" },
+		"heading_2":          func() string { return "## " + text + "\n" },
+		"heading_3":          func() string { return "### " + text + "\n" },
+		"bulleted_list_item": func() string { return "- " + text },
+		"numbered_list_item": func() string { return "1. " + text },
+		"to_do": func() string {
+			marker := "[ ]"
+			if typed.Checked {
+				marker = "[x]"
+			}
+			return "- " + marker + " " + text
+		},
+		"toggle":    func() string { return "- " + text },
+		"quote":     func() string { return "> " + text + "\n" },
+		"callout":   func() string { return "> " + text + "\n" },
+		"divider":   func() string { return "---\n" },
+		"code": func() string {
+			lang := typed.Language
+			return "```" + lang + "\n" + text + "\n```\n"
+		},
+		"equation": func() string {
+			return "$$\n" + typed.Expression + "\n$$\n"
+		},
+		"image": func() string {
+			caption := renderRichText(typed.Caption)
+			url := extractFileURL(blockData)
+			if caption != "" {
+				return fmt.Sprintf("![%s](%s)\n", caption, url)
+			}
+			return fmt.Sprintf("![](%s)\n", url)
+		},
+		"file": func() string {
+			url := extractFileURL(blockData)
+			caption := renderRichText(typed.Caption)
+			if caption == "" {
+				caption = "file"
+			}
+			return fmt.Sprintf("[%s](%s)\n", caption, url)
+		},
+		"bookmark": func() string {
+			caption := renderRichText(typed.Caption)
+			if typed.URL != "" {
+				if caption != "" {
+					return fmt.Sprintf("[%s](%s)\n", caption, typed.URL)
+				}
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"embed": func() string {
+			if typed.URL != "" {
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"table_of_contents": func() string { return "" },
+		"breadcrumb":        func() string { return "" },
+		"column_list":       func() string { return "" },
+		"column":            func() string { return "" },
+		"child_page":        func() string { return "" },
+		"child_database":    func() string { return "" },
+		"synced_block":      func() string { return "" },
+		"link_preview": func() string {
+			if typed.URL != "" {
+				return typed.URL + "\n"
+			}
+			return ""
+		},
+		"table":     func() string { return "" },
+		"table_row": func() string { return renderTableRow(blockData) },
+	}
+
+	renderer, found := blockRenderers[block.Type]
+	if !found {
+		return text
+	}
+	return renderer()
+}
+
+// renderRichText converts a slice of Notion rich text objects to a
+// markdown string with formatting annotations.
+func renderRichText(texts []notionRichText) string {
+	var builder strings.Builder
+	for _, t := range texts {
+		text := t.PlainText
+
+		if t.Annotations.Code {
+			text = "`" + text + "`"
+		}
+		if t.Annotations.Bold {
+			text = "**" + text + "**"
+		}
+		if t.Annotations.Italic {
+			text = "*" + text + "*"
+		}
+		if t.Annotations.Strikethrough {
+			text = "~~" + text + "~~"
+		}
+
+		if t.Href != "" {
+			text = "[" + text + "](" + t.Href + ")"
+		}
+
+		builder.WriteString(text)
+	}
+	return builder.String()
+}
+
+// renderPlainRichText extracts plain text from a rich text array
+// without formatting.
+func renderPlainRichText(texts []notionRichText) string {
+	var parts []string
+	for _, t := range texts {
+		parts = append(parts, t.PlainText)
+	}
+	return strings.Join(parts, "")
+}
+
+// extractFileURL pulls the URL from a file-type block's JSON data.
+func extractFileURL(data json.RawMessage) string {
+	var fileBlock struct {
+		External struct {
+			URL string `json:"url"`
+		} `json:"external"`
+		File struct {
+			URL string `json:"url"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal(data, &fileBlock); err != nil {
+		return ""
+	}
+	if fileBlock.File.URL != "" {
+		return fileBlock.File.URL
+	}
+	return fileBlock.External.URL
+}
+
+// renderTableRow converts a table_row block to a markdown table
+// row.
+func renderTableRow(data json.RawMessage) string {
+	var row struct {
+		Cells [][]notionRichText `json:"cells"`
+	}
+	if err := json.Unmarshal(data, &row); err != nil {
+		return ""
+	}
+
+	cells := make([]string, 0, len(row.Cells))
+	for _, cell := range row.Cells {
+		cells = append(cells, renderRichText(cell))
+	}
+
+	return "| " + strings.Join(cells, " | ") + " |"
+}

--- a/go/connector/notion_http.go
+++ b/go/connector/notion_http.go
@@ -108,7 +108,7 @@ func (c *NotionConnector) doSingleRequest(ctx context.Context, method, path stri
 	if err != nil {
 		return nil, notionNoRetry, fmt.Errorf("connector/notion: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, notionMaxResponseSize))
 	if err != nil {

--- a/go/connector/notion_http.go
+++ b/go/connector/notion_http.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// doNotionRequest performs a single Notion API request with proper
+// headers and timeout. Returns the response body or an error.
+// Retries automatically on 429 responses using the Retry-After
+// header with exponential backoff.
+func (c *NotionConnector) doNotionRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
+	for attempt := 0; attempt <= notionMaxRetryAttempts; attempt++ {
+		// Ensure token is valid before each request attempt.
+		if tokenErr := c.ensureValidToken(ctx); tokenErr != nil {
+			return nil, tokenErr
+		}
+
+		if err := c.rateLimiter.Acquire(ctx, 1); err != nil {
+			return nil, err
+		}
+
+		respBody, retryAfter, err := c.doSingleRequest(ctx, method, path, body)
+		if err == nil {
+			return respBody, nil
+		}
+
+		// Only retry on 429 (rate limited).
+		if retryAfter == notionNoRetry {
+			return nil, err
+		}
+
+		if attempt >= notionMaxRetryAttempts {
+			return nil, err
+		}
+
+		// Use Retry-After header value, or fall back to exponential
+		// backoff with jitter.
+		var wait time.Duration
+		if retryAfter >= 0 {
+			wait = time.Duration(retryAfter) * time.Second
+		} else {
+			wait = c.rateLimiter.BackoffDuration(attempt)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+			// continue to retry
+		}
+	}
+
+	return nil, fmt.Errorf("connector/notion: exhausted retries for %s %s", method, path)
+}
+
+// notionNoRetry is the sentinel value for doSingleRequest's
+// retryAfter return, indicating the error is not retryable.
+const notionNoRetry = -2
+
+// doSingleRequest executes one HTTP request. Returns the response body
+// on success, or an error. The retryAfter return value is:
+//   - >= 0  if a 429 was received and Retry-After header had a value
+//   - -1    if a 429 was received but no Retry-After header (use backoff)
+//   - notionNoRetry (-2) for all other errors (do not retry)
+func (c *NotionConnector) doSingleRequest(ctx context.Context, method, path string, body any) ([]byte, int, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, notionNoRetry, fmt.Errorf("connector/notion: marshalling request body: %w", err)
+		}
+		bodyReader = strings.NewReader(string(data))
+	}
+
+	url := notionBaseURL + path
+	// Override base URL if set via context (for tests).
+	if baseURL, ok := ctx.Value(notionBaseURLKey{}).(string); ok {
+		url = baseURL + path
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, notionDefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, url, bodyReader)
+	if err != nil {
+		return nil, notionNoRetry, fmt.Errorf("connector/notion: creating request: %w", err)
+	}
+
+	c.mu.Lock()
+	apiToken := c.config.APIToken
+	c.mu.Unlock()
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	req.Header.Set("Notion-Version", notionAPIVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, notionNoRetry, fmt.Errorf("connector/notion: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, notionMaxResponseSize))
+	if err != nil {
+		return nil, notionNoRetry, fmt.Errorf("connector/notion: reading response: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		retryAfter := parseRetryAfterHeader(resp.Header.Get("Retry-After"))
+		return nil, retryAfter, fmt.Errorf("connector/notion: rate limited (429)")
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, notionNoRetry, fmt.Errorf("connector/notion: not found (404)")
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, notionNoRetry, fmt.Errorf("connector/notion: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, notionNoRetry, nil
+}
+
+// parseRetryAfterHeader parses the Retry-After header value as an
+// integer number of seconds. Returns -1 if the header is absent or
+// unparseable (indicating exponential backoff should be used).
+func parseRetryAfterHeader(value string) int {
+	if value == "" {
+		return -1
+	}
+	seconds, err := strconv.Atoi(value)
+	if err != nil {
+		return -1
+	}
+	return seconds
+}
+
+// notionBaseURLKey is a context key for overriding the Notion API
+// base URL in tests.
+type notionBaseURLKey struct{}
+
+// WithNotionBaseURL returns a context with an overridden Notion API
+// base URL.
+func WithNotionBaseURL(ctx context.Context, baseURL string) context.Context {
+	return context.WithValue(ctx, notionBaseURLKey{}, baseURL)
+}

--- a/go/connector/notion_oauth2.go
+++ b/go/connector/notion_oauth2.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Notion OAuth2 sentinel errors.
+var (
+	// ErrNotionTokenRefreshFailed is returned when the Notion token
+	// refresh request fails.
+	ErrNotionTokenRefreshFailed = errors.New("connector/notion: token refresh failed")
+)
+
+// notionTokenEndpoint is the Notion OAuth2 token endpoint.
+const notionTokenEndpoint = "https://api.notion.com/v1/oauth/token"
+
+// NotionRefreshedToken holds the result of a Notion token refresh.
+type NotionRefreshedToken struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+// NotionTokenExchanger abstracts the HTTP calls for Notion OAuth2
+// token operations, allowing tests to inject mock implementations.
+type NotionTokenExchanger interface {
+	// Refresh uses a refresh token to obtain a new access token from
+	// Notion's token endpoint.
+	Refresh(ctx context.Context, refreshToken string) (NotionRefreshedToken, error)
+}
+
+// notionPendingRefresh holds the in-flight refresh state for
+// deduplication.
+type notionPendingRefresh struct {
+	done  chan struct{}
+	token NotionRefreshedToken
+	err   error
+}
+
+// NotionOAuth2Client manages Notion OAuth2 token refresh with
+// concurrent deduplication.
+type NotionOAuth2Client struct {
+	clientID     string
+	clientSecret string
+	exchanger    NotionTokenExchanger
+
+	mu      sync.Mutex
+	pending *notionPendingRefresh
+}
+
+// NewNotionOAuth2Client creates a new NotionOAuth2Client.
+func NewNotionOAuth2Client(clientID, clientSecret string, exchanger NotionTokenExchanger) *NotionOAuth2Client {
+	return &NotionOAuth2Client{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		exchanger:    exchanger,
+	}
+}
+
+// RefreshToken refreshes an expired access token. Concurrent calls
+// are deduplicated: only the first caller triggers the actual HTTP
+// refresh; subsequent callers await the same result.
+func (c *NotionOAuth2Client) RefreshToken(ctx context.Context, refreshToken string) (NotionRefreshedToken, error) {
+	if refreshToken == "" {
+		return NotionRefreshedToken{}, fmt.Errorf("%w: no refresh token available", ErrNotionTokenRefreshFailed)
+	}
+
+	c.mu.Lock()
+	if c.pending != nil {
+		p := c.pending
+		c.mu.Unlock()
+		<-p.done
+		return p.token, p.err
+	}
+
+	p := &notionPendingRefresh{done: make(chan struct{})}
+	c.pending = p
+	c.mu.Unlock()
+
+	refreshed, err := c.exchanger.Refresh(ctx, refreshToken)
+	if err != nil {
+		p.err = fmt.Errorf("%w: %v", ErrNotionTokenRefreshFailed, err)
+	} else {
+		// Preserve the refresh token if Notion did not issue a new one.
+		if refreshed.RefreshToken == "" {
+			refreshed.RefreshToken = refreshToken
+		}
+		p.token = refreshed
+	}
+
+	close(p.done)
+	c.mu.Lock()
+	c.pending = nil
+	c.mu.Unlock()
+
+	return p.token, p.err
+}
+
+// notionHTTPTokenExchanger implements NotionTokenExchanger using real
+// HTTP calls to Notion's token endpoint. Notion uses HTTP Basic Auth
+// (clientID:clientSecret) for the token exchange, unlike standard
+// OAuth2 which sends credentials in the body.
+type notionHTTPTokenExchanger struct {
+	clientID     string
+	clientSecret string
+	httpClient   NotionHTTPClient
+}
+
+// Refresh sends a refresh request to Notion's token endpoint.
+func (e *notionHTTPTokenExchanger) Refresh(ctx context.Context, refreshToken string) (NotionRefreshedToken, error) {
+	reqBody := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+	}
+	bodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return NotionRefreshedToken{}, fmt.Errorf("marshalling refresh request: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, notionDefaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, notionTokenEndpoint, strings.NewReader(string(bodyJSON)))
+	if err != nil {
+		return NotionRefreshedToken{}, fmt.Errorf("creating refresh request: %w", err)
+	}
+
+	// Notion requires Basic Auth with clientID:clientSecret for token
+	// exchange.
+	basicAuth := base64.StdEncoding.EncodeToString([]byte(e.clientID + ":" + e.clientSecret))
+	req.Header.Set("Authorization", "Basic "+basicAuth)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return NotionRefreshedToken{}, fmt.Errorf("executing refresh request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, notionMaxResponseSize))
+	if err != nil {
+		return NotionRefreshedToken{}, fmt.Errorf("reading refresh response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return NotionRefreshedToken{}, fmt.Errorf("token endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return NotionRefreshedToken{}, fmt.Errorf("parsing refresh response: %w", err)
+	}
+
+	return NotionRefreshedToken{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresAt:    time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
+	}, nil
+}

--- a/go/connector/notion_oauth2.go
+++ b/go/connector/notion_oauth2.go
@@ -146,7 +146,7 @@ func (e *notionHTTPTokenExchanger) Refresh(ctx context.Context, refreshToken str
 	if err != nil {
 		return NotionRefreshedToken{}, fmt.Errorf("executing refresh request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, notionMaxResponseSize))
 	if err != nil {

--- a/go/connector/notion_properties.go
+++ b/go/connector/notion_properties.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// extractTitleFromProperties finds the title property in a page's
+// properties map and returns its plain text value.
+func extractTitleFromProperties(properties map[string]json.RawMessage) string {
+	for _, propRaw := range properties {
+		var prop struct {
+			Type  string `json:"type"`
+			Title []struct {
+				PlainText string `json:"plain_text"`
+			} `json:"title"`
+		}
+		if err := json.Unmarshal(propRaw, &prop); err != nil {
+			continue
+		}
+		if prop.Type == "title" && len(prop.Title) > 0 {
+			var parts []string
+			for _, t := range prop.Title {
+				parts = append(parts, t.PlainText)
+			}
+			return strings.Join(parts, "")
+		}
+	}
+	return ""
+}
+
+// extractPropertyValue converts a Notion property value to its
+// string representation.
+func extractPropertyValue(raw json.RawMessage) string {
+	var prop struct {
+		Type           string           `json:"type"`
+		Title          []notionRichText `json:"title"`
+		RichText       []notionRichText `json:"rich_text"`
+		Number         *float64         `json:"number"`
+		Select         *struct {
+			Name string `json:"name"`
+		} `json:"select"`
+		MultiSelect []struct {
+			Name string `json:"name"`
+		} `json:"multi_select"`
+		Date *struct {
+			Start string `json:"start"`
+			End   string `json:"end"`
+		} `json:"date"`
+		Checkbox bool   `json:"checkbox"`
+		URL      string `json:"url"`
+		Email    string `json:"email"`
+		Phone    string `json:"phone_number"`
+		Status   *struct {
+			Name string `json:"name"`
+		} `json:"status"`
+		People []struct {
+			Name string `json:"name"`
+		} `json:"people"`
+		Relation []struct {
+			ID string `json:"id"`
+		} `json:"relation"`
+	}
+	if err := json.Unmarshal(raw, &prop); err != nil {
+		return ""
+	}
+
+	renderers := map[string]func() string{
+		"title":    func() string { return renderPlainRichText(prop.Title) },
+		"rich_text": func() string { return renderPlainRichText(prop.RichText) },
+		"number": func() string {
+			if prop.Number == nil {
+				return ""
+			}
+			return fmt.Sprintf("%g", *prop.Number)
+		},
+		"select": func() string {
+			if prop.Select == nil {
+				return ""
+			}
+			return prop.Select.Name
+		},
+		"multi_select": func() string {
+			names := make([]string, 0, len(prop.MultiSelect))
+			for _, ms := range prop.MultiSelect {
+				names = append(names, ms.Name)
+			}
+			return strings.Join(names, ", ")
+		},
+		"date": func() string {
+			if prop.Date == nil {
+				return ""
+			}
+			if prop.Date.End != "" {
+				return prop.Date.Start + " to " + prop.Date.End
+			}
+			return prop.Date.Start
+		},
+		"checkbox": func() string {
+			if prop.Checkbox {
+				return "true"
+			}
+			return "false"
+		},
+		"url":          func() string { return prop.URL },
+		"email":        func() string { return prop.Email },
+		"phone_number": func() string { return prop.Phone },
+		"status": func() string {
+			if prop.Status == nil {
+				return ""
+			}
+			return prop.Status.Name
+		},
+		"people": func() string {
+			names := make([]string, 0, len(prop.People))
+			for _, p := range prop.People {
+				names = append(names, p.Name)
+			}
+			return strings.Join(names, ", ")
+		},
+		"relation": func() string {
+			ids := make([]string, 0, len(prop.Relation))
+			for _, r := range prop.Relation {
+				ids = append(ids, r.ID)
+			}
+			return strings.Join(ids, ", ")
+		},
+	}
+
+	renderer, found := renderers[prop.Type]
+	if !found {
+		return ""
+	}
+	return renderer()
+}
+
+// databaseEntryParsed holds parsed fields from a database entry.
+type databaseEntryParsed struct {
+	pageID             string
+	title              string
+	url                string
+	lastEditedTime     time.Time
+	propertiesMarkdown string
+}
+
+// parseDatabaseEntry extracts structured data from a raw database
+// entry JSON.
+func parseDatabaseEntry(raw json.RawMessage) (databaseEntryParsed, error) {
+	var entry struct {
+		ID             string                     `json:"id"`
+		URL            string                     `json:"url"`
+		LastEditedTime string                     `json:"last_edited_time"`
+		Properties     map[string]json.RawMessage `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return databaseEntryParsed{}, err
+	}
+
+	editedTime, _ := time.Parse(time.RFC3339, entry.LastEditedTime)
+
+	title := ""
+	var propLines []string
+
+	// Sort property keys for deterministic output.
+	keys := make([]string, 0, len(entry.Properties))
+	for k := range entry.Properties {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		propRaw := entry.Properties[key]
+		val := extractPropertyValue(propRaw)
+
+		// Detect title property.
+		var propType struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(propRaw, &propType); err == nil && propType.Type == "title" {
+			title = val
+			continue
+		}
+
+		if val != "" {
+			propLines = append(propLines, fmt.Sprintf("- **%s**: %s", key, val))
+		}
+	}
+
+	var builder strings.Builder
+	if title != "" {
+		builder.WriteString("## " + title + "\n\n")
+	}
+	if len(propLines) > 0 {
+		builder.WriteString(strings.Join(propLines, "\n"))
+		builder.WriteString("\n")
+	}
+
+	return databaseEntryParsed{
+		pageID:             entry.ID,
+		title:              title,
+		url:                entry.URL,
+		lastEditedTime:     editedTime,
+		propertiesMarkdown: builder.String(),
+	}, nil
+}
+
+// parsePageResponse extracts page metadata from a Notion page API
+// response.
+func parsePageResponse(data []byte) (NotionPage, error) {
+	var resp struct {
+		ID             string                     `json:"id"`
+		URL            string                     `json:"url"`
+		LastEditedTime string                     `json:"last_edited_time"`
+		Properties     map[string]json.RawMessage `json:"properties"`
+		Parent         struct {
+			Type   string `json:"type"`
+			PageID string `json:"page_id"`
+		} `json:"parent"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return NotionPage{}, fmt.Errorf("parsing page: %w", err)
+	}
+
+	editedTime, _ := time.Parse(time.RFC3339, resp.LastEditedTime)
+
+	// Extract title from properties.
+	title := extractTitleFromProperties(resp.Properties)
+
+	return NotionPage{
+		ID:             resp.ID,
+		Title:          title,
+		URL:            resp.URL,
+		LastEditedTime: editedTime,
+		ParentID:       resp.Parent.PageID,
+	}, nil
+}

--- a/go/connector/notion_test.go
+++ b/go/connector/notion_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -688,16 +689,22 @@ func TestNotionConnector_CursorUpdatedAfterSync(t *testing.T) {
 }
 
 func TestNotionConnector_RateLimit429Handling(t *testing.T) {
-	pageResp := `{
-		"id": "page-rl", "url": "https://notion.so/page-rl",
-		"last_edited_time": "2026-05-10T14:00:00.000Z",
-		"properties": {"Title": {"type": "title", "title": [{"plain_text": "RL Page"}]}},
-		"parent": {"type": "workspace"}
-	}`
+	// Provide enough 429 responses to exhaust all retries
+	// (notionMaxRetryAttempts + 1 = 6).
+	rateLimitResp := mockResponse{
+		statusCode: 429,
+		body:       `{"message": "rate limited"}`,
+		headers:    http.Header{"Retry-After": []string{"0"}},
+	}
 
 	mock := &mockHTTPClient{
 		responses: []mockResponse{
-			{statusCode: 429, body: `{"message": "rate limited"}`, headers: http.Header{"Retry-After": []string{"1"}}},
+			rateLimitResp,
+			rateLimitResp,
+			rateLimitResp,
+			rateLimitResp,
+			rateLimitResp,
+			rateLimitResp,
 		},
 	}
 
@@ -707,8 +714,8 @@ func TestNotionConnector_RateLimit429Handling(t *testing.T) {
 	docsCh, errsCh := conn.FetchAll(context.Background())
 	_, errs := collectDocs(docsCh, errsCh)
 
-	// The connector should report a rate limit error.
-	_ = pageResp // Used for documentation; the mock returns 429 first.
+	// The connector should report a rate limit error after exhausting
+	// retries.
 	hasRateLimitErr := false
 	for _, err := range errs {
 		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "rate limited") {
@@ -1102,6 +1109,300 @@ func TestNotionConnector_ContextCancellation(t *testing.T) {
 	// Just verify it doesn't hang.
 }
 
+func TestNotionConnector_NestedBlockChildrenRendering(t *testing.T) {
+	pageResp := `{
+		"id": "nested-page",
+		"url": "https://notion.so/nested-page",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Nested"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	// Parent list item with has_children=true.
+	blocksResp := `{
+		"results": [
+			{
+				"id": "parent-list",
+				"type": "bulleted_list_item",
+				"has_children": true,
+				"bulleted_list_item": {
+					"rich_text": [{"type": "text", "plain_text": "Parent item"}]
+				}
+			}
+		],
+		"has_more": false
+	}`
+	// Child blocks of the parent list item.
+	childBlocksResp := `{
+		"results": [
+			{
+				"id": "child-para",
+				"type": "paragraph",
+				"has_children": false,
+				"paragraph": {
+					"rich_text": [{"type": "text", "plain_text": "Nested paragraph"}]
+				}
+			},
+			{
+				"id": "child-list",
+				"type": "bulleted_list_item",
+				"has_children": false,
+				"bulleted_list_item": {
+					"rich_text": [{"type": "text", "plain_text": "Nested list item"}]
+				}
+			}
+		],
+		"has_more": false
+	}`
+	// No children for the page.
+	pageChildBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 404, body: `{"message": "not found"}`},
+			{statusCode: 200, body: blocksResp},
+			{statusCode: 200, body: childBlocksResp},
+			{statusCode: 200, body: pageChildBlocks},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"nested-page"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	content := string(docs[0].Content)
+	if !strings.Contains(content, "- Parent item") {
+		t.Errorf("expected parent list item, got %q", content)
+	}
+	// Child content of a list block should be indented with two spaces.
+	if !strings.Contains(content, "  Nested paragraph") {
+		t.Errorf("expected indented nested paragraph, got %q", content)
+	}
+	if !strings.Contains(content, "  - Nested list item") {
+		t.Errorf("expected indented nested list item, got %q", content)
+	}
+}
+
+func TestNotionConnector_SyncedBlockRendering(t *testing.T) {
+	pageResp := `{
+		"id": "sync-page",
+		"url": "https://notion.so/sync-page",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Synced"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	blocksResp := `{
+		"results": [
+			{
+				"id": "synced-1",
+				"type": "synced_block",
+				"has_children": false,
+				"synced_block": {
+					"synced_from": {"block_id": "original-block-123"}
+				}
+			},
+			{
+				"id": "para-1",
+				"type": "paragraph",
+				"has_children": false,
+				"paragraph": {
+					"rich_text": [{"type": "text", "plain_text": "After synced block"}]
+				}
+			}
+		],
+		"has_more": false
+	}`
+	childBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 404, body: `{"message": "not found"}`},
+			{statusCode: 200, body: blocksResp},
+			{statusCode: 200, body: childBlocks},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"sync-page"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	content := string(docs[0].Content)
+	// synced_block renders as empty; only the paragraph should appear.
+	if !strings.Contains(content, "After synced block") {
+		t.Errorf("expected paragraph after synced block, got %q", content)
+	}
+	// The synced_from reference should not appear in output.
+	if strings.Contains(content, "original-block-123") {
+		t.Errorf("synced_from reference should not leak into content: %q", content)
+	}
+}
+
+func TestNotionConnector_EquationBlockRendering(t *testing.T) {
+	conn := newTestConnector(nil)
+
+	block := makeBlock("equation", `{"expression": "E = mc^2"}`)
+	result := conn.blockToMarkdown(block)
+
+	expected := "$$\nE = mc^2\n$$\n"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestNotionConnector_ImageBlockRendering(t *testing.T) {
+	conn := newTestConnector(nil)
+
+	// Image with caption.
+	block := makeBlock("image", `{
+		"caption": [{"type": "text", "plain_text": "My photo"}],
+		"file": {"url": "https://example.com/photo.png"}
+	}`)
+	result := conn.blockToMarkdown(block)
+	expected := "![My photo](https://example.com/photo.png)\n"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+
+	// Image without caption.
+	block2 := makeBlock("image", `{
+		"caption": [],
+		"external": {"url": "https://example.com/ext.jpg"}
+	}`)
+	result2 := conn.blockToMarkdown(block2)
+	expected2 := "![](https://example.com/ext.jpg)\n"
+	if result2 != expected2 {
+		t.Errorf("expected %q, got %q", expected2, result2)
+	}
+}
+
+func TestNotionConnector_FileBlockRendering(t *testing.T) {
+	conn := newTestConnector(nil)
+
+	block := makeBlock("file", `{
+		"caption": [{"type": "text", "plain_text": "Document"}],
+		"file": {"url": "https://example.com/doc.pdf"}
+	}`)
+	result := conn.blockToMarkdown(block)
+	expected := "[Document](https://example.com/doc.pdf)\n"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestNotionConnector_BlockTypeFilter(t *testing.T) {
+	conn := newTestConnector(nil)
+	conn.config.BlockTypeFilter = map[string]struct{}{
+		"heading_1": {},
+	}
+
+	// heading_1 is allowed.
+	h1Block := makeBlock("heading_1", `{
+		"rich_text": [{"type": "text", "plain_text": "Allowed Heading"}]
+	}`)
+	result := conn.blockToMarkdown(h1Block)
+	if result != "# Allowed Heading\n" {
+		t.Errorf("expected heading, got %q", result)
+	}
+
+	// paragraph is not in the filter, should be excluded.
+	paraBlock := makeBlock("paragraph", `{
+		"rich_text": [{"type": "text", "plain_text": "Filtered out"}]
+	}`)
+	result2 := conn.blockToMarkdown(paraBlock)
+	if result2 != "" {
+		t.Errorf("expected empty for filtered block, got %q", result2)
+	}
+}
+
+func TestNotionConnector_RetryAfterHandling(t *testing.T) {
+	pageResp := `{
+		"id": "retry-page",
+		"url": "https://notion.so/retry-page",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Retry"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	md := `{"markdown": "retried content"}`
+	childBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			// First call returns 429 with Retry-After header.
+			{
+				statusCode: 429,
+				body:       `{"message": "rate limited"}`,
+				headers:    http.Header{"Retry-After": []string{"1"}},
+			},
+			// Retry succeeds.
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: md},
+			{statusCode: 200, body: childBlocks},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"retry-page"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document after retry, got %d", len(docs))
+	}
+	if docs[0].Title != "Retry" {
+		t.Errorf("expected title 'Retry', got %q", docs[0].Title)
+	}
+	content := string(docs[0].Content)
+	if !strings.Contains(content, "retried content") {
+		t.Errorf("expected retried content, got %q", content)
+	}
+}
+
+func TestNotionConnector_DefaultRateLimiter(t *testing.T) {
+	// Verify that a connector created without a rate limiter in deps
+	// gets a default one.
+	deps := ConnectorConfig{
+		Name:    "notion",
+		BrainID: "test-brain",
+		// No RateLimiter set.
+	}
+	conn := NewNotionConnector(deps, nil)
+	if conn.rateLimiter == nil {
+		t.Fatal("expected default rate limiter to be created")
+	}
+}
+
 // makeBlock constructs a notionBlock with RawData for testing.
 func makeBlock(blockType, blockDataJSON string) notionBlock {
 	raw := map[string]json.RawMessage{
@@ -1167,4 +1468,245 @@ func (t *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error
 		t.captureReq(req)
 	}
 	return t.response, nil
+}
+
+// mockNotionTokenExchanger implements NotionTokenExchanger for testing.
+type mockNotionTokenExchanger struct {
+	refreshFn func(ctx context.Context, refreshToken string) (NotionRefreshedToken, error)
+}
+
+func (m *mockNotionTokenExchanger) Refresh(ctx context.Context, refreshToken string) (NotionRefreshedToken, error) {
+	return m.refreshFn(ctx, refreshToken)
+}
+
+func TestNotionConnector_TokenRefreshOnExpiry(t *testing.T) {
+	refreshCalled := false
+	exchanger := &mockNotionTokenExchanger{
+		refreshFn: func(_ context.Context, rt string) (NotionRefreshedToken, error) {
+			refreshCalled = true
+			if rt != "test-refresh-token" {
+				t.Errorf("unexpected refresh token: %s", rt)
+			}
+			return NotionRefreshedToken{
+				AccessToken:  "refreshed-notion-token",
+				RefreshToken: "test-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	pageResp := `{
+		"id": "page-1",
+		"url": "https://notion.so/page-1",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Refreshed Page"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	md := `{"markdown": "content after refresh"}`
+	childBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: md},
+			{statusCode: 200, body: childBlocks},
+		},
+	}
+
+	deps := ConnectorConfig{
+		Name:    "notion",
+		BrainID: "test-brain",
+	}
+	conn := NewNotionConnector(deps, mock)
+	err := conn.Configure(map[string]any{
+		"apiToken":           "expired-token",
+		"rootPageIds":        []any{"page-1"},
+		"oauth2_client_id":   "client-id",
+		"oauth2_client_secret": "client-secret",
+		"refresh_token":      "test-refresh-token",
+		"token_expires_at":   time.Now().Add(-time.Hour).Format(time.RFC3339),
+		"token_exchanger":    exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+	if !refreshCalled {
+		t.Error("expected token refresh to be called for expired token")
+	}
+}
+
+func TestNotionConnector_TokenRefreshFailurePropagates(t *testing.T) {
+	exchanger := &mockNotionTokenExchanger{
+		refreshFn: func(_ context.Context, _ string) (NotionRefreshedToken, error) {
+			return NotionRefreshedToken{}, fmt.Errorf("invalid_grant: token revoked")
+		},
+	}
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{},
+	}
+
+	deps := ConnectorConfig{
+		Name:    "notion",
+		BrainID: "test-brain",
+	}
+	conn := NewNotionConnector(deps, mock)
+	err := conn.Configure(map[string]any{
+		"apiToken":             "expired-token",
+		"rootPageIds":          []any{"page-1"},
+		"oauth2_client_id":    "client-id",
+		"oauth2_client_secret": "client-secret",
+		"refresh_token":        "revoked-token",
+		"token_expires_at":     time.Now().Add(-time.Hour).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	_, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) == 0 {
+		t.Fatal("expected error when token refresh fails")
+	}
+
+	hasRefreshErr := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "token refresh failed") {
+			hasRefreshErr = true
+			break
+		}
+	}
+	if !hasRefreshErr {
+		t.Errorf("expected token refresh error, got: %v", errs)
+	}
+}
+
+func TestNotionConnector_NoRefreshForIntegrationToken(t *testing.T) {
+	// Internal integration tokens do not have OAuth2 config or
+	// refresh tokens, so no refresh should happen.
+	pageResp := `{
+		"id": "page-int",
+		"url": "https://notion.so/page-int",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Int Token Page"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	md := `{"markdown": "internal token content"}`
+	childBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: md},
+			{statusCode: 200, body: childBlocks},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-int"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_RefreshWithinBuffer(t *testing.T) {
+	refreshCalled := false
+	exchanger := &mockNotionTokenExchanger{
+		refreshFn: func(_ context.Context, _ string) (NotionRefreshedToken, error) {
+			refreshCalled = true
+			return NotionRefreshedToken{
+				AccessToken:  "refreshed-token",
+				RefreshToken: "test-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: `{
+				"id": "page-buf",
+				"url": "https://notion.so/page-buf",
+				"last_edited_time": "2026-05-10T14:00:00.000Z",
+				"properties": {"Title": {"type": "title", "title": [{"plain_text": "Buffer"}]}},
+				"parent": {"type": "workspace"}
+			}`},
+			{statusCode: 200, body: `{"markdown": "content"}`},
+			{statusCode: 200, body: `{"results": [], "has_more": false}`},
+		},
+	}
+
+	deps := ConnectorConfig{Name: "notion", BrainID: "test-brain"}
+	conn := NewNotionConnector(deps, mock)
+	// Token expires in 3 minutes -- within the 5-minute buffer.
+	err := conn.Configure(map[string]any{
+		"apiToken":             "expiring-token",
+		"rootPageIds":          []any{"page-buf"},
+		"oauth2_client_id":    "client-id",
+		"oauth2_client_secret": "client-secret",
+		"refresh_token":        "test-refresh-token",
+		"token_expires_at":     time.Now().Add(3 * time.Minute).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	_, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if !refreshCalled {
+		t.Error("expected refresh for token within expiry buffer")
+	}
+}
+
+func TestNotionConnector_Health(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+
+	// Before configuration.
+	health := conn.Health()
+	if health.Status != StatusDisconnected {
+		t.Errorf("Health().Status = %q, want %q", health.Status, StatusDisconnected)
+	}
+	if health.Message == "" {
+		t.Error("Health().Message should describe unconfigured state")
+	}
+
+	// After configuration.
+	_ = conn.Configure(map[string]any{
+		"apiToken": "secret_test_token",
+	})
+	health = conn.Health()
+	if health.Status != StatusConnected {
+		t.Errorf("Health().Status = %q, want %q", health.Status, StatusConnected)
+	}
+	if health.RateLimitRemaining != -1 {
+		t.Errorf("Health().RateLimitRemaining = %d, want -1", health.RateLimitRemaining)
+	}
 }

--- a/go/connector/notion_test.go
+++ b/go/connector/notion_test.go
@@ -1,0 +1,1170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockHTTPClient captures requests and returns canned responses.
+type mockHTTPClient struct {
+	responses []mockResponse
+	calls     []capturedRequest
+	callIndex int
+}
+
+type mockResponse struct {
+	statusCode int
+	body       string
+	headers    http.Header
+}
+
+type capturedRequest struct {
+	method string
+	url    string
+	body   string
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	var bodyStr string
+	if req.Body != nil {
+		data, _ := io.ReadAll(req.Body)
+		bodyStr = string(data)
+	}
+
+	m.calls = append(m.calls, capturedRequest{
+		method: req.Method,
+		url:    req.URL.String(),
+		body:   bodyStr,
+	})
+
+	idx := m.callIndex
+	m.callIndex++
+
+	if idx >= len(m.responses) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+			Header:     http.Header{},
+		}, nil
+	}
+
+	resp := m.responses[idx]
+	headers := resp.headers
+	if headers == nil {
+		headers = http.Header{}
+	}
+
+	return &http.Response{
+		StatusCode: resp.statusCode,
+		Body:       io.NopCloser(strings.NewReader(resp.body)),
+		Header:     headers,
+	}, nil
+}
+
+// newTestConnector creates a NotionConnector with the given mock
+// client and a pre-configured API token.
+func newTestConnector(mock *mockHTTPClient) *NotionConnector {
+	deps := ConnectorConfig{
+		Name:    "notion",
+		BrainID: "test-brain",
+	}
+	conn := NewNotionConnector(deps, mock)
+	_ = conn.Configure(map[string]any{
+		"apiToken": "secret_test_token",
+	})
+	return conn
+}
+
+// collectDocs drains the document and error channels, returning
+// all documents and any errors encountered.
+func collectDocs(docsCh <-chan ConnectorDocument, errsCh <-chan error) ([]ConnectorDocument, []error) {
+	var docs []ConnectorDocument
+	var errs []error
+	done := make(chan struct{})
+
+	go func() {
+		for err := range errsCh {
+			errs = append(errs, err)
+		}
+		close(done)
+	}()
+
+	for doc := range docsCh {
+		docs = append(docs, doc)
+	}
+	<-done
+	return docs, errs
+}
+
+func TestNotionConnector_Name(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	if conn.Name() != "notion" {
+		t.Errorf("expected name 'notion', got %q", conn.Name())
+	}
+}
+
+func TestNotionConnector_Configure_RequiresAPIToken(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	err := conn.Configure(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing apiToken")
+	}
+	if !strings.Contains(err.Error(), "apiToken is required") {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestNotionConnector_Configure_EmptyToken(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	err := conn.Configure(map[string]any{"apiToken": ""})
+	if err == nil {
+		t.Fatal("expected error for empty apiToken")
+	}
+}
+
+func TestNotionConnector_Configure_ValidToken(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	err := conn.Configure(map[string]any{
+		"apiToken":          "secret_abc123",
+		"rootPageIds":       []any{"page-1", "page-2"},
+		"databaseIds":       []any{"db-1"},
+		"includeChildPages": false,
+		"includeDatabases":  true,
+		"maxDepth":          float64(5),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conn.configured {
+		t.Error("expected connector to be configured")
+	}
+	if conn.config.APIToken != "secret_abc123" {
+		t.Errorf("unexpected token: %s", conn.config.APIToken)
+	}
+	if len(conn.config.RootPageIDs) != 2 {
+		t.Errorf("expected 2 root page IDs, got %d", len(conn.config.RootPageIDs))
+	}
+	if conn.config.IncludeChildPages {
+		t.Error("expected includeChildPages=false")
+	}
+	if conn.config.MaxDepth != 5 {
+		t.Errorf("expected maxDepth=5, got %d", conn.config.MaxDepth)
+	}
+}
+
+func TestNotionConnector_FetchAll_NotConfigured(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	_, errs := collectDocs(docsCh, errsCh)
+	if len(errs) == 0 {
+		t.Fatal("expected error for unconfigured connector")
+	}
+}
+
+func TestNotionConnector_FetchPageViaMarkdownAPI(t *testing.T) {
+	pageResp := `{
+		"id": "page-123",
+		"url": "https://notion.so/page-123",
+		"last_edited_time": "2026-05-10T14:30:00.000Z",
+		"properties": {
+			"Name": {
+				"type": "title",
+				"title": [{"plain_text": "Test Page"}]
+			}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	markdownResp := `{"markdown": "# Test Page\n\nThis is test content."}`
+	childBlocksResp := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: markdownResp},
+			{statusCode: 200, body: childBlocksResp},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-123"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	doc := docs[0]
+	if doc.ExternalID != "page-123" {
+		t.Errorf("expected externalID 'page-123', got %q", doc.ExternalID)
+	}
+	if doc.Title != "Test Page" {
+		t.Errorf("expected title 'Test Page', got %q", doc.Title)
+	}
+	if doc.MIME != "text/markdown" {
+		t.Errorf("expected mime 'text/markdown', got %q", doc.MIME)
+	}
+	if !strings.Contains(string(doc.Content), "This is test content") {
+		t.Errorf("expected content to contain test text, got %q", string(doc.Content))
+	}
+	if doc.Metadata["source"] != "notion" {
+		t.Errorf("expected source=notion in metadata")
+	}
+}
+
+func TestNotionConnector_FetchPageFallbackToBlocks(t *testing.T) {
+	pageResp := `{
+		"id": "page-456",
+		"url": "https://notion.so/page-456",
+		"last_edited_time": "2026-05-10T14:30:00.000Z",
+		"properties": {
+			"Title": {
+				"type": "title",
+				"title": [{"plain_text": "Block Page"}]
+			}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	// Markdown API returns 404.
+	markdownNotFound := `{"message": "not found"}`
+
+	blocksResp := `{
+		"results": [
+			{
+				"id": "block-1",
+				"type": "heading_1",
+				"has_children": false,
+				"heading_1": {
+					"rich_text": [{"type": "text", "plain_text": "Heading One"}]
+				}
+			},
+			{
+				"id": "block-2",
+				"type": "paragraph",
+				"has_children": false,
+				"paragraph": {
+					"rich_text": [{"type": "text", "plain_text": "Paragraph content here."}]
+				}
+			}
+		],
+		"has_more": false
+	}`
+	childBlocksResp := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 404, body: markdownNotFound},
+			{statusCode: 200, body: blocksResp},
+			{statusCode: 200, body: childBlocksResp},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-456"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	content := string(docs[0].Content)
+	if !strings.Contains(content, "# Heading One") {
+		t.Errorf("expected heading markdown, got %q", content)
+	}
+	if !strings.Contains(content, "Paragraph content here.") {
+		t.Errorf("expected paragraph content, got %q", content)
+	}
+}
+
+func TestNotionConnector_DatabaseQuery(t *testing.T) {
+	dbQueryResp := `{
+		"results": [
+			{
+				"id": "entry-1",
+				"url": "https://notion.so/entry-1",
+				"last_edited_time": "2026-05-10T10:00:00.000Z",
+				"properties": {
+					"Name": {
+						"type": "title",
+						"title": [{"plain_text": "Entry One"}]
+					},
+					"Status": {
+						"type": "select",
+						"select": {"name": "Active"}
+					},
+					"Priority": {
+						"type": "number",
+						"number": 3
+					}
+				}
+			},
+			{
+				"id": "entry-2",
+				"url": "https://notion.so/entry-2",
+				"last_edited_time": "2026-05-10T11:00:00.000Z",
+				"properties": {
+					"Name": {
+						"type": "title",
+						"title": [{"plain_text": "Entry Two"}]
+					},
+					"Status": {
+						"type": "select",
+						"select": {"name": "Done"}
+					}
+				}
+			}
+		],
+		"has_more": false
+	}`
+	// Page content for entry-1 and entry-2 (markdown API).
+	entryMarkdown1 := `{"markdown": "Details for entry one."}`
+	entryMarkdown2 := `{"markdown": "Details for entry two."}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: dbQueryResp},
+			// Content for entry-1
+			{statusCode: 200, body: entryMarkdown1},
+			// Content for entry-2
+			{statusCode: 200, body: entryMarkdown2},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.DatabaseIDs = []string{"db-test"}
+	conn.config.RootPageIDs = nil
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(docs))
+	}
+
+	if docs[0].Title != "Entry One" {
+		t.Errorf("expected title 'Entry One', got %q", docs[0].Title)
+	}
+	if docs[0].Metadata["type"] != "database_entry" {
+		t.Errorf("expected type=database_entry, got %q", docs[0].Metadata["type"])
+	}
+
+	content := string(docs[0].Content)
+	if !strings.Contains(content, "## Entry One") {
+		t.Errorf("expected title heading in content: %q", content)
+	}
+	if !strings.Contains(content, "Active") {
+		t.Errorf("expected status in content: %q", content)
+	}
+}
+
+func TestNotionConnector_PaginatedDatabaseQuery(t *testing.T) {
+	page1 := `{
+		"results": [
+			{
+				"id": "entry-a",
+				"url": "https://notion.so/entry-a",
+				"last_edited_time": "2026-05-10T10:00:00.000Z",
+				"properties": {
+					"Name": {"type": "title", "title": [{"plain_text": "A"}]}
+				}
+			}
+		],
+		"has_more": true,
+		"next_cursor": "cursor-page-2"
+	}`
+	page2 := `{
+		"results": [
+			{
+				"id": "entry-b",
+				"url": "https://notion.so/entry-b",
+				"last_edited_time": "2026-05-10T11:00:00.000Z",
+				"properties": {
+					"Name": {"type": "title", "title": [{"plain_text": "B"}]}
+				}
+			}
+		],
+		"has_more": false
+	}`
+	entryMD := `{"markdown": "content"}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: page1},
+			{statusCode: 200, body: entryMD},
+			{statusCode: 200, body: page2},
+			{statusCode: 200, body: entryMD},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.DatabaseIDs = []string{"db-paginated"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents across pages, got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_RecursiveChildPages(t *testing.T) {
+	// Root page.
+	rootPageResp := `{
+		"id": "root",
+		"url": "https://notion.so/root",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Root"}]}
+		},
+		"parent": {"type": "workspace"}
+	}`
+	rootMD := `{"markdown": "Root content"}`
+	rootChildren := `{
+		"results": [
+			{"id": "child-1", "type": "child_page", "has_children": false}
+		],
+		"has_more": false
+	}`
+
+	// Child page.
+	childPageResp := `{
+		"id": "child-1",
+		"url": "https://notion.so/child-1",
+		"last_edited_time": "2026-05-10T15:00:00.000Z",
+		"properties": {
+			"Title": {"type": "title", "title": [{"plain_text": "Child"}]}
+		},
+		"parent": {"type": "page_id", "page_id": "root"}
+	}`
+	childMD := `{"markdown": "Child content"}`
+	childChildren := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: rootPageResp},
+			{statusCode: 200, body: rootMD},
+			{statusCode: 200, body: rootChildren},
+			{statusCode: 200, body: childPageResp},
+			{statusCode: 200, body: childMD},
+			{statusCode: 200, body: childChildren},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"root"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents (root + child), got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_MaxDepthEnforcement(t *testing.T) {
+	// Root page with child that has its own child (depth 3).
+	rootPage := `{
+		"id": "root", "url": "https://notion.so/root",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "Root"}]}},
+		"parent": {"type": "workspace"}
+	}`
+	rootMD := `{"markdown": "root"}`
+	rootChildren := `{
+		"results": [{"id": "child-1", "type": "child_page", "has_children": false}],
+		"has_more": false
+	}`
+	childPage := `{
+		"id": "child-1", "url": "https://notion.so/child-1",
+		"last_edited_time": "2026-05-10T15:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "Child"}]}},
+		"parent": {"type": "page_id", "page_id": "root"}
+	}`
+	childMD := `{"markdown": "child"}`
+	childChildren := `{
+		"results": [{"id": "grandchild-1", "type": "child_page", "has_children": false}],
+		"has_more": false
+	}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: rootPage},
+			{statusCode: 200, body: rootMD},
+			{statusCode: 200, body: rootChildren},
+			{statusCode: 200, body: childPage},
+			{statusCode: 200, body: childMD},
+			{statusCode: 200, body: childChildren},
+			// Grandchild would be at depth 2 but maxDepth=1 stops it.
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"root"}
+	conn.config.MaxDepth = 1
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	// Root is depth 0, child is depth 1, grandchild would be depth 2
+	// (exceeds maxDepth=1).
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents (root + child, no grandchild), got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_CycleDetection(t *testing.T) {
+	// Page A -> Page B -> Page A (cycle).
+	pageA := `{
+		"id": "page-a", "url": "https://notion.so/page-a",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "A"}]}},
+		"parent": {"type": "workspace"}
+	}`
+	pageMD := `{"markdown": "content"}`
+	childrenA := `{
+		"results": [{"id": "page-b", "type": "child_page", "has_children": false}],
+		"has_more": false
+	}`
+	pageB := `{
+		"id": "page-b", "url": "https://notion.so/page-b",
+		"last_edited_time": "2026-05-10T15:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "B"}]}},
+		"parent": {"type": "page_id", "page_id": "page-a"}
+	}`
+	childrenB := `{
+		"results": [{"id": "page-a", "type": "child_page", "has_children": false}],
+		"has_more": false
+	}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageA},
+			{statusCode: 200, body: pageMD},
+			{statusCode: 200, body: childrenA},
+			{statusCode: 200, body: pageB},
+			{statusCode: 200, body: pageMD},
+			{statusCode: 200, body: childrenB},
+			// page-a would be fetched again here but cycle detection stops it.
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-a"}
+	conn.config.IncludeChildPages = true
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents (A and B, no cycle), got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_IncrementalSyncViaTimestamp(t *testing.T) {
+	dbQueryResp := `{
+		"results": [
+			{
+				"id": "recent-entry",
+				"url": "https://notion.so/recent",
+				"last_edited_time": "2026-05-15T10:00:00.000Z",
+				"properties": {
+					"Name": {"type": "title", "title": [{"plain_text": "Recent"}]}
+				}
+			}
+		],
+		"has_more": false
+	}`
+	entryMD := `{"markdown": "updated content"}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: dbQueryResp},
+			{statusCode: 200, body: entryMD},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.DatabaseIDs = []string{"db-incremental"}
+
+	cursor := SyncCursor{
+		Value:     "2026-05-01T00:00:00.000Z",
+		UpdatedAt: time.Now(),
+	}
+	docsCh, errsCh := conn.FetchSince(context.Background(), cursor)
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	// Verify the filter was sent in the request body.
+	if len(mock.calls) < 1 {
+		t.Fatal("expected at least 1 API call")
+	}
+	requestBody := mock.calls[0].body
+	if !strings.Contains(requestBody, "on_or_after") {
+		t.Errorf("expected on_or_after filter in request body: %s", requestBody)
+	}
+}
+
+func TestNotionConnector_CursorUpdatedAfterSync(t *testing.T) {
+	dbResp := `{
+		"results": [
+			{
+				"id": "e1", "url": "https://notion.so/e1",
+				"last_edited_time": "2026-05-15T10:00:00.000Z",
+				"properties": {"Name": {"type": "title", "title": [{"plain_text": "E1"}]}}
+			}
+		],
+		"has_more": false
+	}`
+	entryMD := `{"markdown": "content"}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: dbResp},
+			{statusCode: 200, body: entryMD},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.DatabaseIDs = []string{"db-cursor"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	// Verify the document has the correct modified time for cursor
+	// tracking.
+	expected, _ := time.Parse(time.RFC3339, "2026-05-15T10:00:00.000Z")
+	if !docs[0].ModifiedAt.Equal(expected) {
+		t.Errorf("expected modifiedAt %v, got %v", expected, docs[0].ModifiedAt)
+	}
+}
+
+func TestNotionConnector_RateLimit429Handling(t *testing.T) {
+	pageResp := `{
+		"id": "page-rl", "url": "https://notion.so/page-rl",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "RL Page"}]}},
+		"parent": {"type": "workspace"}
+	}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 429, body: `{"message": "rate limited"}`, headers: http.Header{"Retry-After": []string{"1"}}},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-rl"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	_, errs := collectDocs(docsCh, errsCh)
+
+	// The connector should report a rate limit error.
+	_ = pageResp // Used for documentation; the mock returns 429 first.
+	hasRateLimitErr := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "rate limited") {
+			hasRateLimitErr = true
+			break
+		}
+	}
+	if !hasRateLimitErr {
+		t.Errorf("expected rate limit error in results, got: %v", errs)
+	}
+}
+
+func TestNotionConnector_FileBlockDownload(t *testing.T) {
+	pageResp := `{
+		"id": "page-file", "url": "https://notion.so/page-file",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "File Page"}]}},
+		"parent": {"type": "workspace"}
+	}`
+	// Markdown API returns content with image reference.
+	markdownResp := `{"markdown": "![image](https://example.com/image.png)\n\nSome text."}`
+	childBlocksResp := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: markdownResp},
+			{statusCode: 200, body: childBlocksResp},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"page-file"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+
+	content := string(docs[0].Content)
+	if !strings.Contains(content, "image.png") {
+		t.Errorf("expected image reference in content: %q", content)
+	}
+}
+
+func TestNotionConnector_EmptyWorkspace(t *testing.T) {
+	searchResp := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: searchResp},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	// No rootPageIds or databaseIds, triggers workspace search.
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("expected 0 documents, got %d", len(docs))
+	}
+}
+
+func TestNotionConnector_WorkspaceSearch(t *testing.T) {
+	searchResp := `{
+		"results": [
+			{
+				"id": "ws-page-1",
+				"object": "page",
+				"last_edited_time": "2026-05-10T14:00:00.000Z"
+			}
+		],
+		"has_more": false
+	}`
+	pageResp := `{
+		"id": "ws-page-1", "url": "https://notion.so/ws-page-1",
+		"last_edited_time": "2026-05-10T14:00:00.000Z",
+		"properties": {"Title": {"type": "title", "title": [{"plain_text": "WS Page"}]}},
+		"parent": {"type": "workspace"}
+	}`
+	pageMD := `{"markdown": "workspace page content"}`
+	childBlocks := `{"results": [], "has_more": false}`
+
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: searchResp},
+			{statusCode: 200, body: pageResp},
+			{statusCode: 200, body: pageMD},
+			{statusCode: 200, body: childBlocks},
+		},
+	}
+
+	conn := newTestConnector(mock)
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	docs, errs := collectDocs(docsCh, errsCh)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document from workspace search, got %d", len(docs))
+	}
+	if docs[0].Title != "WS Page" {
+		t.Errorf("expected title 'WS Page', got %q", docs[0].Title)
+	}
+}
+
+func TestNotionConnector_BlockToMarkdown_RichText(t *testing.T) {
+	conn := newTestConnector(nil)
+
+	tests := []struct {
+		name     string
+		block    notionBlock
+		expected string
+	}{
+		{
+			name: "heading_1",
+			block: makeBlock("heading_1", `{
+				"rich_text": [{"type": "text", "plain_text": "Main Heading"}]
+			}`),
+			expected: "# Main Heading\n",
+		},
+		{
+			name: "paragraph with bold",
+			block: makeBlock("paragraph", `{
+				"rich_text": [{"type": "text", "plain_text": "bold text", "annotations": {"bold": true}}]
+			}`),
+			expected: "**bold text**\n",
+		},
+		{
+			name: "code block",
+			block: makeBlock("code", `{
+				"rich_text": [{"type": "text", "plain_text": "fmt.Println(\"hello\")"}],
+				"language": "go"
+			}`),
+			expected: "```go\nfmt.Println(\"hello\")\n```\n",
+		},
+		{
+			name: "bulleted list",
+			block: makeBlock("bulleted_list_item", `{
+				"rich_text": [{"type": "text", "plain_text": "List item"}]
+			}`),
+			expected: "- List item",
+		},
+		{
+			name: "to_do checked",
+			block: makeBlock("to_do", `{
+				"rich_text": [{"type": "text", "plain_text": "Done task"}],
+				"checked": true
+			}`),
+			expected: "- [x] Done task",
+		},
+		{
+			name: "quote",
+			block: makeBlock("quote", `{
+				"rich_text": [{"type": "text", "plain_text": "Quoted text"}]
+			}`),
+			expected: "> Quoted text\n",
+		},
+		{
+			name:     "divider",
+			block:    makeBlock("divider", `{}`),
+			expected: "---\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := conn.blockToMarkdown(tt.block)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNotionConnector_PropertyExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "select",
+			raw:      `{"type": "select", "select": {"name": "Active"}}`,
+			expected: "Active",
+		},
+		{
+			name:     "multi_select",
+			raw:      `{"type": "multi_select", "multi_select": [{"name": "Tag1"}, {"name": "Tag2"}]}`,
+			expected: "Tag1, Tag2",
+		},
+		{
+			name:     "number",
+			raw:      `{"type": "number", "number": 42}`,
+			expected: "42",
+		},
+		{
+			name:     "checkbox true",
+			raw:      `{"type": "checkbox", "checkbox": true}`,
+			expected: "true",
+		},
+		{
+			name:     "date range",
+			raw:      `{"type": "date", "date": {"start": "2026-05-01", "end": "2026-05-15"}}`,
+			expected: "2026-05-01 to 2026-05-15",
+		},
+		{
+			name:     "url",
+			raw:      `{"type": "url", "url": "https://example.com"}`,
+			expected: "https://example.com",
+		},
+		{
+			name:     "rich_text",
+			raw:      `{"type": "rich_text", "rich_text": [{"plain_text": "Hello"}, {"plain_text": " world"}]}`,
+			expected: "Hello world",
+		},
+		{
+			name:     "status",
+			raw:      `{"type": "status", "status": {"name": "In Progress"}}`,
+			expected: "In Progress",
+		},
+		{
+			name:     "null select",
+			raw:      `{"type": "select", "select": null}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractPropertyValue(json.RawMessage(tt.raw))
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNotionConnector_RenderRichText(t *testing.T) {
+	tests := []struct {
+		name     string
+		texts    []notionRichText
+		expected string
+	}{
+		{
+			name: "plain text",
+			texts: []notionRichText{
+				{PlainText: "Hello"},
+			},
+			expected: "Hello",
+		},
+		{
+			name: "bold and italic",
+			texts: []notionRichText{
+				{PlainText: "bold", Annotations: notionAnnotations{Bold: true}},
+				{PlainText: " and "},
+				{PlainText: "italic", Annotations: notionAnnotations{Italic: true}},
+			},
+			expected: "**bold** and *italic*",
+		},
+		{
+			name: "code annotation",
+			texts: []notionRichText{
+				{PlainText: "codeVar", Annotations: notionAnnotations{Code: true}},
+			},
+			expected: "`codeVar`",
+		},
+		{
+			name: "link",
+			texts: []notionRichText{
+				{PlainText: "click here", Href: "https://example.com"},
+			},
+			expected: "[click here](https://example.com)",
+		},
+		{
+			name: "strikethrough",
+			texts: []notionRichText{
+				{PlainText: "deleted", Annotations: notionAnnotations{Strikethrough: true}},
+			},
+			expected: "~~deleted~~",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderRichText(tt.texts)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNotionConnector_TableRowRendering(t *testing.T) {
+	data := json.RawMessage(`{
+		"cells": [
+			[{"type": "text", "plain_text": "Col1"}],
+			[{"type": "text", "plain_text": "Col2"}],
+			[{"type": "text", "plain_text": "Col3"}]
+		]
+	}`)
+
+	result := renderTableRow(data)
+	expected := "| Col1 | Col2 | Col3 |"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestNotionConnector_Stop(t *testing.T) {
+	conn := NewNotionConnector(ConnectorConfig{}, nil)
+	err := conn.Stop()
+	if err != nil {
+		t.Fatalf("unexpected error from Stop: %v", err)
+	}
+
+	// Calling Stop again should not panic.
+	err = conn.Stop()
+	if err != nil {
+		t.Fatalf("second Stop call failed: %v", err)
+	}
+}
+
+func TestNotionConnector_AuthHeader(t *testing.T) {
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: `{
+				"id": "p1", "url": "https://notion.so/p1",
+				"last_edited_time": "2026-05-10T14:00:00.000Z",
+				"properties": {"Title": {"type": "title", "title": [{"plain_text": "T"}]}},
+				"parent": {"type": "workspace"}
+			}`},
+			{statusCode: 200, body: `{"markdown": "content"}`},
+			{statusCode: 200, body: `{"results": [], "has_more": false}`},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"p1"}
+
+	docsCh, errsCh := conn.FetchAll(context.Background())
+	collectDocs(docsCh, errsCh)
+
+	if len(mock.calls) < 1 {
+		t.Fatal("expected at least 1 API call")
+	}
+
+	// Verify auth header was sent (via URL containing Bearer token in
+	// the mock's captured requests).
+	firstCall := mock.calls[0]
+	if !strings.Contains(firstCall.url, "/pages/p1") {
+		t.Errorf("expected first call to /pages/p1, got %s", firstCall.url)
+	}
+}
+
+func TestNotionConnector_ContextCancellation(t *testing.T) {
+	// Create a slow mock that would block.
+	mock := &mockHTTPClient{
+		responses: []mockResponse{
+			{statusCode: 200, body: `{
+				"id": "p1", "url": "https://notion.so/p1",
+				"last_edited_time": "2026-05-10T14:00:00.000Z",
+				"properties": {"Title": {"type": "title", "title": [{"plain_text": "T"}]}},
+				"parent": {"type": "workspace"}
+			}`},
+			{statusCode: 200, body: `{"markdown": "content"}`},
+			{statusCode: 200, body: `{"results": [], "has_more": false}`},
+		},
+	}
+
+	conn := newTestConnector(mock)
+	conn.config.RootPageIDs = []string{"p1"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	docsCh, errsCh := conn.FetchAll(ctx)
+	collectDocs(docsCh, errsCh)
+	// Just verify it doesn't hang.
+}
+
+// makeBlock constructs a notionBlock with RawData for testing.
+func makeBlock(blockType, blockDataJSON string) notionBlock {
+	raw := map[string]json.RawMessage{
+		"id":           json.RawMessage(`"test-block"`),
+		"type":         json.RawMessage(`"` + blockType + `"`),
+		"has_children": json.RawMessage(`false`),
+		blockType:      json.RawMessage(blockDataJSON),
+	}
+	data, _ := json.Marshal(raw)
+
+	return notionBlock{
+		ID:          "test-block",
+		Type:        blockType,
+		HasChildren: false,
+		RawData:     data,
+	}
+}
+
+// TestNotionConnector_doNotionRequest_SetsHeaders verifies request
+// headers are correctly set.
+func TestNotionConnector_doNotionRequest_SetsHeaders(t *testing.T) {
+	var capturedReq *http.Request
+
+	transport := &capturingTransport{
+		response: &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
+			Header:     http.Header{},
+		},
+		captureReq: func(r *http.Request) {
+			capturedReq = r
+		},
+	}
+
+	conn := newTestConnector(nil)
+	conn.httpClient = &http.Client{Transport: transport}
+
+	ctx := WithNotionBaseURL(context.Background(), "http://localhost:9999")
+	_, err := conn.doNotionRequest(ctx, http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedReq == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if capturedReq.Header.Get("Authorization") != "Bearer secret_test_token" {
+		t.Errorf("unexpected auth header: %s", capturedReq.Header.Get("Authorization"))
+	}
+	if capturedReq.Header.Get("Notion-Version") != notionAPIVersion {
+		t.Errorf("unexpected notion version: %s", capturedReq.Header.Get("Notion-Version"))
+	}
+}
+
+// capturingTransport captures the request for inspection.
+type capturingTransport struct {
+	response   *http.Response
+	captureReq func(r *http.Request)
+}
+
+func (t *capturingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.captureReq != nil {
+		t.captureReq(req)
+	}
+	return t.response, nil
+}

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -71,3 +71,10 @@ export {
 
 export { GDriveConnector, createGDriveConnector } from './gdrive.js'
 export type { GDriveConnectorConfig } from './gdrive.js'
+
+export {
+  createNotionConnector,
+  type NotionConnectorConfig,
+  type NotionConnectorOptions,
+  type NotionHTTPFetcher,
+} from './notion.js'

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -78,3 +78,21 @@ export {
   type NotionConnectorOptions,
   type NotionHTTPFetcher,
 } from './notion.js'
+
+export {
+  blockToMarkdown,
+  isListBlock,
+  renderPlainRichText,
+  renderRichText,
+  type NotionBlock,
+  type NotionRichText,
+} from './notion-blocks.js'
+
+export {
+  extractPropertyValue,
+  extractTitleFromProperties,
+  parseDatabaseEntry,
+  parsePageResponse,
+  type ParsedDatabaseEntry,
+  type ParsedPage,
+} from './notion-properties.js'

--- a/sdks/ts/memory/src/connector/notion-blocks.ts
+++ b/sdks/ts/memory/src/connector/notion-blocks.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Block rendering helpers for the Notion connector. Converts Notion
+ * block objects to markdown representation and handles rich text
+ * formatting.
+ */
+
+// ---------- Types ----------
+
+/**
+ * Notion rich text object.
+ */
+export type NotionRichText = {
+  readonly type: string
+  readonly plain_text: string
+  readonly href?: string
+  readonly annotations?: NotionAnnotations
+}
+
+/**
+ * Notion text formatting annotations.
+ */
+type NotionAnnotations = {
+  readonly bold?: boolean
+  readonly italic?: boolean
+  readonly strikethrough?: boolean
+  readonly underline?: boolean
+  readonly code?: boolean
+  readonly color?: string
+}
+
+/**
+ * Notion block object from the blocks API.
+ */
+export type NotionBlock = {
+  readonly id: string
+  readonly type: string
+  readonly has_children: boolean
+  readonly [key: string]: unknown
+}
+
+// ---------- Module-level constants ----------
+
+/**
+ * Set of block types considered list items for indentation.
+ * Module-level constant avoids per-call allocation.
+ */
+const LIST_BLOCK_TYPES = new Set([
+  'bulleted_list_item',
+  'numbered_list_item',
+  'to_do',
+  'toggle',
+])
+
+// ---------- Rich text helpers ----------
+
+/**
+ * Renders a Notion rich text array to markdown with formatting.
+ */
+export const renderRichText = (texts: readonly NotionRichText[]): string => {
+  const parts: string[] = []
+
+  for (const t of texts) {
+    let text = t.plain_text
+
+    if (t.annotations?.code === true) {
+      text = '`' + text + '`'
+    }
+    if (t.annotations?.bold === true) {
+      text = '**' + text + '**'
+    }
+    if (t.annotations?.italic === true) {
+      text = '*' + text + '*'
+    }
+    if (t.annotations?.strikethrough === true) {
+      text = '~~' + text + '~~'
+    }
+
+    if (t.href !== undefined && t.href !== '') {
+      text = `[${text}](${t.href})`
+    }
+
+    parts.push(text)
+  }
+
+  return parts.join('')
+}
+
+/**
+ * Extracts plain text from rich text without formatting.
+ */
+export const renderPlainRichText = (
+  texts: readonly NotionRichText[],
+): string => texts.map((t) => t.plain_text).join('')
+
+// ---------- Block rendering ----------
+
+/**
+ * Converts a single Notion block to markdown. Blocks whose type is
+ * not in the allowedTypes filter (when provided) are skipped.
+ */
+export const blockToMarkdown = (
+  block: NotionBlock,
+  allowedTypes?: ReadonlySet<string>,
+): string => {
+  // Apply block type filter when configured.
+  if (allowedTypes !== undefined && !allowedTypes.has(block.type)) {
+    return ''
+  }
+
+  const blockData = block[block.type] as Record<string, unknown> | undefined
+  if (blockData === undefined) return ''
+
+  const richText = (blockData.rich_text ?? []) as readonly NotionRichText[]
+  const text = renderRichText(richText)
+  const caption = (blockData.caption ?? []) as readonly NotionRichText[]
+
+  const renderers: Readonly<Record<string, () => string>> = {
+    paragraph: () => `${text}\n`,
+    heading_1: () => `# ${text}\n`,
+    heading_2: () => `## ${text}\n`,
+    heading_3: () => `### ${text}\n`,
+    bulleted_list_item: () => `- ${text}`,
+    numbered_list_item: () => `1. ${text}`,
+    to_do: () => {
+      const checked = blockData.checked === true
+      const marker = checked ? '[x]' : '[ ]'
+      return `- ${marker} ${text}`
+    },
+    toggle: () => `- ${text}`,
+    quote: () => `> ${text}\n`,
+    callout: () => `> ${text}\n`,
+    divider: () => '---\n',
+    code: () => {
+      const lang = (blockData.language as string) ?? ''
+      return '```' + lang + '\n' + text + '\n```\n'
+    },
+    equation: () => {
+      const expression = (blockData.expression as string) ?? ''
+      return `$$\n${expression}\n$$\n`
+    },
+    image: () => {
+      const capText = renderRichText(caption)
+      const url = extractFileUrl(blockData)
+      return capText !== ''
+        ? `![${capText}](${url})\n`
+        : `![](${url})\n`
+    },
+    file: () => {
+      const url = extractFileUrl(blockData)
+      const capText = renderRichText(caption)
+      const label = capText !== '' ? capText : 'file'
+      return `[${label}](${url})\n`
+    },
+    bookmark: () => {
+      const capText = renderRichText(caption)
+      const url = blockData.url as string | undefined
+      if (url !== undefined) {
+        return capText !== '' ? `[${capText}](${url})\n` : `${url}\n`
+      }
+      return ''
+    },
+    embed: () => {
+      const url = blockData.url as string | undefined
+      return url !== undefined ? `${url}\n` : ''
+    },
+    table_of_contents: () => '',
+    breadcrumb: () => '',
+    column_list: () => '',
+    column: () => '',
+    child_page: () => '',
+    child_database: () => '',
+    synced_block: () => '',
+    link_preview: () => {
+      const url = blockData.url as string | undefined
+      return url !== undefined ? `${url}\n` : ''
+    },
+    table: () => '',
+    table_row: () => {
+      const cells = (blockData.cells ?? []) as readonly (readonly NotionRichText[])[]
+      const rendered = cells.map((cell) => renderRichText(cell))
+      return `| ${rendered.join(' | ')} |`
+    },
+  }
+
+  const renderer = renderers[block.type]
+  return renderer !== undefined ? renderer() : text
+}
+
+/**
+ * Checks whether a block type is a list item.
+ */
+export const isListBlock = (blockType: string): boolean =>
+  LIST_BLOCK_TYPES.has(blockType)
+
+/**
+ * Extracts a file URL from a file-type block's data.
+ */
+const extractFileUrl = (data: Record<string, unknown>): string => {
+  const file = data.file as { url?: string } | undefined
+  const external = data.external as { url?: string } | undefined
+  return file?.url ?? external?.url ?? ''
+}

--- a/sdks/ts/memory/src/connector/notion-properties.ts
+++ b/sdks/ts/memory/src/connector/notion-properties.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Property extraction helpers for the Notion connector. Converts
+ * Notion property objects to their string representations and
+ * parses database entries into structured data.
+ */
+
+import { renderPlainRichText, type NotionRichText } from './notion-blocks.js'
+
+// ---------- Types ----------
+
+/**
+ * Parsed database entry.
+ */
+export type ParsedDatabaseEntry = {
+  readonly pageId: string
+  readonly title: string
+  readonly url: string
+  readonly lastEditedTime: Date
+  readonly propertiesMarkdown: string
+}
+
+/**
+ * Parsed page metadata.
+ */
+export type ParsedPage = {
+  readonly id: string
+  readonly title: string
+  readonly url: string
+  readonly lastEditedTime: Date
+}
+
+// ---------- Title extraction ----------
+
+/**
+ * Extracts the title from a page's properties map.
+ */
+export const extractTitleFromProperties = (
+  properties: Record<string, Record<string, unknown>>,
+): string => {
+  for (const prop of Object.values(properties)) {
+    if (prop.type === 'title') {
+      const titleArr = (prop.title ?? []) as readonly NotionRichText[]
+      return renderPlainRichText(titleArr)
+    }
+  }
+  return ''
+}
+
+// ---------- Property value extraction ----------
+
+/**
+ * Converts a Notion property to its string representation.
+ */
+export const extractPropertyValue = (
+  prop: Record<string, unknown>,
+): string => {
+  const propType = prop.type as string
+
+  const renderers: Readonly<Record<string, () => string>> = {
+    title: () =>
+      renderPlainRichText((prop.title ?? []) as readonly NotionRichText[]),
+    rich_text: () =>
+      renderPlainRichText(
+        (prop.rich_text ?? []) as readonly NotionRichText[],
+      ),
+    number: () => {
+      const num = prop.number as number | null
+      return num !== null && num !== undefined ? String(num) : ''
+    },
+    select: () => {
+      const sel = prop.select as { name: string } | null
+      return sel?.name ?? ''
+    },
+    multi_select: () => {
+      const items = (prop.multi_select ?? []) as readonly { name: string }[]
+      return items.map((i) => i.name).join(', ')
+    },
+    date: () => {
+      const d = prop.date as { start: string; end?: string } | null
+      if (d === null || d === undefined) return ''
+      return d.end !== undefined && d.end !== ''
+        ? `${d.start} to ${d.end}`
+        : d.start
+    },
+    checkbox: () => (prop.checkbox === true ? 'true' : 'false'),
+    url: () => (prop.url as string) ?? '',
+    email: () => (prop.email as string) ?? '',
+    phone_number: () => (prop.phone_number as string) ?? '',
+    status: () => {
+      const st = prop.status as { name: string } | null
+      return st?.name ?? ''
+    },
+    people: () => {
+      const people = (prop.people ?? []) as readonly { name: string }[]
+      return people.map((p) => p.name).join(', ')
+    },
+    relation: () => {
+      const rels = (prop.relation ?? []) as readonly { id: string }[]
+      return rels.map((r) => r.id).join(', ')
+    },
+  }
+
+  const renderer = renderers[propType]
+  return renderer !== undefined ? renderer() : ''
+}
+
+// ---------- Database entry parsing ----------
+
+/**
+ * Parses a database entry from the query response.
+ */
+export const parseDatabaseEntry = (
+  raw: Record<string, unknown>,
+): ParsedDatabaseEntry => {
+  const properties = (raw.properties ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >
+  const lastEditedStr = raw.last_edited_time as string
+  const lastEditedTime = new Date(lastEditedStr)
+
+  let title = ''
+  const propLines: string[] = []
+
+  // Sort keys for deterministic output.
+  const sortedKeys = Object.keys(properties).sort()
+
+  for (const key of sortedKeys) {
+    const prop = properties[key]
+    if (prop === undefined) continue
+    const val = extractPropertyValue(prop)
+
+    if (prop.type === 'title') {
+      title = val
+      continue
+    }
+
+    if (val !== '') {
+      propLines.push(`- **${key}**: ${val}`)
+    }
+  }
+
+  let markdown = ''
+  if (title !== '') {
+    markdown += `## ${title}\n\n`
+  }
+  if (propLines.length > 0) {
+    markdown += propLines.join('\n') + '\n'
+  }
+
+  return {
+    pageId: raw.id as string,
+    title,
+    url: raw.url as string,
+    lastEditedTime,
+    propertiesMarkdown: markdown,
+  }
+}
+
+// ---------- Page response parsing ----------
+
+/**
+ * Parses a Notion API page response into structured metadata.
+ */
+export const parsePageResponse = (
+  data: Record<string, unknown>,
+): ParsedPage => {
+  const properties = (data.properties ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >
+  const title = extractTitleFromProperties(properties)
+  const lastEditedStr = data.last_edited_time as string
+  const lastEditedTime = new Date(lastEditedStr)
+
+  return {
+    id: data.id as string,
+    title,
+    url: data.url as string,
+    lastEditedTime,
+  }
+}

--- a/sdks/ts/memory/src/connector/notion-utils.ts
+++ b/sdks/ts/memory/src/connector/notion-utils.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Utility functions for the Notion connector. Contains transport
+ * helpers, signal combinators, and configuration parsers.
+ */
+
+// ---------- Retry-After parsing ----------
+
+/**
+ * Parses the Retry-After header value as seconds. Returns -1 if
+ * absent or unparseable (indicating backoff should be used instead).
+ */
+export const parseRetryAfterHeader = (value: string | null): number => {
+  if (value === null || value === '') return -1
+  const parsed = parseInt(value, 10)
+  return isNaN(parsed) ? -1 : parsed
+}
+
+// ---------- Response body size limiting ----------
+
+/**
+ * Reads a Response body with a size limit. Throws if the body
+ * exceeds the limit.
+ */
+export const readResponseWithLimit = async (
+  response: Response,
+  maxBytes: number,
+): Promise<string> => {
+  // If the Content-Length header is present and exceeds the limit,
+  // reject early.
+  const contentLength = response.headers.get('Content-Length')
+  if (contentLength !== null) {
+    const length = parseInt(contentLength, 10)
+    if (!isNaN(length) && length > maxBytes) {
+      throw new Error(
+        `connector/notion: response body exceeds ${String(maxBytes)} bytes limit`,
+      )
+    }
+  }
+
+  // Stream the body, checking size as we go.
+  if (response.body !== null) {
+    const reader = response.body.getReader()
+    const chunks: Uint8Array[] = []
+    let totalBytes = 0
+
+    let readResult = await reader.read()
+    while (!readResult.done) {
+      totalBytes += readResult.value.byteLength
+      if (totalBytes > maxBytes) {
+        reader.cancel().catch(() => { /* intentionally empty */ })
+        throw new Error(
+          `connector/notion: response body exceeds ${String(maxBytes)} bytes limit`,
+        )
+      }
+      chunks.push(readResult.value)
+      readResult = await reader.read()
+    }
+
+    const decoder = new TextDecoder()
+    return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join('') +
+      decoder.decode()
+  }
+
+  return response.text()
+}
+
+// ---------- Signal helpers ----------
+
+/**
+ * Sleeps for the given duration, but resolves early if the signal
+ * fires.
+ */
+export const interruptibleSleep = (
+  signal: AbortSignal,
+  ms: number,
+): Promise<void> =>
+  new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      resolve()
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+/**
+ * Combines two abort signals into one that fires when either fires.
+ */
+export const combineSignals = (a: AbortSignal, b: AbortSignal): AbortSignal => {
+  if (a.aborted) return a
+  if (b.aborted) return b
+
+  const controller = new AbortController()
+  const onAbort = (): void => controller.abort()
+  a.addEventListener('abort', onAbort, { once: true })
+  b.addEventListener('abort', onAbort, { once: true })
+  return controller.signal
+}
+
+// ---------- Configuration parsers ----------
+
+/**
+ * Parses a value that might be a string array or undefined.
+ */
+export const parseStringArray = (
+  value: unknown,
+): readonly string[] | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string')
+  }
+  return undefined
+}
+
+/**
+ * Parses a block type filter from raw config. Accepts a string
+ * array and converts to a Set.
+ */
+export const parseBlockTypeFilter = (
+  value: unknown,
+): ReadonlySet<string> | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (Array.isArray(value)) {
+    const filtered = value.filter((v): v is string => typeof v === 'string')
+    return filtered.length > 0 ? new Set(filtered) : undefined
+  }
+  return undefined
+}
+
+// ---------- HTTP ----------
+
+/**
+ * HTTP fetcher interface for dependency injection in tests.
+ */
+export type NotionHTTPFetcher = (
+  url: string,
+  options: RequestInit,
+) => Promise<Response>
+
+/**
+ * Global fetch wrapper for the default HTTP fetcher.
+ */
+export const globalFetch: NotionHTTPFetcher = (url, options) =>
+  fetch(url, options)

--- a/sdks/ts/memory/src/connector/notion.test.ts
+++ b/sdks/ts/memory/src/connector/notion.test.ts
@@ -515,9 +515,19 @@ describe('NotionConnector', () => {
     })
 
     it('handles rate limit 429 responses', async () => {
-      const { fetcher } = createMockFetcher([
-        { status: 429, body: '{"message": "rate limited"}' },
-      ])
+      // Provide enough 429 responses (with Retry-After: 0 for fast
+      // retries) to exhaust all retries (6 total).
+      let callIndex = 0
+      const fetcher: NotionHTTPFetcher = async (url, options) => {
+        callIndex++
+        return new Response('{"message": "rate limited"}', {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': '0',
+          },
+        })
+      }
 
       const conn = createNotionConnector(testDeps(), { fetcher })
       await conn.configure({
@@ -525,7 +535,7 @@ describe('NotionConnector', () => {
         rootPageIds: ['page-rl'],
       })
 
-      const signal = AbortSignal.timeout(5000)
+      const signal = AbortSignal.timeout(15000)
       // The fetch should not throw but skip the page due to the error.
       const docs = await collectDocs(conn.fetchAll(signal))
       expect(docs).toHaveLength(0) // Page skipped due to error
@@ -1000,6 +1010,391 @@ describe('NotionConnector', () => {
       const content = String(docs[0].content)
       expect(content).toContain('**bold**')
       expect(content).toContain('*italic*')
+    })
+  })
+
+  describe('nested block children rendering', () => {
+    it('renders nested blocks with indentation', async () => {
+      const pageResp = JSON.stringify({
+        id: 'nested-page',
+        url: 'https://notion.so/nested-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Nested' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      // Parent list item with has_children: true
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'parent-list',
+            type: 'bulleted_list_item',
+            has_children: true,
+            bulleted_list_item: {
+              rich_text: [{ type: 'text', plain_text: 'Parent item' }],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      // Child blocks of the parent list item
+      const childBlocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'child-para',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                { type: 'text', plain_text: 'Nested paragraph' },
+              ],
+            },
+          },
+          {
+            id: 'child-list',
+            type: 'bulleted_list_item',
+            has_children: false,
+            bulleted_list_item: {
+              rich_text: [
+                { type: 'text', plain_text: 'Nested list item' },
+              ],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      // No children for page itself
+      const pageChildBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' }, // markdown API not available
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocksResp },
+        { status: 200, body: pageChildBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['nested-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      // The parent item should be present.
+      expect(content).toContain('- Parent item')
+      // Child content should be indented (list block gets "  " prefix).
+      expect(content).toContain('  Nested paragraph')
+      expect(content).toContain('  - Nested list item')
+    })
+  })
+
+  describe('synced_block rendering', () => {
+    it('returns empty string for synced_block type', async () => {
+      const pageResp = JSON.stringify({
+        id: 'sync-page',
+        url: 'https://notion.so/sync-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Synced' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'synced-1',
+            type: 'synced_block',
+            has_children: false,
+            synced_block: {
+              synced_from: { block_id: 'original-block-123' },
+            },
+          },
+          {
+            id: 'para-1',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                { type: 'text', plain_text: 'After synced block' },
+              ],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['sync-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      // synced_block renders as empty string, so only the paragraph
+      // after it should appear.
+      expect(content).toContain('After synced block')
+      // The synced_from reference should not leak into output.
+      expect(content).not.toContain('original-block-123')
+    })
+  })
+
+  describe('equation block rendering', () => {
+    it('renders equation blocks with $$ delimiters', async () => {
+      const pageResp = JSON.stringify({
+        id: 'eq-page',
+        url: 'https://notion.so/eq-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Equations' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'eq-1',
+            type: 'equation',
+            has_children: false,
+            equation: {
+              expression: 'E = mc^2',
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['eq-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      expect(content).toContain('$$')
+      expect(content).toContain('E = mc^2')
+    })
+  })
+
+  describe('image/file block rendering via block fallback', () => {
+    it('renders image blocks with alt text', async () => {
+      const pageResp = JSON.stringify({
+        id: 'img-page',
+        url: 'https://notion.so/img-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Images' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'img-1',
+            type: 'image',
+            has_children: false,
+            image: {
+              caption: [{ type: 'text', plain_text: 'My photo' }],
+              file: { url: 'https://example.com/photo.png' },
+            },
+          },
+          {
+            id: 'file-1',
+            type: 'file',
+            has_children: false,
+            file: {
+              caption: [{ type: 'text', plain_text: 'Document' }],
+              file: { url: 'https://example.com/doc.pdf' },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['img-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      expect(content).toContain('![My photo](https://example.com/photo.png)')
+      expect(content).toContain('[Document](https://example.com/doc.pdf)')
+    })
+  })
+
+  describe('block type filter', () => {
+    it('filters out non-allowed block types', async () => {
+      const pageResp = JSON.stringify({
+        id: 'filter-page',
+        url: 'https://notion.so/filter-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Filtered' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'h1',
+            type: 'heading_1',
+            has_children: false,
+            heading_1: {
+              rich_text: [{ type: 'text', plain_text: 'Allowed Heading' }],
+            },
+          },
+          {
+            id: 'p1',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                { type: 'text', plain_text: 'Filtered paragraph' },
+              ],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['filter-page'],
+        blockTypeFilter: ['heading_1'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      expect(content).toContain('# Allowed Heading')
+      expect(content).not.toContain('Filtered paragraph')
+    })
+  })
+
+  describe('retry-after handling on 429', () => {
+    it('retries after receiving 429 with Retry-After header', async () => {
+      const pageResp = JSON.stringify({
+        id: 'retry-page',
+        url: 'https://notion.so/retry-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Retry' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const md = JSON.stringify({ markdown: 'retried content' })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      // Custom fetcher that returns 429 with Retry-After on first call,
+      // then succeeds.
+      let callIndex = 0
+      const responses = [
+        { status: 429, body: '{"message":"rate limited"}', retryAfter: '1' },
+        { status: 200, body: pageResp, retryAfter: undefined },
+        { status: 200, body: md, retryAfter: undefined },
+        { status: 200, body: childBlocks, retryAfter: undefined },
+      ]
+
+      const fetcher: NotionHTTPFetcher = async (url, options) => {
+        const idx = callIndex++
+        const resp = idx < responses.length
+          ? responses[idx]
+          : { status: 200, body: '{}', retryAfter: undefined }
+
+        const headers = new Headers({ 'Content-Type': 'application/json' })
+        if (resp.retryAfter !== undefined) {
+          headers.set('Retry-After', resp.retryAfter)
+        }
+
+        return new Response(resp.body, {
+          status: resp.status,
+          headers,
+        })
+      }
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['retry-page'],
+      })
+
+      const signal = AbortSignal.timeout(10000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].title).toBe('Retry')
+      expect(String(docs[0].content)).toContain('retried content')
     })
   })
 

--- a/sdks/ts/memory/src/connector/notion.test.ts
+++ b/sdks/ts/memory/src/connector/notion.test.ts
@@ -1,0 +1,1040 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  createNotionConnector,
+  type NotionHTTPFetcher,
+} from './notion.js'
+import type { ConnectorConfig, ConnectorDocument } from './types.js'
+
+// ---------- Test helpers ----------
+
+type MockResponse = {
+  readonly status: number
+  readonly body: string
+}
+
+/**
+ * Creates a mock fetcher that returns canned responses in sequence.
+ */
+const createMockFetcher = (
+  responses: readonly MockResponse[],
+): {
+  readonly fetcher: NotionHTTPFetcher
+  readonly calls: { url: string; method: string; body: string }[]
+} => {
+  let callIndex = 0
+  const calls: { url: string; method: string; body: string }[] = []
+
+  const fetcher: NotionHTTPFetcher = async (url, options) => {
+    const bodyText =
+      options.body !== undefined && options.body !== null
+        ? String(options.body)
+        : ''
+    calls.push({ url, method: options.method ?? 'GET', body: bodyText })
+
+    const idx = callIndex
+    callIndex++
+
+    const resp =
+      idx < responses.length
+        ? responses[idx]
+        : { status: 200, body: '{}' }
+
+    return new Response(resp.body, {
+      status: resp.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  return { fetcher, calls }
+}
+
+/**
+ * Collects all documents from an async iterable.
+ */
+const collectDocs = async (
+  iterable: AsyncIterable<ConnectorDocument>,
+): Promise<readonly ConnectorDocument[]> => {
+  const docs: ConnectorDocument[] = []
+  for await (const doc of iterable) {
+    docs.push(doc)
+  }
+  return docs
+}
+
+/**
+ * Creates a minimal ConnectorConfig for tests.
+ */
+const testDeps = (): ConnectorConfig =>
+  ({
+    name: 'notion',
+    brainId: 'test-brain',
+    store: {} as ConnectorConfig['store'],
+  }) as ConnectorConfig
+
+// ---------- Tests ----------
+
+describe('NotionConnector', () => {
+  describe('name', () => {
+    it('returns notion', () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      expect(conn.name).toBe('notion')
+    })
+  })
+
+  describe('configure', () => {
+    it('rejects missing apiToken', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await expect(conn.configure({})).rejects.toThrow('apiToken is required')
+    })
+
+    it('rejects empty apiToken', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await expect(conn.configure({ apiToken: '' })).rejects.toThrow(
+        'apiToken is required',
+      )
+    })
+
+    it('accepts valid configuration', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_abc123',
+        rootPageIds: ['page-1', 'page-2'],
+        databaseIds: ['db-1'],
+        includeChildPages: false,
+        maxDepth: 5,
+      })
+      // No error thrown.
+    })
+  })
+
+  describe('fetchAll', () => {
+    it('errors when not configured', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      const signal = AbortSignal.timeout(5000)
+      await expect(collectDocs(conn.fetchAll(signal))).rejects.toThrow(
+        'not configured',
+      )
+    })
+
+    it('fetches page via markdown API', async () => {
+      const pageResp = JSON.stringify({
+        id: 'page-123',
+        url: 'https://notion.so/page-123',
+        last_edited_time: '2026-05-10T14:30:00.000Z',
+        properties: {
+          Name: {
+            type: 'title',
+            title: [{ plain_text: 'Test Page' }],
+          },
+        },
+        parent: { type: 'workspace' },
+      })
+      const markdownResp = JSON.stringify({
+        markdown: '# Test Page\n\nThis is test content.',
+      })
+      const childBlocksResp = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 200, body: markdownResp },
+        { status: 200, body: childBlocksResp },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['page-123'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].externalId).toBe('page-123')
+      expect(docs[0].title).toBe('Test Page')
+      expect(docs[0].mime).toBe('text/markdown')
+      expect(String(docs[0].content)).toContain('This is test content')
+      expect(docs[0].metadata.source).toBe('notion')
+    })
+
+    it('falls back to block retrieval when markdown API returns 404', async () => {
+      const pageResp = JSON.stringify({
+        id: 'page-456',
+        url: 'https://notion.so/page-456',
+        last_edited_time: '2026-05-10T14:30:00.000Z',
+        properties: {
+          Title: {
+            type: 'title',
+            title: [{ plain_text: 'Block Page' }],
+          },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'block-1',
+            type: 'heading_1',
+            has_children: false,
+            heading_1: {
+              rich_text: [{ type: 'text', plain_text: 'Heading One' }],
+            },
+          },
+          {
+            id: 'block-2',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                { type: 'text', plain_text: 'Paragraph content here.' },
+              ],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocksResp = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{"message": "not found"}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocksResp },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['page-456'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(1)
+      const content = String(docs[0].content)
+      expect(content).toContain('# Heading One')
+      expect(content).toContain('Paragraph content here.')
+    })
+
+    it('queries database with property listings', async () => {
+      const dbQueryResp = JSON.stringify({
+        results: [
+          {
+            id: 'entry-1',
+            url: 'https://notion.so/entry-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Entry One' }],
+              },
+              Status: {
+                type: 'select',
+                select: { name: 'Active' },
+              },
+              Priority: {
+                type: 'number',
+                number: 3,
+              },
+            },
+          },
+          {
+            id: 'entry-2',
+            url: 'https://notion.so/entry-2',
+            last_edited_time: '2026-05-10T11:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Entry Two' }],
+              },
+              Status: {
+                type: 'select',
+                select: { name: 'Done' },
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const entryMD = JSON.stringify({ markdown: 'Details.' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbQueryResp },
+        { status: 200, body: entryMD },
+        { status: 200, body: entryMD },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-test'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+
+      expect(docs).toHaveLength(2)
+      expect(docs[0].title).toBe('Entry One')
+      expect(docs[0].metadata.type).toBe('database_entry')
+      expect(String(docs[0].content)).toContain('## Entry One')
+      expect(String(docs[0].content)).toContain('Active')
+    })
+
+    it('handles paginated database query', async () => {
+      const page1 = JSON.stringify({
+        results: [
+          {
+            id: 'entry-a',
+            url: 'https://notion.so/entry-a',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'A' }],
+              },
+            },
+          },
+        ],
+        has_more: true,
+        next_cursor: 'cursor-page-2',
+      })
+      const page2 = JSON.stringify({
+        results: [
+          {
+            id: 'entry-b',
+            url: 'https://notion.so/entry-b',
+            last_edited_time: '2026-05-10T11:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'B' }],
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const entryMD = JSON.stringify({ markdown: 'content' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: page1 },
+        { status: 200, body: entryMD },
+        { status: 200, body: page2 },
+        { status: 200, body: entryMD },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-paginated'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(2)
+    })
+
+    it('recursively fetches child pages', async () => {
+      const rootPage = JSON.stringify({
+        id: 'root',
+        url: 'https://notion.so/root',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Root' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const rootMD = JSON.stringify({ markdown: 'Root content' })
+      const rootChildren = JSON.stringify({
+        results: [
+          { id: 'child-1', type: 'child_page', has_children: false },
+        ],
+        has_more: false,
+      })
+      const childPage = JSON.stringify({
+        id: 'child-1',
+        url: 'https://notion.so/child-1',
+        last_edited_time: '2026-05-10T15:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Child' }] },
+        },
+        parent: { type: 'page_id', page_id: 'root' },
+      })
+      const childMD = JSON.stringify({ markdown: 'Child content' })
+      const childChildren = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: rootPage },
+        { status: 200, body: rootMD },
+        { status: 200, body: rootChildren },
+        { status: 200, body: childPage },
+        { status: 200, body: childMD },
+        { status: 200, body: childChildren },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['root'],
+        includeChildPages: true,
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(2)
+    })
+
+    it('enforces max depth', async () => {
+      const rootPage = JSON.stringify({
+        id: 'root',
+        url: 'https://notion.so/root',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Root' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const md = JSON.stringify({ markdown: 'content' })
+      const children = JSON.stringify({
+        results: [
+          { id: 'child-1', type: 'child_page', has_children: false },
+        ],
+        has_more: false,
+      })
+      const childPage = JSON.stringify({
+        id: 'child-1',
+        url: 'https://notion.so/child-1',
+        last_edited_time: '2026-05-10T15:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Child' }] },
+        },
+        parent: { type: 'page_id', page_id: 'root' },
+      })
+      const childChildren = JSON.stringify({
+        results: [
+          {
+            id: 'grandchild-1',
+            type: 'child_page',
+            has_children: false,
+          },
+        ],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: rootPage },
+        { status: 200, body: md },
+        { status: 200, body: children },
+        { status: 200, body: childPage },
+        { status: 200, body: md },
+        { status: 200, body: childChildren },
+        // grandchild would be depth 2, maxDepth=1 stops it.
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['root'],
+        maxDepth: 1,
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(2) // root + child, no grandchild
+    })
+
+    it('detects cycles and prevents infinite loops', async () => {
+      const pageA = JSON.stringify({
+        id: 'page-a',
+        url: 'https://notion.so/page-a',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'A' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const md = JSON.stringify({ markdown: 'content' })
+      const childrenA = JSON.stringify({
+        results: [
+          { id: 'page-b', type: 'child_page', has_children: false },
+        ],
+        has_more: false,
+      })
+      const pageB = JSON.stringify({
+        id: 'page-b',
+        url: 'https://notion.so/page-b',
+        last_edited_time: '2026-05-10T15:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'B' }] },
+        },
+        parent: { type: 'page_id', page_id: 'page-a' },
+      })
+      const childrenB = JSON.stringify({
+        results: [
+          { id: 'page-a', type: 'child_page', has_children: false },
+        ],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageA },
+        { status: 200, body: md },
+        { status: 200, body: childrenA },
+        { status: 200, body: pageB },
+        { status: 200, body: md },
+        { status: 200, body: childrenB },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['page-a'],
+        includeChildPages: true,
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(2) // A and B, no cycle
+    })
+
+    it('handles rate limit 429 responses', async () => {
+      const { fetcher } = createMockFetcher([
+        { status: 429, body: '{"message": "rate limited"}' },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['page-rl'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      // The fetch should not throw but skip the page due to the error.
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(0) // Page skipped due to error
+    })
+
+    it('returns no documents for empty workspace', async () => {
+      const searchResp = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: searchResp },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({ apiToken: 'secret_test' })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(0)
+    })
+
+    it('discovers pages via workspace search', async () => {
+      const searchResp = JSON.stringify({
+        results: [
+          {
+            id: 'ws-page-1',
+            object: 'page',
+            last_edited_time: '2026-05-10T14:00:00.000Z',
+          },
+        ],
+        has_more: false,
+      })
+      const pageResp = JSON.stringify({
+        id: 'ws-page-1',
+        url: 'https://notion.so/ws-page-1',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: {
+            type: 'title',
+            title: [{ plain_text: 'WS Page' }],
+          },
+        },
+        parent: { type: 'workspace' },
+      })
+      const md = JSON.stringify({ markdown: 'workspace content' })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: searchResp },
+        { status: 200, body: pageResp },
+        { status: 200, body: md },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({ apiToken: 'secret_test' })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs).toHaveLength(1)
+      expect(docs[0].title).toBe('WS Page')
+    })
+  })
+
+  describe('fetchSince', () => {
+    it('passes filter for incremental sync', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'recent',
+            url: 'https://notion.so/recent',
+            last_edited_time: '2026-05-15T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Recent' }],
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const entryMD = JSON.stringify({ markdown: 'updated' })
+
+      const { fetcher, calls } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: entryMD },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-inc'],
+      })
+
+      const cursor = {
+        value: '2026-05-01T00:00:00.000Z',
+        updatedAt: new Date(),
+      }
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchSince(signal, cursor))
+
+      expect(docs).toHaveLength(1)
+      // Verify the filter was sent.
+      const dbCall = calls[0]
+      expect(dbCall.body).toContain('on_or_after')
+    })
+
+    it('tracks modified time for cursor updates', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'e1',
+            url: 'https://notion.so/e1',
+            last_edited_time: '2026-05-15T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'E1' }],
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: 'content' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-cursor'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(docs[0].modifiedAt).toEqual(
+        new Date('2026-05-15T10:00:00.000Z'),
+      )
+    })
+  })
+
+  describe('stop', () => {
+    it('does not throw when called before start', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await expect(conn.stop()).resolves.toBeUndefined()
+    })
+
+    it('can be called multiple times safely', async () => {
+      const { fetcher } = createMockFetcher([])
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.stop()
+      await conn.stop()
+    })
+  })
+
+  describe('property extraction', () => {
+    it('handles select properties in database entries', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'sel-1',
+            url: 'https://notion.so/sel-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Select Test' }],
+              },
+              Priority: {
+                type: 'select',
+                select: { name: 'High' },
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: '' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-sel'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(String(docs[0].content)).toContain('High')
+    })
+
+    it('handles multi_select properties', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'ms-1',
+            url: 'https://notion.so/ms-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Tags Test' }],
+              },
+              Tags: {
+                type: 'multi_select',
+                multi_select: [{ name: 'Tag1' }, { name: 'Tag2' }],
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: '' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-ms'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(String(docs[0].content)).toContain('Tag1, Tag2')
+    })
+
+    it('handles date range properties', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'dt-1',
+            url: 'https://notion.so/dt-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Date Test' }],
+              },
+              Dates: {
+                type: 'date',
+                date: { start: '2026-05-01', end: '2026-05-15' },
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: '' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-dt'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(String(docs[0].content)).toContain('2026-05-01 to 2026-05-15')
+    })
+
+    it('handles checkbox properties', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'cb-1',
+            url: 'https://notion.so/cb-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Checkbox Test' }],
+              },
+              Done: {
+                type: 'checkbox',
+                checkbox: true,
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: '' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-cb'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      expect(String(docs[0].content)).toContain('true')
+    })
+
+    it('handles null select property', async () => {
+      const dbResp = JSON.stringify({
+        results: [
+          {
+            id: 'ns-1',
+            url: 'https://notion.so/ns-1',
+            last_edited_time: '2026-05-10T10:00:00.000Z',
+            properties: {
+              Name: {
+                type: 'title',
+                title: [{ plain_text: 'Null Select' }],
+              },
+              Category: {
+                type: 'select',
+                select: null,
+              },
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const md = JSON.stringify({ markdown: '' })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: dbResp },
+        { status: 200, body: md },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        databaseIds: ['db-ns'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      // Null select should not appear in property listing.
+      expect(String(docs[0].content)).not.toContain('Category')
+    })
+  })
+
+  describe('block rendering', () => {
+    it('renders code blocks with language', async () => {
+      const pageResp = JSON.stringify({
+        id: 'code-page',
+        url: 'https://notion.so/code-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Code' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'code-1',
+            type: 'code',
+            has_children: false,
+            code: {
+              rich_text: [
+                { type: 'text', plain_text: 'const x = 1' },
+              ],
+              language: 'typescript',
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' }, // markdown API not available
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['code-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      const content = String(docs[0].content)
+      expect(content).toContain('```typescript')
+      expect(content).toContain('const x = 1')
+    })
+
+    it('renders rich text with formatting', async () => {
+      const pageResp = JSON.stringify({
+        id: 'rt-page',
+        url: 'https://notion.so/rt-page',
+        last_edited_time: '2026-05-10T14:00:00.000Z',
+        properties: {
+          Title: { type: 'title', title: [{ plain_text: 'Rich' }] },
+        },
+        parent: { type: 'workspace' },
+      })
+      const blocksResp = JSON.stringify({
+        results: [
+          {
+            id: 'rt-1',
+            type: 'paragraph',
+            has_children: false,
+            paragraph: {
+              rich_text: [
+                {
+                  type: 'text',
+                  plain_text: 'bold',
+                  annotations: { bold: true },
+                },
+                { type: 'text', plain_text: ' and ' },
+                {
+                  type: 'text',
+                  plain_text: 'italic',
+                  annotations: { italic: true },
+                },
+              ],
+            },
+          },
+        ],
+        has_more: false,
+      })
+      const childBlocks = JSON.stringify({
+        results: [],
+        has_more: false,
+      })
+
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: pageResp },
+        { status: 404, body: '{}' },
+        { status: 200, body: blocksResp },
+        { status: 200, body: childBlocks },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['rt-page'],
+      })
+
+      const signal = AbortSignal.timeout(5000)
+      const docs = await collectDocs(conn.fetchAll(signal))
+      const content = String(docs[0].content)
+      expect(content).toContain('**bold**')
+      expect(content).toContain('*italic*')
+    })
+  })
+
+  describe('context cancellation', () => {
+    it('does not hang when signal is already aborted', async () => {
+      const { fetcher } = createMockFetcher([
+        { status: 200, body: JSON.stringify({
+          id: 'p1',
+          url: 'https://notion.so/p1',
+          last_edited_time: '2026-05-10T14:00:00.000Z',
+          properties: {
+            Title: { type: 'title', title: [{ plain_text: 'T' }] },
+          },
+          parent: { type: 'workspace' },
+        }) },
+        { status: 200, body: JSON.stringify({ markdown: 'content' }) },
+        { status: 200, body: JSON.stringify({ results: [], has_more: false }) },
+      ])
+
+      const conn = createNotionConnector(testDeps(), { fetcher })
+      await conn.configure({
+        apiToken: 'secret_test',
+        rootPageIds: ['p1'],
+      })
+
+      const controller = new AbortController()
+      controller.abort()
+
+      // Should not hang; may throw or return empty.
+      try {
+        const docs = await collectDocs(conn.fetchAll(controller.signal))
+        expect(docs.length).toBeLessThanOrEqual(1)
+      } catch {
+        // Expected when signal is aborted.
+      }
+    })
+  })
+})

--- a/sdks/ts/memory/src/connector/notion.ts
+++ b/sdks/ts/memory/src/connector/notion.ts
@@ -1,0 +1,920 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Notion connector for syncing pages and databases into a brain.
+ * Uses Notion's native Markdown API (February 2026) for page content
+ * retrieval, with fallback to block-by-block reconstruction.
+ * Supports incremental sync via last_edited_time filtering.
+ */
+
+import type {
+  Connector,
+  ConnectorConfig,
+  ConnectorDocument,
+  RateLimiter,
+  SyncCursor,
+} from './types.js'
+
+// ---------- Constants ----------
+
+const NOTION_API_VERSION = '2022-06-28'
+const NOTION_DEFAULT_BASE_URL = 'https://api.notion.com/v1'
+const NOTION_DEFAULT_MAX_DEPTH = 10
+const NOTION_DEFAULT_POLL_INTERVAL = 15 * 60 * 1000
+const NOTION_DEFAULT_TIMEOUT = 30_000
+const NOTION_DEFAULT_PAGE_SIZE = 100
+
+// ---------- Types ----------
+
+/**
+ * Notion-specific connector configuration.
+ */
+export type NotionConnectorConfig = {
+  readonly apiToken: string
+  readonly rootPageIds?: readonly string[] | undefined
+  readonly databaseIds?: readonly string[] | undefined
+  readonly includeChildPages?: boolean | undefined // default: true
+  readonly includeDatabases?: boolean | undefined // default: true
+  readonly maxDepth?: number | undefined // default: 10
+}
+
+/**
+ * Notion rich text object.
+ */
+type NotionRichText = {
+  readonly type: string
+  readonly plain_text: string
+  readonly href?: string
+  readonly annotations?: NotionAnnotations
+}
+
+/**
+ * Notion text formatting annotations.
+ */
+type NotionAnnotations = {
+  readonly bold?: boolean
+  readonly italic?: boolean
+  readonly strikethrough?: boolean
+  readonly underline?: boolean
+  readonly code?: boolean
+  readonly color?: string
+}
+
+/**
+ * Notion block object from the blocks API.
+ */
+type NotionBlock = {
+  readonly id: string
+  readonly type: string
+  readonly has_children: boolean
+  readonly [key: string]: unknown
+}
+
+/**
+ * Notion search/database query response shape.
+ */
+type NotionPaginatedResponse = {
+  readonly results: readonly Record<string, unknown>[]
+  readonly next_cursor: string | null
+  readonly has_more: boolean
+}
+
+/**
+ * Parsed page metadata.
+ */
+type ParsedPage = {
+  readonly id: string
+  readonly title: string
+  readonly url: string
+  readonly lastEditedTime: Date
+}
+
+/**
+ * Parsed database entry.
+ */
+type ParsedDatabaseEntry = {
+  readonly pageId: string
+  readonly title: string
+  readonly url: string
+  readonly lastEditedTime: Date
+  readonly propertiesMarkdown: string
+}
+
+/**
+ * HTTP fetcher interface for dependency injection in tests.
+ */
+export type NotionHTTPFetcher = (
+  url: string,
+  options: RequestInit,
+) => Promise<Response>
+
+/**
+ * Options for creating a Notion connector.
+ */
+export type NotionConnectorOptions = {
+  readonly baseUrl?: string
+  readonly fetcher?: NotionHTTPFetcher
+}
+
+// ---------- Implementation ----------
+
+/**
+ * Creates a Notion connector that implements the Connector interface.
+ */
+export const createNotionConnector = (
+  deps: ConnectorConfig,
+  options?: NotionConnectorOptions,
+): Connector & { readonly name: 'notion' } => {
+  let config: NotionConnectorConfig | undefined
+  let abortController: AbortController | undefined
+  const baseUrl = options?.baseUrl ?? NOTION_DEFAULT_BASE_URL
+  const fetcher: NotionHTTPFetcher = options?.fetcher ?? globalFetch
+  const rateLimiter: RateLimiter | undefined = deps.rateLimiter
+
+  const ensureConfigured = (): NotionConnectorConfig => {
+    if (config === undefined) {
+      throw new Error('connector/notion: not configured, call configure first')
+    }
+    return config
+  }
+
+  const acquireRateLimit = async (signal: AbortSignal): Promise<void> => {
+    if (rateLimiter !== undefined) {
+      await rateLimiter.acquire(signal, 1)
+    }
+  }
+
+  const doRequest = async (
+    signal: AbortSignal,
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<unknown> => {
+    const cfg = ensureConfigured()
+
+    await acquireRateLimit(signal)
+
+    const timeoutController = new AbortController()
+    const timeoutId = setTimeout(
+      () => timeoutController.abort(new Error('request timeout')),
+      NOTION_DEFAULT_TIMEOUT,
+    )
+
+    const combinedSignal = combineSignals(signal, timeoutController.signal)
+
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${cfg.apiToken}`,
+        'Notion-Version': NOTION_API_VERSION,
+      }
+
+      const init: RequestInit = {
+        method,
+        headers,
+        signal: combinedSignal,
+      }
+
+      if (body !== undefined) {
+        headers['Content-Type'] = 'application/json'
+        init.body = JSON.stringify(body)
+      }
+
+      const response = await fetcher(`${baseUrl}${path}`, init)
+
+      if (response.status === 429) {
+        throw new Error('connector/notion: rate limited (429)')
+      }
+
+      if (response.status === 404) {
+        throw new Error('connector/notion: not found (404)')
+      }
+
+      if (response.status < 200 || response.status >= 300) {
+        const text = await response.text()
+        throw new Error(
+          `connector/notion: HTTP ${String(response.status)}: ${text}`,
+        )
+      }
+
+      return (await response.json()) as unknown
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+
+  // ---------- Page fetching ----------
+
+  const parsePageResponse = (data: Record<string, unknown>): ParsedPage => {
+    const properties = (data.properties ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >
+    const title = extractTitleFromProperties(properties)
+    const lastEditedStr = data.last_edited_time as string
+    const lastEditedTime = new Date(lastEditedStr)
+
+    return {
+      id: data.id as string,
+      title,
+      url: data.url as string,
+      lastEditedTime,
+    }
+  }
+
+  const fetchPageContent = async (
+    signal: AbortSignal,
+    pageId: string,
+    maxDepth: number,
+  ): Promise<string> => {
+    // Try Markdown API first.
+    try {
+      const mdResp = (await doRequest(
+        signal,
+        'GET',
+        `/pages/${pageId}/markdown`,
+      )) as { markdown?: string }
+      if (mdResp.markdown !== undefined) {
+        return mdResp.markdown
+      }
+    } catch {
+      // Fall back to block retrieval.
+    }
+
+    return fetchBlocksAsMarkdown(signal, pageId, 0, maxDepth)
+  }
+
+  const fetchBlocksAsMarkdown = async (
+    signal: AbortSignal,
+    blockId: string,
+    depth: number,
+    maxDepth: number,
+  ): Promise<string> => {
+    if (depth > maxDepth) return ''
+
+    const allBlocks: NotionBlock[] = []
+    let cursor: string | undefined
+
+    while (!signal.aborted) {
+      let endpoint = `/blocks/${blockId}/children?page_size=${String(NOTION_DEFAULT_PAGE_SIZE)}`
+      if (cursor !== undefined) {
+        endpoint += `&start_cursor=${cursor}`
+      }
+
+      const resp = (await doRequest(
+        signal,
+        'GET',
+        endpoint,
+      )) as NotionPaginatedResponse
+      for (const result of resp.results) {
+        allBlocks.push(result as unknown as NotionBlock)
+      }
+
+      if (!resp.has_more || resp.next_cursor === null) break
+      cursor = resp.next_cursor
+    }
+
+    const parts: string[] = []
+
+    for (const block of allBlocks) {
+      const md = blockToMarkdown(block)
+      if (md !== '') {
+        parts.push(md)
+      }
+
+      if (block.has_children) {
+        const childContent = await fetchBlocksAsMarkdown(
+          signal,
+          block.id,
+          depth + 1,
+          maxDepth,
+        )
+        if (childContent !== '') {
+          const lines = childContent.split('\n')
+          const prefix = isListBlock(block.type) ? '  ' : ''
+          for (const line of lines) {
+            parts.push(`${prefix}${line}`)
+          }
+        }
+      }
+    }
+
+    return parts.join('\n')
+  }
+
+  const fetchChildPageIds = async (
+    signal: AbortSignal,
+    blockId: string,
+  ): Promise<readonly string[]> => {
+    const childIds: string[] = []
+    let cursor: string | undefined
+
+    while (!signal.aborted) {
+      let endpoint = `/blocks/${blockId}/children?page_size=${String(NOTION_DEFAULT_PAGE_SIZE)}`
+      if (cursor !== undefined) {
+        endpoint += `&start_cursor=${cursor}`
+      }
+
+      const resp = (await doRequest(
+        signal,
+        'GET',
+        endpoint,
+      )) as NotionPaginatedResponse
+
+      for (const result of resp.results) {
+        const block = result as unknown as NotionBlock
+        if (block.type === 'child_page' || block.type === 'child_database') {
+          childIds.push(block.id)
+        }
+      }
+
+      if (!resp.has_more || resp.next_cursor === null) break
+      cursor = resp.next_cursor
+    }
+
+    return childIds
+  }
+
+  // ---------- Page tree traversal ----------
+
+  async function* fetchPageTree(
+    signal: AbortSignal,
+    pageId: string,
+    depth: number,
+    sinceISO: string | undefined,
+    visited: Set<string>,
+    cfg: NotionConnectorConfig,
+  ): AsyncGenerator<ConnectorDocument> {
+    if (depth > (cfg.maxDepth ?? NOTION_DEFAULT_MAX_DEPTH)) return
+    if (visited.has(pageId)) return
+    visited.add(pageId)
+
+    let pageData: Record<string, unknown>
+    try {
+      pageData = (await doRequest(
+        signal,
+        'GET',
+        `/pages/${pageId}`,
+      )) as Record<string, unknown>
+    } catch (err) {
+      return
+    }
+
+    const page = parsePageResponse(pageData)
+
+    // For incremental sync, skip pages older than cursor.
+    if (sinceISO !== undefined) {
+      const cursorTime = new Date(sinceISO)
+      if (page.lastEditedTime < cursorTime) return
+    }
+
+    const content = await fetchPageContent(
+      signal,
+      pageId,
+      cfg.maxDepth ?? NOTION_DEFAULT_MAX_DEPTH,
+    )
+
+    yield {
+      externalId: pageId,
+      content,
+      mime: 'text/markdown',
+      title: page.title,
+      url: page.url,
+      metadata: {
+        source: 'notion',
+        type: 'page',
+        last_edited_time: page.lastEditedTime.toISOString(),
+      },
+      modifiedAt: page.lastEditedTime,
+    }
+
+    // Recursively fetch child pages.
+    if (cfg.includeChildPages !== false) {
+      const childIds = await fetchChildPageIds(signal, pageId)
+      for (const childId of childIds) {
+        yield* fetchPageTree(signal, childId, depth + 1, sinceISO, visited, cfg)
+      }
+    }
+  }
+
+  // ---------- Database fetching ----------
+
+  async function* fetchDatabaseEntries(
+    signal: AbortSignal,
+    dbId: string,
+    sinceISO: string | undefined,
+    visited: Set<string>,
+    cfg: NotionConnectorConfig,
+  ): AsyncGenerator<ConnectorDocument> {
+    let cursor: string | undefined
+
+    while (!signal.aborted) {
+      const body: Record<string, unknown> = {
+        page_size: NOTION_DEFAULT_PAGE_SIZE,
+      }
+      if (cursor !== undefined) {
+        body.start_cursor = cursor
+      }
+      if (sinceISO !== undefined) {
+        body.filter = {
+          timestamp: 'last_edited_time',
+          last_edited_time: { on_or_after: sinceISO },
+        }
+      }
+
+      const resp = (await doRequest(
+        signal,
+        'POST',
+        `/databases/${dbId}/query`,
+        body,
+      )) as NotionPaginatedResponse
+
+      for (const result of resp.results) {
+        const entry = parseDatabaseEntry(result)
+        if (visited.has(entry.pageId)) continue
+        visited.add(entry.pageId)
+
+        let pageContent = ''
+        try {
+          const content = await fetchPageContent(
+            signal,
+            entry.pageId,
+            cfg.maxDepth ?? NOTION_DEFAULT_MAX_DEPTH,
+          )
+          if (content !== '') {
+            pageContent = `\n\n${content}`
+          }
+        } catch {
+          // Page content fetch is optional; proceed without it.
+        }
+
+        yield {
+          externalId: entry.pageId,
+          content: entry.propertiesMarkdown + pageContent,
+          mime: 'text/markdown',
+          title: entry.title,
+          url: entry.url,
+          metadata: {
+            source: 'notion',
+            type: 'database_entry',
+            database_id: dbId,
+            last_edited_time: entry.lastEditedTime.toISOString(),
+          },
+          modifiedAt: entry.lastEditedTime,
+        }
+      }
+
+      if (!resp.has_more || resp.next_cursor === null) break
+      cursor = resp.next_cursor
+    }
+  }
+
+  // ---------- Workspace search ----------
+
+  async function* searchWorkspace(
+    signal: AbortSignal,
+    sinceISO: string | undefined,
+    visited: Set<string>,
+    cfg: NotionConnectorConfig,
+  ): AsyncGenerator<ConnectorDocument> {
+    let cursor: string | undefined
+
+    while (!signal.aborted) {
+      const body: Record<string, unknown> = {
+        page_size: NOTION_DEFAULT_PAGE_SIZE,
+      }
+      if (sinceISO !== undefined) {
+        body.sort = {
+          direction: 'descending',
+          timestamp: 'last_edited_time',
+        }
+      }
+      if (cursor !== undefined) {
+        body.start_cursor = cursor
+      }
+
+      const resp = (await doRequest(
+        signal,
+        'POST',
+        '/search',
+        body,
+      )) as NotionPaginatedResponse
+
+      for (const result of resp.results) {
+        const objectType = result.object as string
+        const id = result.id as string
+        const lastEditedStr = result.last_edited_time as string
+
+        // For incremental sync with descending sort, stop when we
+        // pass the cursor boundary.
+        if (sinceISO !== undefined && lastEditedStr !== undefined) {
+          const editedTime = new Date(lastEditedStr)
+          const cursorTime = new Date(sinceISO)
+          if (editedTime < cursorTime) return
+        }
+
+        if (objectType === 'page') {
+          yield* fetchPageTree(signal, id, 0, sinceISO, visited, cfg)
+        } else if (objectType === 'database' && cfg.includeDatabases !== false) {
+          yield* fetchDatabaseEntries(signal, id, sinceISO, visited, cfg)
+        }
+      }
+
+      if (!resp.has_more || resp.next_cursor === null) break
+      cursor = resp.next_cursor
+    }
+  }
+
+  // ---------- Sync orchestrator ----------
+
+  async function* syncPages(
+    signal: AbortSignal,
+    sinceISO: string | undefined,
+  ): AsyncGenerator<ConnectorDocument> {
+    const cfg = ensureConfigured()
+    const visited = new Set<string>()
+
+    // Fetch specific root pages.
+    const rootPageIds = cfg.rootPageIds ?? []
+    for (const pageId of rootPageIds) {
+      yield* fetchPageTree(signal, pageId, 0, sinceISO, visited, cfg)
+    }
+
+    // Fetch specific databases.
+    if (cfg.includeDatabases !== false) {
+      const databaseIds = cfg.databaseIds ?? []
+      for (const dbId of databaseIds) {
+        yield* fetchDatabaseEntries(signal, dbId, sinceISO, visited, cfg)
+      }
+    }
+
+    // If no specific targets, search entire workspace.
+    if (rootPageIds.length === 0 && (cfg.databaseIds ?? []).length === 0) {
+      yield* searchWorkspace(signal, sinceISO, visited, cfg)
+    }
+  }
+
+  // ---------- Connector interface ----------
+
+  return {
+    name: 'notion' as const,
+
+    async configure(rawConfig: Record<string, unknown>): Promise<void> {
+      const token = rawConfig.apiToken as string | undefined
+      if (token === undefined || token.trim() === '') {
+        throw new Error('connector/notion: apiToken is required')
+      }
+
+      config = {
+        apiToken: token,
+        rootPageIds: parseStringArray(rawConfig.rootPageIds),
+        databaseIds: parseStringArray(rawConfig.databaseIds),
+        includeChildPages: (rawConfig.includeChildPages as boolean) ?? true,
+        includeDatabases: (rawConfig.includeDatabases as boolean) ?? true,
+        maxDepth: (rawConfig.maxDepth as number) ?? NOTION_DEFAULT_MAX_DEPTH,
+      }
+    },
+
+    async *fetchAll(signal: AbortSignal): AsyncIterable<ConnectorDocument> {
+      yield* syncPages(signal, undefined)
+    },
+
+    async *fetchSince(
+      signal: AbortSignal,
+      cursor: SyncCursor,
+    ): AsyncIterable<ConnectorDocument> {
+      yield* syncPages(signal, cursor.value)
+    },
+
+    async start(signal: AbortSignal): Promise<void> {
+      ensureConfigured()
+      abortController = new AbortController()
+
+      const interval = deps.pollInterval ?? NOTION_DEFAULT_POLL_INTERVAL
+
+      while (!signal.aborted && !abortController.signal.aborted) {
+        const combinedSignal = combineSignals(
+          signal,
+          abortController.signal,
+        )
+        for await (const _doc of syncPages(combinedSignal, undefined)) {
+          // Documents consumed by the sync loop.
+        }
+
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(resolve, interval)
+          const onAbort = (): void => {
+            clearTimeout(timer)
+            resolve()
+          }
+          signal.addEventListener('abort', onAbort, { once: true })
+          abortController?.signal.addEventListener('abort', onAbort, {
+            once: true,
+          })
+        })
+      }
+    },
+
+    async stop(): Promise<void> {
+      abortController?.abort()
+    },
+  }
+}
+
+// ---------- Helper functions ----------
+
+/**
+ * Renders a Notion rich text array to markdown with formatting.
+ */
+const renderRichText = (texts: readonly NotionRichText[]): string => {
+  const parts: string[] = []
+
+  for (const t of texts) {
+    let text = t.plain_text
+
+    if (t.annotations?.code === true) {
+      text = '`' + text + '`'
+    }
+    if (t.annotations?.bold === true) {
+      text = '**' + text + '**'
+    }
+    if (t.annotations?.italic === true) {
+      text = '*' + text + '*'
+    }
+    if (t.annotations?.strikethrough === true) {
+      text = '~~' + text + '~~'
+    }
+
+    if (t.href !== undefined && t.href !== '') {
+      text = `[${text}](${t.href})`
+    }
+
+    parts.push(text)
+  }
+
+  return parts.join('')
+}
+
+/**
+ * Extracts plain text from rich text without formatting.
+ */
+const renderPlainRichText = (texts: readonly NotionRichText[]): string =>
+  texts.map((t) => t.plain_text).join('')
+
+/**
+ * Converts a single Notion block to markdown.
+ */
+const blockToMarkdown = (block: NotionBlock): string => {
+  const blockData = block[block.type] as Record<string, unknown> | undefined
+  if (blockData === undefined) return ''
+
+  const richText = (blockData.rich_text ?? []) as readonly NotionRichText[]
+  const text = renderRichText(richText)
+  const caption = (blockData.caption ?? []) as readonly NotionRichText[]
+
+  const renderers: Readonly<Record<string, () => string>> = {
+    paragraph: () => `${text}\n`,
+    heading_1: () => `# ${text}\n`,
+    heading_2: () => `## ${text}\n`,
+    heading_3: () => `### ${text}\n`,
+    bulleted_list_item: () => `- ${text}`,
+    numbered_list_item: () => `1. ${text}`,
+    to_do: () => {
+      const checked = blockData.checked === true
+      const marker = checked ? '[x]' : '[ ]'
+      return `- ${marker} ${text}`
+    },
+    toggle: () => `- ${text}`,
+    quote: () => `> ${text}\n`,
+    callout: () => `> ${text}\n`,
+    divider: () => '---\n',
+    code: () => {
+      const lang = (blockData.language as string) ?? ''
+      return '```' + lang + '\n' + text + '\n```\n'
+    },
+    equation: () => {
+      const expression = (blockData.expression as string) ?? ''
+      return `$$\n${expression}\n$$\n`
+    },
+    image: () => {
+      const capText = renderRichText(caption)
+      const url = extractFileUrl(blockData)
+      return capText !== ''
+        ? `![${capText}](${url})\n`
+        : `![](${url})\n`
+    },
+    file: () => {
+      const url = extractFileUrl(blockData)
+      const capText = renderRichText(caption)
+      const label = capText !== '' ? capText : 'file'
+      return `[${label}](${url})\n`
+    },
+    bookmark: () => {
+      const capText = renderRichText(caption)
+      const url = blockData.url as string | undefined
+      if (url !== undefined) {
+        return capText !== '' ? `[${capText}](${url})\n` : `${url}\n`
+      }
+      return ''
+    },
+    embed: () => {
+      const url = blockData.url as string | undefined
+      return url !== undefined ? `${url}\n` : ''
+    },
+    table_of_contents: () => '',
+    breadcrumb: () => '',
+    column_list: () => '',
+    column: () => '',
+    child_page: () => '',
+    child_database: () => '',
+    synced_block: () => '',
+    link_preview: () => {
+      const url = blockData.url as string | undefined
+      return url !== undefined ? `${url}\n` : ''
+    },
+    table: () => '',
+    table_row: () => {
+      const cells = (blockData.cells ?? []) as readonly (readonly NotionRichText[])[]
+      const rendered = cells.map((cell) => renderRichText(cell))
+      return `| ${rendered.join(' | ')} |`
+    },
+  }
+
+  const renderer = renderers[block.type]
+  return renderer !== undefined ? renderer() : text
+}
+
+/**
+ * Extracts the title from a page's properties map.
+ */
+const extractTitleFromProperties = (
+  properties: Record<string, Record<string, unknown>>,
+): string => {
+  for (const prop of Object.values(properties)) {
+    if (prop.type === 'title') {
+      const titleArr = (prop.title ?? []) as readonly NotionRichText[]
+      return renderPlainRichText(titleArr)
+    }
+  }
+  return ''
+}
+
+/**
+ * Converts a Notion property to its string representation.
+ */
+const extractPropertyValue = (
+  prop: Record<string, unknown>,
+): string => {
+  const propType = prop.type as string
+
+  const renderers: Readonly<Record<string, () => string>> = {
+    title: () =>
+      renderPlainRichText((prop.title ?? []) as readonly NotionRichText[]),
+    rich_text: () =>
+      renderPlainRichText(
+        (prop.rich_text ?? []) as readonly NotionRichText[],
+      ),
+    number: () => {
+      const num = prop.number as number | null
+      return num !== null && num !== undefined ? String(num) : ''
+    },
+    select: () => {
+      const sel = prop.select as { name: string } | null
+      return sel?.name ?? ''
+    },
+    multi_select: () => {
+      const items = (prop.multi_select ?? []) as readonly { name: string }[]
+      return items.map((i) => i.name).join(', ')
+    },
+    date: () => {
+      const d = prop.date as { start: string; end?: string } | null
+      if (d === null || d === undefined) return ''
+      return d.end !== undefined && d.end !== ''
+        ? `${d.start} to ${d.end}`
+        : d.start
+    },
+    checkbox: () => (prop.checkbox === true ? 'true' : 'false'),
+    url: () => (prop.url as string) ?? '',
+    email: () => (prop.email as string) ?? '',
+    phone_number: () => (prop.phone_number as string) ?? '',
+    status: () => {
+      const st = prop.status as { name: string } | null
+      return st?.name ?? ''
+    },
+    people: () => {
+      const people = (prop.people ?? []) as readonly { name: string }[]
+      return people.map((p) => p.name).join(', ')
+    },
+    relation: () => {
+      const rels = (prop.relation ?? []) as readonly { id: string }[]
+      return rels.map((r) => r.id).join(', ')
+    },
+  }
+
+  const renderer = renderers[propType]
+  return renderer !== undefined ? renderer() : ''
+}
+
+/**
+ * Parses a database entry from the query response.
+ */
+const parseDatabaseEntry = (
+  raw: Record<string, unknown>,
+): ParsedDatabaseEntry => {
+  const properties = (raw.properties ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >
+  const lastEditedStr = raw.last_edited_time as string
+  const lastEditedTime = new Date(lastEditedStr)
+
+  let title = ''
+  const propLines: string[] = []
+
+  // Sort keys for deterministic output.
+  const sortedKeys = Object.keys(properties).sort()
+
+  for (const key of sortedKeys) {
+    const prop = properties[key]
+    if (prop === undefined) continue
+    const val = extractPropertyValue(prop)
+
+    if (prop.type === 'title') {
+      title = val
+      continue
+    }
+
+    if (val !== '') {
+      propLines.push(`- **${key}**: ${val}`)
+    }
+  }
+
+  let markdown = ''
+  if (title !== '') {
+    markdown += `## ${title}\n\n`
+  }
+  if (propLines.length > 0) {
+    markdown += propLines.join('\n') + '\n'
+  }
+
+  return {
+    pageId: raw.id as string,
+    title,
+    url: raw.url as string,
+    lastEditedTime,
+    propertiesMarkdown: markdown,
+  }
+}
+
+/**
+ * Extracts a file URL from a file-type block's data.
+ */
+const extractFileUrl = (data: Record<string, unknown>): string => {
+  const file = data.file as { url?: string } | undefined
+  const external = data.external as { url?: string } | undefined
+  return file?.url ?? external?.url ?? ''
+}
+
+/**
+ * Checks whether a block type is a list item.
+ */
+const isListBlock = (blockType: string): boolean => {
+  const listTypes = new Set([
+    'bulleted_list_item',
+    'numbered_list_item',
+    'to_do',
+    'toggle',
+  ])
+  return listTypes.has(blockType)
+}
+
+/**
+ * Parses a value that might be a string array or undefined.
+ */
+const parseStringArray = (
+  value: unknown,
+): readonly string[] | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string')
+  }
+  return undefined
+}
+
+/**
+ * Combines two abort signals into one that fires when either fires.
+ */
+const combineSignals = (a: AbortSignal, b: AbortSignal): AbortSignal => {
+  if (a.aborted) return a
+  if (b.aborted) return b
+
+  const controller = new AbortController()
+  const onAbort = (): void => controller.abort()
+  a.addEventListener('abort', onAbort, { once: true })
+  b.addEventListener('abort', onAbort, { once: true })
+  return controller.signal
+}
+
+/**
+ * Global fetch wrapper for the default HTTP fetcher.
+ */
+const globalFetch: NotionHTTPFetcher = (url, options) => fetch(url, options)

--- a/sdks/ts/memory/src/connector/notion.ts
+++ b/sdks/ts/memory/src/connector/notion.ts
@@ -11,9 +11,33 @@ import type {
   Connector,
   ConnectorConfig,
   ConnectorDocument,
-  RateLimiter,
   SyncCursor,
 } from './types.js'
+import { RateLimiter } from './types.js'
+import {
+  blockToMarkdown,
+  isListBlock,
+  type NotionBlock,
+} from './notion-blocks.js'
+import {
+  parseDatabaseEntry,
+  parsePageResponse,
+} from './notion-properties.js'
+import {
+  combineSignals,
+  globalFetch,
+  interruptibleSleep,
+  parseBlockTypeFilter,
+  parseRetryAfterHeader,
+  parseStringArray,
+  readResponseWithLimit,
+  type NotionHTTPFetcher,
+} from './notion-utils.js'
+
+// Re-export types that consumers may need.
+export type { NotionBlock } from './notion-blocks.js'
+export type { NotionRichText } from './notion-blocks.js'
+export type { NotionHTTPFetcher } from './notion-utils.js'
 
 // ---------- Constants ----------
 
@@ -23,6 +47,9 @@ const NOTION_DEFAULT_MAX_DEPTH = 10
 const NOTION_DEFAULT_POLL_INTERVAL = 15 * 60 * 1000
 const NOTION_DEFAULT_TIMEOUT = 30_000
 const NOTION_DEFAULT_PAGE_SIZE = 100
+const NOTION_DEFAULT_RATE_LIMIT = 3
+const NOTION_MAX_RETRY_ATTEMPTS = 5
+const NOTION_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 
 // ---------- Types ----------
 
@@ -36,38 +63,7 @@ export type NotionConnectorConfig = {
   readonly includeChildPages?: boolean | undefined // default: true
   readonly includeDatabases?: boolean | undefined // default: true
   readonly maxDepth?: number | undefined // default: 10
-}
-
-/**
- * Notion rich text object.
- */
-type NotionRichText = {
-  readonly type: string
-  readonly plain_text: string
-  readonly href?: string
-  readonly annotations?: NotionAnnotations
-}
-
-/**
- * Notion text formatting annotations.
- */
-type NotionAnnotations = {
-  readonly bold?: boolean
-  readonly italic?: boolean
-  readonly strikethrough?: boolean
-  readonly underline?: boolean
-  readonly code?: boolean
-  readonly color?: string
-}
-
-/**
- * Notion block object from the blocks API.
- */
-type NotionBlock = {
-  readonly id: string
-  readonly type: string
-  readonly has_children: boolean
-  readonly [key: string]: unknown
+  readonly blockTypeFilter?: ReadonlySet<string> | undefined
 }
 
 /**
@@ -78,35 +74,6 @@ type NotionPaginatedResponse = {
   readonly next_cursor: string | null
   readonly has_more: boolean
 }
-
-/**
- * Parsed page metadata.
- */
-type ParsedPage = {
-  readonly id: string
-  readonly title: string
-  readonly url: string
-  readonly lastEditedTime: Date
-}
-
-/**
- * Parsed database entry.
- */
-type ParsedDatabaseEntry = {
-  readonly pageId: string
-  readonly title: string
-  readonly url: string
-  readonly lastEditedTime: Date
-  readonly propertiesMarkdown: string
-}
-
-/**
- * HTTP fetcher interface for dependency injection in tests.
- */
-export type NotionHTTPFetcher = (
-  url: string,
-  options: RequestInit,
-) => Promise<Response>
 
 /**
  * Options for creating a Notion connector.
@@ -120,6 +87,8 @@ export type NotionConnectorOptions = {
 
 /**
  * Creates a Notion connector that implements the Connector interface.
+ * A default rate limiter of 3 req/sec is created if none is provided
+ * via deps.rateLimiter.
  */
 export const createNotionConnector = (
   deps: ConnectorConfig,
@@ -129,7 +98,10 @@ export const createNotionConnector = (
   let abortController: AbortController | undefined
   const baseUrl = options?.baseUrl ?? NOTION_DEFAULT_BASE_URL
   const fetcher: NotionHTTPFetcher = options?.fetcher ?? globalFetch
-  const rateLimiter: RateLimiter | undefined = deps.rateLimiter
+  const rateLimiter = deps.rateLimiter ?? new RateLimiter({
+    maxTokens: NOTION_DEFAULT_RATE_LIMIT,
+    refillRate: NOTION_DEFAULT_RATE_LIMIT,
+  })
 
   const ensureConfigured = (): NotionConnectorConfig => {
     if (config === undefined) {
@@ -139,20 +111,69 @@ export const createNotionConnector = (
   }
 
   const acquireRateLimit = async (signal: AbortSignal): Promise<void> => {
-    if (rateLimiter !== undefined) {
-      await rateLimiter.acquire(signal, 1)
-    }
+    await rateLimiter.acquire(signal, 1)
   }
 
+  /**
+   * Performs a single HTTP request to the Notion API. Retries on 429
+   * responses using the Retry-After header with exponential backoff.
+   */
   const doRequest = async (
     signal: AbortSignal,
     method: string,
     path: string,
     body?: Record<string, unknown>,
   ): Promise<unknown> => {
-    const cfg = ensureConfigured()
+    for (let attempt = 0; attempt <= NOTION_MAX_RETRY_ATTEMPTS; attempt++) {
+      await acquireRateLimit(signal)
 
-    await acquireRateLimit(signal)
+      const { data, retryAfterSeconds, error } = await doSingleRequest(
+        signal,
+        method,
+        path,
+        body,
+      )
+
+      if (error === undefined) {
+        return data
+      }
+
+      // Only retry on 429.
+      if (retryAfterSeconds === undefined) {
+        throw error
+      }
+
+      if (attempt >= NOTION_MAX_RETRY_ATTEMPTS) {
+        throw error
+      }
+
+      const waitMs = retryAfterSeconds >= 0
+        ? retryAfterSeconds * 1000
+        : rateLimiter.backoffDuration(attempt)
+
+      await interruptibleSleep(signal, waitMs)
+    }
+
+    throw new Error(
+      `connector/notion: exhausted retries for ${method} ${path}`,
+    )
+  }
+
+  /**
+   * Executes a single HTTP request. Returns the parsed body on
+   * success, or an error with optional retryAfterSeconds for 429.
+   */
+  const doSingleRequest = async (
+    signal: AbortSignal,
+    method: string,
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<{
+    data?: unknown
+    retryAfterSeconds?: number
+    error?: Error
+  }> => {
+    const cfg = ensureConfigured()
 
     const timeoutController = new AbortController()
     const timeoutId = setTimeout(
@@ -182,44 +203,79 @@ export const createNotionConnector = (
       const response = await fetcher(`${baseUrl}${path}`, init)
 
       if (response.status === 429) {
-        throw new Error('connector/notion: rate limited (429)')
+        const retryHeader = response.headers.get('Retry-After')
+        const retryAfterSeconds = parseRetryAfterHeader(retryHeader)
+        return {
+          retryAfterSeconds,
+          error: new Error('connector/notion: rate limited (429)'),
+        }
       }
 
       if (response.status === 404) {
-        throw new Error('connector/notion: not found (404)')
+        return {
+          error: new Error('connector/notion: not found (404)'),
+        }
       }
 
       if (response.status < 200 || response.status >= 300) {
         const text = await response.text()
-        throw new Error(
-          `connector/notion: HTTP ${String(response.status)}: ${text}`,
-        )
+        return {
+          error: new Error(
+            `connector/notion: HTTP ${String(response.status)}: ${text}`,
+          ),
+        }
       }
 
-      return (await response.json()) as unknown
+      // Enforce response body size limit (10 MiB).
+      const text = await readResponseWithLimit(response, NOTION_MAX_RESPONSE_BYTES)
+      const data = JSON.parse(text) as unknown
+      return { data }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('connector/notion:')) {
+        return { error: err }
+      }
+      return { error: err instanceof Error ? err : new Error(String(err)) }
     } finally {
       clearTimeout(timeoutId)
     }
   }
 
-  // ---------- Page fetching ----------
+  // ---------- Block children pagination ----------
 
-  const parsePageResponse = (data: Record<string, unknown>): ParsedPage => {
-    const properties = (data.properties ?? {}) as Record<
-      string,
-      Record<string, unknown>
-    >
-    const title = extractTitleFromProperties(properties)
-    const lastEditedStr = data.last_edited_time as string
-    const lastEditedTime = new Date(lastEditedStr)
+  /**
+   * Shared pagination helper for fetching all block children.
+   * Used by both fetchBlocksAsMarkdown and fetchChildPageIds.
+   */
+  const fetchBlockChildren = async (
+    signal: AbortSignal,
+    blockId: string,
+  ): Promise<readonly NotionBlock[]> => {
+    const allBlocks: NotionBlock[] = []
+    let cursor: string | undefined
 
-    return {
-      id: data.id as string,
-      title,
-      url: data.url as string,
-      lastEditedTime,
+    while (!signal.aborted) {
+      let endpoint = `/blocks/${blockId}/children?page_size=${String(NOTION_DEFAULT_PAGE_SIZE)}`
+      if (cursor !== undefined) {
+        endpoint += `&start_cursor=${cursor}`
+      }
+
+      const resp = (await doRequest(
+        signal,
+        'GET',
+        endpoint,
+      )) as NotionPaginatedResponse
+      for (const result of resp.results) {
+        allBlocks.push(result as unknown as NotionBlock)
+      }
+
+      if (!resp.has_more || resp.next_cursor === null) break
+      cursor = resp.next_cursor
     }
+
+    return allBlocks
   }
+
+  // ---------- Page fetching ----------
 
   const fetchPageContent = async (
     signal: AbortSignal,
@@ -251,32 +307,11 @@ export const createNotionConnector = (
   ): Promise<string> => {
     if (depth > maxDepth) return ''
 
-    const allBlocks: NotionBlock[] = []
-    let cursor: string | undefined
-
-    while (!signal.aborted) {
-      let endpoint = `/blocks/${blockId}/children?page_size=${String(NOTION_DEFAULT_PAGE_SIZE)}`
-      if (cursor !== undefined) {
-        endpoint += `&start_cursor=${cursor}`
-      }
-
-      const resp = (await doRequest(
-        signal,
-        'GET',
-        endpoint,
-      )) as NotionPaginatedResponse
-      for (const result of resp.results) {
-        allBlocks.push(result as unknown as NotionBlock)
-      }
-
-      if (!resp.has_more || resp.next_cursor === null) break
-      cursor = resp.next_cursor
-    }
-
+    const allBlocks = await fetchBlockChildren(signal, blockId)
     const parts: string[] = []
 
     for (const block of allBlocks) {
-      const md = blockToMarkdown(block)
+      const md = blockToMarkdown(block, config?.blockTypeFilter)
       if (md !== '') {
         parts.push(md)
       }
@@ -305,32 +340,13 @@ export const createNotionConnector = (
     signal: AbortSignal,
     blockId: string,
   ): Promise<readonly string[]> => {
+    const allBlocks = await fetchBlockChildren(signal, blockId)
     const childIds: string[] = []
-    let cursor: string | undefined
-
-    while (!signal.aborted) {
-      let endpoint = `/blocks/${blockId}/children?page_size=${String(NOTION_DEFAULT_PAGE_SIZE)}`
-      if (cursor !== undefined) {
-        endpoint += `&start_cursor=${cursor}`
+    for (const block of allBlocks) {
+      if (block.type === 'child_page' || block.type === 'child_database') {
+        childIds.push(block.id)
       }
-
-      const resp = (await doRequest(
-        signal,
-        'GET',
-        endpoint,
-      )) as NotionPaginatedResponse
-
-      for (const result of resp.results) {
-        const block = result as unknown as NotionBlock
-        if (block.type === 'child_page' || block.type === 'child_database') {
-          childIds.push(block.id)
-        }
-      }
-
-      if (!resp.has_more || resp.next_cursor === null) break
-      cursor = resp.next_cursor
     }
-
     return childIds
   }
 
@@ -355,7 +371,7 @@ export const createNotionConnector = (
         'GET',
         `/pages/${pageId}`,
       )) as Record<string, unknown>
-    } catch (err) {
+    } catch {
       return
     }
 
@@ -571,6 +587,7 @@ export const createNotionConnector = (
         includeChildPages: (rawConfig.includeChildPages as boolean) ?? true,
         includeDatabases: (rawConfig.includeDatabases as boolean) ?? true,
         maxDepth: (rawConfig.maxDepth as number) ?? NOTION_DEFAULT_MAX_DEPTH,
+        blockTypeFilter: parseBlockTypeFilter(rawConfig.blockTypeFilter),
       }
     },
 
@@ -600,7 +617,7 @@ export const createNotionConnector = (
           // Documents consumed by the sync loop.
         }
 
-        await new Promise<void>((resolve, reject) => {
+        await new Promise<void>((resolve) => {
           const timer = setTimeout(resolve, interval)
           const onAbort = (): void => {
             clearTimeout(timer)
@@ -620,301 +637,3 @@ export const createNotionConnector = (
   }
 }
 
-// ---------- Helper functions ----------
-
-/**
- * Renders a Notion rich text array to markdown with formatting.
- */
-const renderRichText = (texts: readonly NotionRichText[]): string => {
-  const parts: string[] = []
-
-  for (const t of texts) {
-    let text = t.plain_text
-
-    if (t.annotations?.code === true) {
-      text = '`' + text + '`'
-    }
-    if (t.annotations?.bold === true) {
-      text = '**' + text + '**'
-    }
-    if (t.annotations?.italic === true) {
-      text = '*' + text + '*'
-    }
-    if (t.annotations?.strikethrough === true) {
-      text = '~~' + text + '~~'
-    }
-
-    if (t.href !== undefined && t.href !== '') {
-      text = `[${text}](${t.href})`
-    }
-
-    parts.push(text)
-  }
-
-  return parts.join('')
-}
-
-/**
- * Extracts plain text from rich text without formatting.
- */
-const renderPlainRichText = (texts: readonly NotionRichText[]): string =>
-  texts.map((t) => t.plain_text).join('')
-
-/**
- * Converts a single Notion block to markdown.
- */
-const blockToMarkdown = (block: NotionBlock): string => {
-  const blockData = block[block.type] as Record<string, unknown> | undefined
-  if (blockData === undefined) return ''
-
-  const richText = (blockData.rich_text ?? []) as readonly NotionRichText[]
-  const text = renderRichText(richText)
-  const caption = (blockData.caption ?? []) as readonly NotionRichText[]
-
-  const renderers: Readonly<Record<string, () => string>> = {
-    paragraph: () => `${text}\n`,
-    heading_1: () => `# ${text}\n`,
-    heading_2: () => `## ${text}\n`,
-    heading_3: () => `### ${text}\n`,
-    bulleted_list_item: () => `- ${text}`,
-    numbered_list_item: () => `1. ${text}`,
-    to_do: () => {
-      const checked = blockData.checked === true
-      const marker = checked ? '[x]' : '[ ]'
-      return `- ${marker} ${text}`
-    },
-    toggle: () => `- ${text}`,
-    quote: () => `> ${text}\n`,
-    callout: () => `> ${text}\n`,
-    divider: () => '---\n',
-    code: () => {
-      const lang = (blockData.language as string) ?? ''
-      return '```' + lang + '\n' + text + '\n```\n'
-    },
-    equation: () => {
-      const expression = (blockData.expression as string) ?? ''
-      return `$$\n${expression}\n$$\n`
-    },
-    image: () => {
-      const capText = renderRichText(caption)
-      const url = extractFileUrl(blockData)
-      return capText !== ''
-        ? `![${capText}](${url})\n`
-        : `![](${url})\n`
-    },
-    file: () => {
-      const url = extractFileUrl(blockData)
-      const capText = renderRichText(caption)
-      const label = capText !== '' ? capText : 'file'
-      return `[${label}](${url})\n`
-    },
-    bookmark: () => {
-      const capText = renderRichText(caption)
-      const url = blockData.url as string | undefined
-      if (url !== undefined) {
-        return capText !== '' ? `[${capText}](${url})\n` : `${url}\n`
-      }
-      return ''
-    },
-    embed: () => {
-      const url = blockData.url as string | undefined
-      return url !== undefined ? `${url}\n` : ''
-    },
-    table_of_contents: () => '',
-    breadcrumb: () => '',
-    column_list: () => '',
-    column: () => '',
-    child_page: () => '',
-    child_database: () => '',
-    synced_block: () => '',
-    link_preview: () => {
-      const url = blockData.url as string | undefined
-      return url !== undefined ? `${url}\n` : ''
-    },
-    table: () => '',
-    table_row: () => {
-      const cells = (blockData.cells ?? []) as readonly (readonly NotionRichText[])[]
-      const rendered = cells.map((cell) => renderRichText(cell))
-      return `| ${rendered.join(' | ')} |`
-    },
-  }
-
-  const renderer = renderers[block.type]
-  return renderer !== undefined ? renderer() : text
-}
-
-/**
- * Extracts the title from a page's properties map.
- */
-const extractTitleFromProperties = (
-  properties: Record<string, Record<string, unknown>>,
-): string => {
-  for (const prop of Object.values(properties)) {
-    if (prop.type === 'title') {
-      const titleArr = (prop.title ?? []) as readonly NotionRichText[]
-      return renderPlainRichText(titleArr)
-    }
-  }
-  return ''
-}
-
-/**
- * Converts a Notion property to its string representation.
- */
-const extractPropertyValue = (
-  prop: Record<string, unknown>,
-): string => {
-  const propType = prop.type as string
-
-  const renderers: Readonly<Record<string, () => string>> = {
-    title: () =>
-      renderPlainRichText((prop.title ?? []) as readonly NotionRichText[]),
-    rich_text: () =>
-      renderPlainRichText(
-        (prop.rich_text ?? []) as readonly NotionRichText[],
-      ),
-    number: () => {
-      const num = prop.number as number | null
-      return num !== null && num !== undefined ? String(num) : ''
-    },
-    select: () => {
-      const sel = prop.select as { name: string } | null
-      return sel?.name ?? ''
-    },
-    multi_select: () => {
-      const items = (prop.multi_select ?? []) as readonly { name: string }[]
-      return items.map((i) => i.name).join(', ')
-    },
-    date: () => {
-      const d = prop.date as { start: string; end?: string } | null
-      if (d === null || d === undefined) return ''
-      return d.end !== undefined && d.end !== ''
-        ? `${d.start} to ${d.end}`
-        : d.start
-    },
-    checkbox: () => (prop.checkbox === true ? 'true' : 'false'),
-    url: () => (prop.url as string) ?? '',
-    email: () => (prop.email as string) ?? '',
-    phone_number: () => (prop.phone_number as string) ?? '',
-    status: () => {
-      const st = prop.status as { name: string } | null
-      return st?.name ?? ''
-    },
-    people: () => {
-      const people = (prop.people ?? []) as readonly { name: string }[]
-      return people.map((p) => p.name).join(', ')
-    },
-    relation: () => {
-      const rels = (prop.relation ?? []) as readonly { id: string }[]
-      return rels.map((r) => r.id).join(', ')
-    },
-  }
-
-  const renderer = renderers[propType]
-  return renderer !== undefined ? renderer() : ''
-}
-
-/**
- * Parses a database entry from the query response.
- */
-const parseDatabaseEntry = (
-  raw: Record<string, unknown>,
-): ParsedDatabaseEntry => {
-  const properties = (raw.properties ?? {}) as Record<
-    string,
-    Record<string, unknown>
-  >
-  const lastEditedStr = raw.last_edited_time as string
-  const lastEditedTime = new Date(lastEditedStr)
-
-  let title = ''
-  const propLines: string[] = []
-
-  // Sort keys for deterministic output.
-  const sortedKeys = Object.keys(properties).sort()
-
-  for (const key of sortedKeys) {
-    const prop = properties[key]
-    if (prop === undefined) continue
-    const val = extractPropertyValue(prop)
-
-    if (prop.type === 'title') {
-      title = val
-      continue
-    }
-
-    if (val !== '') {
-      propLines.push(`- **${key}**: ${val}`)
-    }
-  }
-
-  let markdown = ''
-  if (title !== '') {
-    markdown += `## ${title}\n\n`
-  }
-  if (propLines.length > 0) {
-    markdown += propLines.join('\n') + '\n'
-  }
-
-  return {
-    pageId: raw.id as string,
-    title,
-    url: raw.url as string,
-    lastEditedTime,
-    propertiesMarkdown: markdown,
-  }
-}
-
-/**
- * Extracts a file URL from a file-type block's data.
- */
-const extractFileUrl = (data: Record<string, unknown>): string => {
-  const file = data.file as { url?: string } | undefined
-  const external = data.external as { url?: string } | undefined
-  return file?.url ?? external?.url ?? ''
-}
-
-/**
- * Checks whether a block type is a list item.
- */
-const isListBlock = (blockType: string): boolean => {
-  const listTypes = new Set([
-    'bulleted_list_item',
-    'numbered_list_item',
-    'to_do',
-    'toggle',
-  ])
-  return listTypes.has(blockType)
-}
-
-/**
- * Parses a value that might be a string array or undefined.
- */
-const parseStringArray = (
-  value: unknown,
-): readonly string[] | undefined => {
-  if (value === undefined || value === null) return undefined
-  if (Array.isArray(value)) {
-    return value.filter((v): v is string => typeof v === 'string')
-  }
-  return undefined
-}
-
-/**
- * Combines two abort signals into one that fires when either fires.
- */
-const combineSignals = (a: AbortSignal, b: AbortSignal): AbortSignal => {
-  if (a.aborted) return a
-  if (b.aborted) return b
-
-  const controller = new AbortController()
-  const onAbort = (): void => controller.abort()
-  a.addEventListener('abort', onAbort, { once: true })
-  b.addEventListener('abort', onAbort, { once: true })
-  return controller.signal
-}
-
-/**
- * Global fetch wrapper for the default HTTP fetcher.
- */
-const globalFetch: NotionHTTPFetcher = (url, options) => fetch(url, options)

--- a/sdks/ts/memory/src/index.ts
+++ b/sdks/ts/memory/src/index.ts
@@ -42,6 +42,7 @@ export {
 export * from './knowledge/index.js'
 export * from './memory/index.js'
 export * from './ingest/index.js'
+export * from './connector/index.js'
 
 // Access-control primitives (RBAC, OpenFGA adapter, Store wrapper).
 export * from './acl/index.js'


### PR DESCRIPTION
## What
Notion connector syncing pages and databases as markdown documents with full block rendering.

## Why
Team documentation lives in Notion. Need to ingest pages, databases, and nested content for searchability.

## How
- Page sync: recursive block rendering to markdown (20+ block types)
- Database sync: structured documents with property extraction (12 property types)
- Incremental sync via `last_edited_time` filter
- Recursive child page fetching with cycle detection and configurable max depth
- Block type filter configuration for selective rendering
- OAuth2 token refresh with Notion's Basic Auth exchange pattern
- Integration tokens (non-OAuth) skip refresh entirely
- Rate limiting at 3 req/sec with Retry-After handling on 429
- Response body size limit: 10 MiB
- Health status: connection state, error count, last sync time

| Language | Tests |
|----------|-------|
| Go | `go/connector/` — notion.go, notion_blocks.go, notion_properties.go, notion_http.go, notion_oauth2.go | 37 tests |
| TypeScript | `sdks/ts/memory/src/connector/` — notion.ts, notion-blocks.ts, notion-properties.ts, notion-utils.ts | 33 tests |

## Ticket
LLE-9814