### PR TITLE
feat(connector): Google Drive sync with OAuth2 refresh (P5-3)

### DIFF
--- a/go/connector/gdrive.go
+++ b/go/connector/gdrive.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -52,6 +53,15 @@ const (
 
 	// httpDownloadTimeout is the timeout for file download/export requests.
 	httpDownloadTimeout = 5 * time.Minute
+
+	// rateLimitMaxRetries is the maximum number of retry attempts on rate-limit errors.
+	rateLimitMaxRetries = 5
+
+	// rateLimitBaseBackoff is the initial backoff duration for rate-limit retries.
+	rateLimitBaseBackoff = 1 * time.Second
+
+	// rateLimitMaxBackoff caps the backoff duration for rate-limit retries.
+	rateLimitMaxBackoff = 60 * time.Second
 )
 
 // Google MIME types for native document formats.
@@ -60,12 +70,11 @@ const (
 	mimeGoogleSheet        = "application/vnd.google-apps.spreadsheet"
 	mimeGoogleSlides       = "application/vnd.google-apps.presentation"
 	mimeGoogleDrawing      = "application/vnd.google-apps.drawing"
-	mimeGoogleFolder       = "application/vnd.google-apps.folder"
-	mimeTextMarkdown       = "text/markdown"
-	mimeTextPlain          = "text/plain"
-	mimeTextCSV            = "text/csv"
-	mimeImagePNG           = "image/png"
-	mimeApplicationOctet   = "application/octet-stream"
+	mimeGoogleFolder     = "application/vnd.google-apps.folder"
+	mimeTextMarkdown     = "text/markdown"
+	mimeTextPlain        = "text/plain"
+	mimeTextCSV          = "text/csv"
+	mimeImagePNG         = "image/png"
 )
 
 // defaultExportFormats maps Google-native MIME types to the export format
@@ -147,13 +156,19 @@ type HTTPClient interface {
 // It supports full sync via files.list and incremental sync via the
 // Changes API with startPageToken cursors.
 type GDriveConnector struct {
-	deps        ConnectorConfig
-	config      GDriveConfig
-	httpClient  HTTPClient
-	logger      *slog.Logger
-	accessToken string
-	configured  bool
-	stopFn      context.CancelFunc
+	deps         ConnectorConfig
+	config       GDriveConfig
+	httpClient   HTTPClient
+	logger       *slog.Logger
+	accessToken  string
+	configured   bool
+	stopFn       context.CancelFunc
+	oauth2Client *OAuth2Client
+	tokenStore   TokenStore
+	token        *OAuth2Token
+	mu           sync.Mutex
+	lastSyncAt   time.Time
+	errorCount   int64
 }
 
 // NewGDriveConnector creates a new Google Drive connector with the
@@ -170,16 +185,21 @@ func NewGDriveConnector(deps ConnectorConfig, logger *slog.Logger, httpClient HT
 func (c *GDriveConnector) Name() string { return "gdrive" }
 
 // Configure validates and stores the Google Drive-specific settings.
-func (c *GDriveConnector) Configure(config map[string]string) error {
-	clientID, ok := config["oauth2_client_id"]
-	if !ok || clientID == "" {
+// Accepts map[string]any to match the P5-1 Connector interface.
+func (c *GDriveConnector) Configure(config map[string]any) error {
+	clientID, _ := config["oauth2_client_id"].(string)
+	if clientID == "" {
 		return fmt.Errorf("gdrive: oauth2_client_id is required")
 	}
 
-	clientSecret, ok := config["oauth2_client_secret"]
-	if !ok || clientSecret == "" {
+	clientSecret, _ := config["oauth2_client_secret"].(string)
+	if clientSecret == "" {
 		return fmt.Errorf("gdrive: oauth2_client_secret is required")
 	}
+
+	redirectURI, _ := config["oauth2_redirect_uri"].(string)
+	folderID, _ := config["folder_id"].(string)
+	includeSharedRaw, _ := config["include_shared_drives"].(string)
 
 	c.config = GDriveConfig{
 		OAuth2: OAuth2Config{
@@ -188,27 +208,79 @@ func (c *GDriveConnector) Configure(config map[string]string) error {
 			AuthURL:      "https://accounts.google.com/o/oauth2/v2/auth",
 			TokenURL:     "https://oauth2.googleapis.com/token",
 			Scopes:       []string{"https://www.googleapis.com/auth/drive.readonly"},
-			RedirectURI:  config["oauth2_redirect_uri"],
+			RedirectURI:  redirectURI,
 		},
-		FolderID:            config["folder_id"],
-		IncludeSharedDrives: config["include_shared_drives"] == "true",
+		FolderID:            folderID,
+		IncludeSharedDrives: includeSharedRaw == "true",
 		MaxFileSize:         defaultMaxFileSize,
 	}
 
-	if maxSize, exists := config["max_file_size"]; exists {
-		parsed, err := strconv.ParseInt(maxSize, 10, 64)
-		if err != nil {
-			return fmt.Errorf("gdrive: invalid max_file_size %q: %w", maxSize, err)
-		}
-		c.config.MaxFileSize = parsed
+	// Also support bool type for includeSharedDrives.
+	if v, ok := config["include_shared_drives"].(bool); ok {
+		c.config.IncludeSharedDrives = v
 	}
 
-	if mimeFilter, exists := config["mime_type_filter"]; exists && mimeFilter != "" {
+	if maxSizeStr, ok := config["max_file_size"].(string); ok && maxSizeStr != "" {
+		parsed, err := strconv.ParseInt(maxSizeStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("gdrive: invalid max_file_size %q: %w", maxSizeStr, err)
+		}
+		c.config.MaxFileSize = parsed
+	} else if maxSizeNum, ok := config["max_file_size"].(float64); ok {
+		c.config.MaxFileSize = int64(maxSizeNum)
+	} else if maxSizeInt, ok := config["max_file_size"].(int); ok {
+		c.config.MaxFileSize = int64(maxSizeInt)
+	}
+
+	if mimeFilter, ok := config["mime_type_filter"].(string); ok && mimeFilter != "" {
 		c.config.MIMETypeFilter = strings.Split(mimeFilter, ",")
 	}
 
-	if token, exists := config["access_token"]; exists {
+	if token, ok := config["access_token"].(string); ok {
 		c.accessToken = token
+	}
+
+	// Store refresh token if provided.
+	refreshToken, _ := config["refresh_token"].(string)
+
+	// Build initial OAuth2Token if access token and refresh token are
+	// available. ExpiresAt defaults to the zero value (already expired)
+	// so the first API call will trigger a proactive refresh when a
+	// refresh token is present.
+	if c.accessToken != "" {
+		tok := OAuth2Token{
+			AccessToken:  c.accessToken,
+			RefreshToken: refreshToken,
+			TokenType:    "Bearer",
+		}
+		if expiresAt, ok := config["token_expires_at"].(string); ok && expiresAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339, expiresAt); parseErr == nil {
+				tok.ExpiresAt = parsed
+			}
+		}
+		c.token = &tok
+	}
+
+	// Set up OAuth2Client for token refresh when credentials are complete.
+	if clientID != "" && clientSecret != "" && refreshToken != "" {
+		exchanger, _ := config["token_exchanger"].(TokenExchanger)
+		if exchanger == nil {
+			exchanger = &httpTokenExchanger{
+				tokenURL:     c.config.OAuth2.TokenURL,
+				clientID:     clientID,
+				clientSecret: clientSecret,
+				httpClient:   c.httpClient,
+			}
+		}
+		oauthClient, oauthErr := NewOAuth2Client(c.config.OAuth2, exchanger)
+		if oauthErr == nil {
+			c.oauth2Client = oauthClient
+		}
+	}
+
+	// Wire token store if provided.
+	if ts, ok := config["token_store"].(TokenStore); ok {
+		c.tokenStore = ts
 	}
 
 	c.config.ExportFormats = make(map[string]string, len(defaultExportFormats))
@@ -239,6 +311,11 @@ func (c *GDriveConnector) FetchAll(ctx context.Context) (<-chan ConnectorDocumen
 
 		if !c.configured {
 			errCh <- fmt.Errorf("gdrive: connector not configured")
+			return
+		}
+
+		if err := c.ensureValidToken(ctx); err != nil {
+			errCh <- err
 			return
 		}
 
@@ -294,6 +371,11 @@ func (c *GDriveConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-
 
 		if !c.configured {
 			errCh <- fmt.Errorf("gdrive: connector not configured")
+			return
+		}
+
+		if err := c.ensureValidToken(ctx); err != nil {
+			errCh <- err
 			return
 		}
 
@@ -398,7 +480,10 @@ func (c *GDriveConnector) listFiles(ctx context.Context, pageToken string) (*dri
 		params.Set("pageToken", pageToken)
 	}
 
-	query := c.buildFileQuery()
+	query, err := c.buildFileQuery()
+	if err != nil {
+		return nil, err
+	}
 	if query != "" {
 		params.Set("q", query)
 	}
@@ -448,30 +533,33 @@ func (c *GDriveConnector) listChanges(ctx context.Context, pageToken string) (*d
 }
 
 // buildFileQuery constructs the Drive API query string from configuration.
-func (c *GDriveConnector) buildFileQuery() string {
+// Returns an error if any user-supplied values fail validation.
+func (c *GDriveConnector) buildFileQuery() (string, error) {
 	var parts []string
 
-	// Exclude folders from results.
 	parts = append(parts, fmt.Sprintf("mimeType != '%s'", mimeGoogleFolder))
 
-	// Filter to a specific folder.
 	if c.config.FolderID != "" {
+		if !folderIDPattern.MatchString(c.config.FolderID) {
+			return "", fmt.Errorf("gdrive: invalid folder ID %q — must be alphanumeric with hyphens/underscores", c.config.FolderID)
+		}
 		parts = append(parts, fmt.Sprintf("'%s' in parents", c.config.FolderID))
 	}
 
-	// Filter by MIME types.
 	if len(c.config.MIMETypeFilter) > 0 {
 		mimeConditions := make([]string, 0, len(c.config.MIMETypeFilter))
 		for _, mime := range c.config.MIMETypeFilter {
+			if !mimeTypePattern.MatchString(mime) {
+				return "", fmt.Errorf("gdrive: invalid MIME type %q", mime)
+			}
 			mimeConditions = append(mimeConditions, fmt.Sprintf("mimeType = '%s'", mime))
 		}
 		parts = append(parts, "("+strings.Join(mimeConditions, " or ")+")")
 	}
 
-	// Exclude trashed files.
 	parts = append(parts, "trashed = false")
 
-	return strings.Join(parts, " and ")
+	return strings.Join(parts, " and "), nil
 }
 
 // fileToDocument converts a Drive file resource into a ConnectorDocument.
@@ -555,7 +643,7 @@ func (c *GDriveConnector) exportFile(ctx context.Context, fileID, targetMIME str
 	exportURL := fmt.Sprintf("%s/%s/export?mimeType=%s",
 		driveFilesURL, url.PathEscape(fileID), url.QueryEscape(targetMIME))
 
-	body, err := c.doAPIGet(ctx, exportURL, httpDownloadTimeout)
+	body, err := c.doAPIGet(ctx, exportURL, httpDownloadTimeout, driveExportMaxBytes)
 	if err != nil {
 		return nil, "", fmt.Errorf("exporting file %s: %w", fileID, err)
 	}
@@ -571,7 +659,11 @@ func (c *GDriveConnector) exportFile(ctx context.Context, fileID, targetMIME str
 func (c *GDriveConnector) downloadFile(ctx context.Context, fileID, mime string) ([]byte, string, error) {
 	downloadURL := fmt.Sprintf("%s/%s?alt=media", driveFilesURL, url.PathEscape(fileID))
 
-	body, err := c.doAPIGet(ctx, downloadURL, httpDownloadTimeout)
+	maxSize := c.config.MaxFileSize
+	if maxSize == 0 {
+		maxSize = defaultMaxFileSize
+	}
+	body, err := c.doAPIGet(ctx, downloadURL, httpDownloadTimeout, maxSize)
 	if err != nil {
 		return nil, "", fmt.Errorf("downloading file %s: %w", fileID, err)
 	}
@@ -579,46 +671,166 @@ func (c *GDriveConnector) downloadFile(ctx context.Context, fileID, mime string)
 	return body, mime, nil
 }
 
-// doAPIGet performs an authenticated GET request to the Google Drive API.
-func (c *GDriveConnector) doAPIGet(ctx context.Context, reqURL string, timeout time.Duration) ([]byte, error) {
-	if c.deps.RateLimiter != nil {
-		// Rate limiter integration point; currently a no-op placeholder
-		// until P5-1 is merged with the full RateLimiter.Acquire method.
+// doAPIGet performs an authenticated GET request to the Google Drive API
+// with retry and exponential backoff on rate-limit errors, and bounded
+// reads to prevent unbounded memory allocation. maxBodyBytes controls
+// the maximum response body size; use 0 for the default (50 MB).
+func (c *GDriveConnector) doAPIGet(ctx context.Context, reqURL string, timeout time.Duration, maxBodyBytes ...int64) ([]byte, error) {
+	maxBodySize := defaultMaxFileSize
+	if len(maxBodyBytes) > 0 && maxBodyBytes[0] > 0 {
+		maxBodySize = maxBodyBytes[0]
 	}
 
-	reqCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	for attempt := range rateLimitMaxRetries + 1 {
+		// Ensure token is valid before each request attempt.
+		if tokenErr := c.ensureValidToken(ctx); tokenErr != nil {
+			return nil, tokenErr
+		}
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+		reqCtx, cancel := context.WithTimeout(ctx, timeout)
+
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		c.mu.Lock()
+		currentToken := c.accessToken
+		c.mu.Unlock()
+		req.Header.Set("Authorization", "Bearer "+currentToken)
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			cancel()
+			return nil, sanitiseGoError(fmt.Errorf("executing request: %w", err))
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBodySize+1))
+		resp.Body.Close()
+		cancel()
+
+		if readErr != nil {
+			return nil, fmt.Errorf("reading response body: %w", readErr)
+		}
+
+		if int64(len(body)) > maxBodySize {
+			return nil, fmt.Errorf("gdrive: response body exceeds %d byte limit", maxBodySize)
+		}
+
+		// Handle 401 Unauthorised: token may have expired mid-session.
+		// Force a refresh and retry once.
+		if resp.StatusCode == http.StatusUnauthorized && c.oauth2Client != nil && c.token != nil && attempt == 0 {
+			c.mu.Lock()
+			c.token.ExpiresAt = time.Time{} // Force expiry.
+			c.mu.Unlock()
+			c.logger.Warn("gdrive: received 401, forcing token refresh")
+			continue
+		}
+
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			rateLimitErr := c.handleRateLimitError(body, resp.StatusCode)
+			isRateLimit := isRateLimitError(body, resp.StatusCode)
+
+			if isRateLimit && attempt < rateLimitMaxRetries {
+				backoff := calculateGoBackoff(attempt, resp.Header.Get("Retry-After"))
+				c.logger.Warn("gdrive: rate limited, retrying",
+					slog.Int("attempt", attempt+1),
+					slog.Int("max_retries", rateLimitMaxRetries),
+					slog.Duration("backoff", backoff),
+				)
+
+				timer := time.NewTimer(backoff)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return nil, ctx.Err()
+				case <-timer.C:
+				}
+				continue
+			}
+
+			return nil, rateLimitErr
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, truncateBody(body))
+		}
+
+		return body, nil
+	}
+
+	return nil, fmt.Errorf("gdrive: rate limit retries exhausted")
+}
+
+// ensureValidToken checks whether the current token is expired (or
+// within the 5-minute buffer) and refreshes it using the OAuth2Client
+// if available. Thread-safe: concurrent calls are deduplicated by the
+// OAuth2Client's pendingRefresh mechanism.
+func (c *GDriveConnector) ensureValidToken(ctx context.Context) error {
+	c.mu.Lock()
+	tok := c.token
+	client := c.oauth2Client
+	c.mu.Unlock()
+
+	// No token management: static access token mode.
+	if tok == nil || client == nil {
+		return nil
+	}
+
+	// Token still valid -- nothing to do.
+	if !tok.IsExpired() {
+		return nil
+	}
+
+	// Refresh required.
+	refreshed, err := client.ValidToken(ctx, *tok)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.accessToken)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
+		c.mu.Lock()
+		c.errorCount++
+		c.mu.Unlock()
+		return fmt.Errorf("gdrive: token refresh failed: %w", err)
 	}
 
-	if resp.StatusCode == http.StatusForbidden {
-		return nil, c.handleRateLimitError(body, resp.StatusCode)
+	c.mu.Lock()
+	c.token = &refreshed
+	c.accessToken = refreshed.AccessToken
+	c.mu.Unlock()
+
+	// Persist refreshed token if a token store is available.
+	if c.tokenStore != nil {
+		if storeErr := c.tokenStore.Save(ctx, "gdrive", c.deps.BrainID, refreshed); storeErr != nil {
+			c.logger.Warn("gdrive: failed to persist refreshed token",
+				slog.String("error", storeErr.Error()),
+			)
+		}
 	}
 
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, c.handleRateLimitError(body, resp.StatusCode)
+	return nil
+}
+
+// Health returns the current health status of the connector.
+func (c *GDriveConnector) Health() HealthStatus {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	status := StatusConnected
+	var message string
+
+	if !c.configured {
+		status = StatusDisconnected
+		message = "connector not configured"
+	} else if c.errorCount > 0 {
+		status = StatusDegraded
+		message = fmt.Sprintf("%d errors since last successful sync", c.errorCount)
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, truncateBody(body))
+	return HealthStatus{
+		Status:             status,
+		LastSyncAt:         c.lastSyncAt,
+		ErrorCount:         c.errorCount,
+		RateLimitRemaining: -1,
+		Message:            message,
 	}
-
-	return body, nil
 }
 
 // handleRateLimitError parses rate limit error responses.
@@ -645,51 +857,3 @@ func (c *GDriveConnector) handleRateLimitError(body []byte, statusCode int) erro
 	return fmt.Errorf("gdrive: API error (status %d): %s", statusCode, apiErr.Error.Message)
 }
 
-// isGoogleNativeFormat reports whether the MIME type is a Google-native
-// document format that must be exported rather than downloaded.
-func isGoogleNativeFormat(mime string) bool {
-	switch mime {
-	case mimeGoogleDoc, mimeGoogleSheet, mimeGoogleSlides, mimeGoogleDrawing:
-		return true
-	}
-	return false
-}
-
-// parseFileSize parses the file size string from the Drive API. Returns
-// 0 for empty or unparsable values (Google-native formats omit size).
-func parseFileSize(sizeStr string) int64 {
-	if sizeStr == "" {
-		return 0
-	}
-	size, err := strconv.ParseInt(sizeStr, 10, 64)
-	if err != nil {
-		return 0
-	}
-	return size
-}
-
-// buildFileMetadata constructs the metadata map for a Drive file.
-func buildFileMetadata(f *driveFile) map[string]string {
-	meta := map[string]string{
-		"source":    "gdrive",
-		"mime_type": f.MIMEType,
-		"file_id":   f.ID,
-	}
-	if len(f.Parents) > 0 {
-		meta["parent_id"] = f.Parents[0]
-	}
-	if f.Size != "" {
-		meta["size"] = f.Size
-	}
-	return meta
-}
-
-// truncateBody returns at most 200 bytes of a response body for error
-// messages, avoiding excessively long error strings.
-func truncateBody(body []byte) string {
-	const maxLen = 200
-	if len(body) <= maxLen {
-		return string(body)
-	}
-	return string(body[:maxLen]) + "..."
-}

--- a/go/connector/gdrive.go
+++ b/go/connector/gdrive.go
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Google Drive API constants.
+const (
+	// driveFilesURL is the base endpoint for Drive files.list.
+	driveFilesURL = "https://www.googleapis.com/drive/v3/files"
+
+	// driveChangesURL is the base endpoint for Drive changes.list.
+	driveChangesURL = "https://www.googleapis.com/drive/v3/changes"
+
+	// driveStartPageTokenURL fetches the initial changes start token.
+	driveStartPageTokenURL = "https://www.googleapis.com/drive/v3/changes/startPageToken"
+
+	// driveFileFields are the fields requested for each file in list/changes.
+	driveFileFields = "id,name,mimeType,modifiedTime,size,parents,webViewLink"
+
+	// driveListFields specifies the top-level response fields for files.list.
+	driveListFields = "nextPageToken,files(" + driveFileFields + ")"
+
+	// driveChangesFields specifies the response fields for changes.list.
+	driveChangesFields = "nextPageToken,newStartPageToken,changes(fileId,removed,file(" + driveFileFields + "))"
+
+	// driveDefaultPageSize is the number of results per API page.
+	driveDefaultPageSize = 100
+
+	// driveExportMaxBytes is the Google-imposed limit on file exports (10 MB).
+	driveExportMaxBytes = 10 * 1024 * 1024
+
+	// defaultMaxFileSize is the default maximum file size to download (50 MB).
+	defaultMaxFileSize int64 = 50 * 1024 * 1024
+
+	// defaultPollInterval is the default continuous sync interval.
+	defaultPollInterval = 15 * time.Minute
+
+	// httpRequestTimeout is the per-request timeout for Google API calls.
+	httpRequestTimeout = 30 * time.Second
+
+	// httpDownloadTimeout is the timeout for file download/export requests.
+	httpDownloadTimeout = 5 * time.Minute
+)
+
+// Google MIME types for native document formats.
+const (
+	mimeGoogleDoc          = "application/vnd.google-apps.document"
+	mimeGoogleSheet        = "application/vnd.google-apps.spreadsheet"
+	mimeGoogleSlides       = "application/vnd.google-apps.presentation"
+	mimeGoogleDrawing      = "application/vnd.google-apps.drawing"
+	mimeGoogleFolder       = "application/vnd.google-apps.folder"
+	mimeTextMarkdown       = "text/markdown"
+	mimeTextPlain          = "text/plain"
+	mimeTextCSV            = "text/csv"
+	mimeImagePNG           = "image/png"
+	mimeApplicationOctet   = "application/octet-stream"
+)
+
+// defaultExportFormats maps Google-native MIME types to the export format
+// used when downloading. Overridable via GDriveConfig.ExportFormats.
+var defaultExportFormats = map[string]string{
+	mimeGoogleDoc:     mimeTextMarkdown,
+	mimeGoogleSheet:   mimeTextCSV,
+	mimeGoogleSlides:  mimeTextPlain,
+	mimeGoogleDrawing: mimeImagePNG,
+}
+
+// GDriveConfig holds Google Drive-specific connector settings.
+type GDriveConfig struct {
+	// OAuth2 holds the OAuth2 credentials for the Drive API.
+	OAuth2 OAuth2Config
+
+	// FolderID restricts sync to files within a specific folder (recursive).
+	// Empty means sync the entire drive.
+	FolderID string
+
+	// MIMETypeFilter restricts sync to specific MIME types. Empty means all.
+	MIMETypeFilter []string
+
+	// IncludeSharedDrives enables shared/team drive access. Default: false.
+	IncludeSharedDrives bool
+
+	// MaxFileSize is the maximum file size in bytes to download.
+	// Files larger than this are skipped with a warning. Default: 50 MB.
+	MaxFileSize int64
+
+	// ExportFormats overrides the default export format mapping for
+	// Google-native document types.
+	ExportFormats map[string]string
+}
+
+// driveFile mirrors the subset of the Google Drive API File resource
+// needed for sync operations.
+type driveFile struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	MIMEType     string   `json:"mimeType"`
+	ModifiedTime string   `json:"modifiedTime"`
+	Size         string   `json:"size"`
+	Parents      []string `json:"parents"`
+	WebViewLink  string   `json:"webViewLink"`
+}
+
+// driveChange mirrors a single entry from the Drive Changes API response.
+type driveChange struct {
+	FileID  string     `json:"fileId"`
+	File    *driveFile `json:"file"`
+	Removed bool       `json:"removed"`
+}
+
+// driveListResponse is the files.list API response envelope.
+type driveListResponse struct {
+	NextPageToken string      `json:"nextPageToken"`
+	Files         []driveFile `json:"files"`
+}
+
+// driveChangesResponse is the changes.list API response envelope.
+type driveChangesResponse struct {
+	NextPageToken     string        `json:"nextPageToken"`
+	NewStartPageToken string        `json:"newStartPageToken"`
+	Changes           []driveChange `json:"changes"`
+}
+
+// driveStartPageTokenResponse is the changes.getStartPageToken response.
+type driveStartPageTokenResponse struct {
+	StartPageToken string `json:"startPageToken"`
+}
+
+// HTTPClient abstracts HTTP transport for testing.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// GDriveConnector implements the Connector interface for Google Drive.
+// It supports full sync via files.list and incremental sync via the
+// Changes API with startPageToken cursors.
+type GDriveConnector struct {
+	deps        ConnectorConfig
+	config      GDriveConfig
+	httpClient  HTTPClient
+	logger      *slog.Logger
+	accessToken string
+	configured  bool
+	stopFn      context.CancelFunc
+}
+
+// NewGDriveConnector creates a new Google Drive connector with the
+// given shared dependencies. Call Configure before fetching.
+func NewGDriveConnector(deps ConnectorConfig, logger *slog.Logger, httpClient HTTPClient) *GDriveConnector {
+	return &GDriveConnector{
+		deps:       deps,
+		logger:     logger,
+		httpClient: httpClient,
+	}
+}
+
+// Name returns the connector identifier.
+func (c *GDriveConnector) Name() string { return "gdrive" }
+
+// Configure validates and stores the Google Drive-specific settings.
+func (c *GDriveConnector) Configure(config map[string]string) error {
+	clientID, ok := config["oauth2_client_id"]
+	if !ok || clientID == "" {
+		return fmt.Errorf("gdrive: oauth2_client_id is required")
+	}
+
+	clientSecret, ok := config["oauth2_client_secret"]
+	if !ok || clientSecret == "" {
+		return fmt.Errorf("gdrive: oauth2_client_secret is required")
+	}
+
+	c.config = GDriveConfig{
+		OAuth2: OAuth2Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			AuthURL:      "https://accounts.google.com/o/oauth2/v2/auth",
+			TokenURL:     "https://oauth2.googleapis.com/token",
+			Scopes:       []string{"https://www.googleapis.com/auth/drive.readonly"},
+			RedirectURI:  config["oauth2_redirect_uri"],
+		},
+		FolderID:            config["folder_id"],
+		IncludeSharedDrives: config["include_shared_drives"] == "true",
+		MaxFileSize:         defaultMaxFileSize,
+	}
+
+	if maxSize, exists := config["max_file_size"]; exists {
+		parsed, err := strconv.ParseInt(maxSize, 10, 64)
+		if err != nil {
+			return fmt.Errorf("gdrive: invalid max_file_size %q: %w", maxSize, err)
+		}
+		c.config.MaxFileSize = parsed
+	}
+
+	if mimeFilter, exists := config["mime_type_filter"]; exists && mimeFilter != "" {
+		c.config.MIMETypeFilter = strings.Split(mimeFilter, ",")
+	}
+
+	if token, exists := config["access_token"]; exists {
+		c.accessToken = token
+	}
+
+	c.config.ExportFormats = make(map[string]string, len(defaultExportFormats))
+	for k, v := range defaultExportFormats {
+		c.config.ExportFormats[k] = v
+	}
+
+	c.configured = true
+	return nil
+}
+
+// SetAccessToken sets the OAuth2 access token directly. This is used
+// when the caller manages token lifecycle externally.
+func (c *GDriveConnector) SetAccessToken(token string) {
+	c.accessToken = token
+}
+
+// FetchAll performs a full sync of all files from the configured Drive
+// scope. It initialises the Changes API start page token for subsequent
+// incremental syncs.
+func (c *GDriveConnector) FetchAll(ctx context.Context) (<-chan ConnectorDocument, <-chan error) {
+	docCh := make(chan ConnectorDocument, driveDefaultPageSize)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(docCh)
+		defer close(errCh)
+
+		if !c.configured {
+			errCh <- fmt.Errorf("gdrive: connector not configured")
+			return
+		}
+
+		pageToken := ""
+		for {
+			resp, err := c.listFiles(ctx, pageToken)
+			if err != nil {
+				errCh <- fmt.Errorf("gdrive: listing files: %w", err)
+				return
+			}
+
+			for i := range resp.Files {
+				doc, err := c.fileToDocument(ctx, &resp.Files[i])
+				if err != nil {
+					c.logger.Warn("gdrive: skipping file",
+						slog.String("file_id", resp.Files[i].ID),
+						slog.String("name", resp.Files[i].Name),
+						slog.String("error", err.Error()),
+					)
+					continue
+				}
+				if doc == nil {
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				case docCh <- *doc:
+				}
+			}
+
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
+		}
+	}()
+
+	return docCh, errCh
+}
+
+// FetchSince performs an incremental sync using the Drive Changes API.
+// The cursor value must be a valid startPageToken from a previous sync.
+func (c *GDriveConnector) FetchSince(ctx context.Context, cursor SyncCursor) (<-chan ConnectorDocument, <-chan error) {
+	docCh := make(chan ConnectorDocument, driveDefaultPageSize)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(docCh)
+		defer close(errCh)
+
+		if !c.configured {
+			errCh <- fmt.Errorf("gdrive: connector not configured")
+			return
+		}
+
+		pageToken := cursor.Value
+		for {
+			resp, err := c.listChanges(ctx, pageToken)
+			if err != nil {
+				errCh <- fmt.Errorf("gdrive: listing changes: %w", err)
+				return
+			}
+
+			for i := range resp.Changes {
+				change := &resp.Changes[i]
+				doc, err := c.changeToDocument(ctx, change)
+				if err != nil {
+					c.logger.Warn("gdrive: skipping change",
+						slog.String("file_id", change.FileID),
+						slog.String("error", err.Error()),
+					)
+					continue
+				}
+				if doc == nil {
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				case docCh <- *doc:
+				}
+			}
+
+			if resp.NewStartPageToken != "" {
+				// Emit a cursor-update document so callers can persist the new token.
+				select {
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				case docCh <- ConnectorDocument{
+					ExternalID: "__cursor_update__",
+					Metadata: map[string]string{
+						"new_start_page_token": resp.NewStartPageToken,
+					},
+				}:
+				}
+				break
+			}
+
+			if resp.NextPageToken == "" {
+				break
+			}
+			pageToken = resp.NextPageToken
+		}
+	}()
+
+	return docCh, errCh
+}
+
+// GetStartPageToken retrieves the current Changes API start page token.
+// This token is used as the initial cursor for incremental sync.
+func (c *GDriveConnector) GetStartPageToken(ctx context.Context) (string, error) {
+	reqURL := driveStartPageTokenURL
+	if c.config.IncludeSharedDrives {
+		reqURL += "?supportsAllDrives=true"
+	}
+
+	body, err := c.doAPIGet(ctx, reqURL, httpRequestTimeout)
+	if err != nil {
+		return "", fmt.Errorf("gdrive: getting start page token: %w", err)
+	}
+
+	var resp driveStartPageTokenResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("gdrive: parsing start page token response: %w", err)
+	}
+	return resp.StartPageToken, nil
+}
+
+// Start begins a continuous sync loop. Not implemented yet as it depends
+// on the full P5-1 SyncStateManager integration.
+func (c *GDriveConnector) Start(_ context.Context) error {
+	return fmt.Errorf("gdrive: continuous sync not yet supported without P5-1 SyncStateManager")
+}
+
+// Stop halts the continuous sync loop.
+func (c *GDriveConnector) Stop() error {
+	if c.stopFn != nil {
+		c.stopFn()
+	}
+	return nil
+}
+
+// listFiles calls the Drive files.list API with pagination and filtering.
+func (c *GDriveConnector) listFiles(ctx context.Context, pageToken string) (*driveListResponse, error) {
+	params := url.Values{
+		"pageSize": {strconv.Itoa(driveDefaultPageSize)},
+		"fields":   {driveListFields},
+	}
+
+	if pageToken != "" {
+		params.Set("pageToken", pageToken)
+	}
+
+	query := c.buildFileQuery()
+	if query != "" {
+		params.Set("q", query)
+	}
+
+	if c.config.IncludeSharedDrives {
+		params.Set("supportsAllDrives", "true")
+		params.Set("includeItemsFromAllDrives", "true")
+	}
+
+	reqURL := driveFilesURL + "?" + params.Encode()
+	body, err := c.doAPIGet(ctx, reqURL, httpRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp driveListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing files.list response: %w", err)
+	}
+	return &resp, nil
+}
+
+// listChanges calls the Drive changes.list API with the given page token.
+func (c *GDriveConnector) listChanges(ctx context.Context, pageToken string) (*driveChangesResponse, error) {
+	params := url.Values{
+		"pageToken": {pageToken},
+		"pageSize":  {strconv.Itoa(driveDefaultPageSize)},
+		"fields":    {driveChangesFields},
+	}
+
+	if c.config.IncludeSharedDrives {
+		params.Set("supportsAllDrives", "true")
+		params.Set("includeItemsFromAllDrives", "true")
+	}
+
+	reqURL := driveChangesURL + "?" + params.Encode()
+	body, err := c.doAPIGet(ctx, reqURL, httpRequestTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp driveChangesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing changes.list response: %w", err)
+	}
+	return &resp, nil
+}
+
+// buildFileQuery constructs the Drive API query string from configuration.
+func (c *GDriveConnector) buildFileQuery() string {
+	var parts []string
+
+	// Exclude folders from results.
+	parts = append(parts, fmt.Sprintf("mimeType != '%s'", mimeGoogleFolder))
+
+	// Filter to a specific folder.
+	if c.config.FolderID != "" {
+		parts = append(parts, fmt.Sprintf("'%s' in parents", c.config.FolderID))
+	}
+
+	// Filter by MIME types.
+	if len(c.config.MIMETypeFilter) > 0 {
+		mimeConditions := make([]string, 0, len(c.config.MIMETypeFilter))
+		for _, mime := range c.config.MIMETypeFilter {
+			mimeConditions = append(mimeConditions, fmt.Sprintf("mimeType = '%s'", mime))
+		}
+		parts = append(parts, "("+strings.Join(mimeConditions, " or ")+")")
+	}
+
+	// Exclude trashed files.
+	parts = append(parts, "trashed = false")
+
+	return strings.Join(parts, " and ")
+}
+
+// fileToDocument converts a Drive file resource into a ConnectorDocument.
+// Returns nil for files that should be skipped (folders, too large).
+func (c *GDriveConnector) fileToDocument(ctx context.Context, f *driveFile) (*ConnectorDocument, error) {
+	if f.MIMEType == mimeGoogleFolder {
+		return nil, nil
+	}
+
+	fileSize := parseFileSize(f.Size)
+	if fileSize > c.config.MaxFileSize && !isGoogleNativeFormat(f.MIMEType) {
+		c.logger.Warn("gdrive: file exceeds size limit, skipping",
+			slog.String("file_id", f.ID),
+			slog.String("name", f.Name),
+			slog.Int64("size", fileSize),
+			slog.Int64("limit", c.config.MaxFileSize),
+		)
+		return nil, nil
+	}
+
+	modifiedAt, err := time.Parse(time.RFC3339, f.ModifiedTime)
+	if err != nil {
+		return nil, fmt.Errorf("parsing modified time for %s: %w", f.ID, err)
+	}
+
+	content, mime, err := c.downloadOrExport(ctx, f)
+	if err != nil {
+		return nil, fmt.Errorf("downloading %s (%s): %w", f.ID, f.Name, err)
+	}
+
+	return &ConnectorDocument{
+		ExternalID: f.ID,
+		Content:    content,
+		MIME:       mime,
+		Title:      f.Name,
+		URL:        f.WebViewLink,
+		Metadata:   buildFileMetadata(f),
+		ModifiedAt: modifiedAt,
+	}, nil
+}
+
+// changeToDocument converts a Drive change entry into a ConnectorDocument.
+func (c *GDriveConnector) changeToDocument(ctx context.Context, ch *driveChange) (*ConnectorDocument, error) {
+	if ch.Removed || ch.File == nil {
+		return &ConnectorDocument{
+			ExternalID: ch.FileID,
+			Deleted:    true,
+			Metadata: map[string]string{
+				"source": "gdrive",
+			},
+		}, nil
+	}
+
+	return c.fileToDocument(ctx, ch.File)
+}
+
+// downloadOrExport fetches file content. Google-native formats are
+// exported via the export API; all others are downloaded directly.
+func (c *GDriveConnector) downloadOrExport(ctx context.Context, f *driveFile) ([]byte, string, error) {
+	exportMIME, isNative := c.resolveExportFormat(f.MIMEType)
+	if isNative {
+		return c.exportFile(ctx, f.ID, exportMIME)
+	}
+	return c.downloadFile(ctx, f.ID, f.MIMEType)
+}
+
+// resolveExportFormat returns the target MIME type for a Google-native
+// format, checking custom overrides first.
+func (c *GDriveConnector) resolveExportFormat(sourceMIME string) (string, bool) {
+	if c.config.ExportFormats != nil {
+		if target, exists := c.config.ExportFormats[sourceMIME]; exists {
+			return target, true
+		}
+	}
+	target, exists := defaultExportFormats[sourceMIME]
+	return target, exists
+}
+
+// exportFile uses the Drive export API to download a Google-native file.
+func (c *GDriveConnector) exportFile(ctx context.Context, fileID, targetMIME string) ([]byte, string, error) {
+	exportURL := fmt.Sprintf("%s/%s/export?mimeType=%s",
+		driveFilesURL, url.PathEscape(fileID), url.QueryEscape(targetMIME))
+
+	body, err := c.doAPIGet(ctx, exportURL, httpDownloadTimeout)
+	if err != nil {
+		return nil, "", fmt.Errorf("exporting file %s: %w", fileID, err)
+	}
+
+	if int64(len(body)) > driveExportMaxBytes {
+		return nil, "", fmt.Errorf("export of %s exceeds %d byte limit", fileID, driveExportMaxBytes)
+	}
+
+	return body, targetMIME, nil
+}
+
+// downloadFile fetches a binary file directly from Drive.
+func (c *GDriveConnector) downloadFile(ctx context.Context, fileID, mime string) ([]byte, string, error) {
+	downloadURL := fmt.Sprintf("%s/%s?alt=media", driveFilesURL, url.PathEscape(fileID))
+
+	body, err := c.doAPIGet(ctx, downloadURL, httpDownloadTimeout)
+	if err != nil {
+		return nil, "", fmt.Errorf("downloading file %s: %w", fileID, err)
+	}
+
+	return body, mime, nil
+}
+
+// doAPIGet performs an authenticated GET request to the Google Drive API.
+func (c *GDriveConnector) doAPIGet(ctx context.Context, reqURL string, timeout time.Duration) ([]byte, error) {
+	if c.deps.RateLimiter != nil {
+		// Rate limiter integration point; currently a no-op placeholder
+		// until P5-1 is merged with the full RateLimiter.Acquire method.
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, c.handleRateLimitError(body, resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, c.handleRateLimitError(body, resp.StatusCode)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, truncateBody(body))
+	}
+
+	return body, nil
+}
+
+// handleRateLimitError parses rate limit error responses.
+func (c *GDriveConnector) handleRateLimitError(body []byte, statusCode int) error {
+	var apiErr struct {
+		Error struct {
+			Message string `json:"message"`
+			Errors  []struct {
+				Reason string `json:"reason"`
+			} `json:"errors"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal(body, &apiErr); err != nil {
+		return fmt.Errorf("rate limit error (status %d): %s", statusCode, truncateBody(body))
+	}
+
+	for _, e := range apiErr.Error.Errors {
+		if e.Reason == "rateLimitExceeded" || e.Reason == "userRateLimitExceeded" {
+			return fmt.Errorf("gdrive: rate limit exceeded: %s", apiErr.Error.Message)
+		}
+	}
+
+	return fmt.Errorf("gdrive: API error (status %d): %s", statusCode, apiErr.Error.Message)
+}
+
+// isGoogleNativeFormat reports whether the MIME type is a Google-native
+// document format that must be exported rather than downloaded.
+func isGoogleNativeFormat(mime string) bool {
+	switch mime {
+	case mimeGoogleDoc, mimeGoogleSheet, mimeGoogleSlides, mimeGoogleDrawing:
+		return true
+	}
+	return false
+}
+
+// parseFileSize parses the file size string from the Drive API. Returns
+// 0 for empty or unparsable values (Google-native formats omit size).
+func parseFileSize(sizeStr string) int64 {
+	if sizeStr == "" {
+		return 0
+	}
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return size
+}
+
+// buildFileMetadata constructs the metadata map for a Drive file.
+func buildFileMetadata(f *driveFile) map[string]string {
+	meta := map[string]string{
+		"source":    "gdrive",
+		"mime_type": f.MIMEType,
+		"file_id":   f.ID,
+	}
+	if len(f.Parents) > 0 {
+		meta["parent_id"] = f.Parents[0]
+	}
+	if f.Size != "" {
+		meta["size"] = f.Size
+	}
+	return meta
+}
+
+// truncateBody returns at most 200 bytes of a response body for error
+// messages, avoiding excessively long error strings.
+func truncateBody(body []byte) string {
+	const maxLen = 200
+	if len(body) <= maxLen {
+		return string(body)
+	}
+	return string(body[:maxLen]) + "..."
+}

--- a/go/connector/gdrive_helpers.go
+++ b/go/connector/gdrive_helpers.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// folderIDPattern matches valid Google Drive folder IDs (alphanumeric, hyphens, underscores).
+var folderIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// mimeTypePattern matches valid MIME type strings.
+var mimeTypePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9!#$&\-.^_+]+/[a-zA-Z0-9][a-zA-Z0-9!#$&\-.^_+]+$`)
+
+// isGoogleNativeFormat reports whether the MIME type is a Google-native
+// document format that must be exported rather than downloaded.
+func isGoogleNativeFormat(mime string) bool {
+	switch mime {
+	case mimeGoogleDoc, mimeGoogleSheet, mimeGoogleSlides, mimeGoogleDrawing:
+		return true
+	}
+	return false
+}
+
+// parseFileSize parses the file size string from the Drive API. Returns
+// 0 for empty or unparsable values (Google-native formats omit size).
+func parseFileSize(sizeStr string) int64 {
+	if sizeStr == "" {
+		return 0
+	}
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return size
+}
+
+// buildFileMetadata constructs the metadata map for a Drive file.
+func buildFileMetadata(f *driveFile) map[string]string {
+	meta := map[string]string{
+		"source":    "gdrive",
+		"mime_type": f.MIMEType,
+		"file_id":   f.ID,
+	}
+	if len(f.Parents) > 0 {
+		meta["parent_id"] = f.Parents[0]
+	}
+	if f.Size != "" {
+		meta["size"] = f.Size
+	}
+	return meta
+}
+
+// truncateBody returns at most 200 bytes of a response body for error
+// messages, avoiding excessively long error strings.
+func truncateBody(body []byte) string {
+	const maxLen = 200
+	if len(body) <= maxLen {
+		return string(body)
+	}
+	return string(body[:maxLen]) + "..."
+}
+
+// isRateLimitError checks whether the error response body indicates a
+// rate-limit error that should be retried.
+func isRateLimitError(body []byte, statusCode int) bool {
+	if statusCode == http.StatusTooManyRequests {
+		return true
+	}
+
+	var apiErr struct {
+		Error struct {
+			Errors []struct {
+				Reason string `json:"reason"`
+			} `json:"errors"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &apiErr); err != nil {
+		return false
+	}
+
+	rateLimitReasons := map[string]bool{
+		"rateLimitExceeded":     true,
+		"userRateLimitExceeded": true,
+	}
+	for _, e := range apiErr.Error.Errors {
+		if rateLimitReasons[e.Reason] {
+			return true
+		}
+	}
+	return false
+}
+
+// calculateGoBackoff computes the backoff duration with exponential
+// increase and jitter, respecting the Retry-After header when present.
+func calculateGoBackoff(attempt int, retryAfter string) time.Duration {
+	if retryAfter != "" {
+		seconds, err := strconv.ParseFloat(retryAfter, 64)
+		if err == nil && seconds > 0 {
+			d := time.Duration(seconds * float64(time.Second))
+			if d > rateLimitMaxBackoff {
+				return rateLimitMaxBackoff
+			}
+			return d
+		}
+	}
+
+	exponential := float64(rateLimitBaseBackoff) * math.Pow(2, float64(attempt))
+	jitter := rand.Float64() * float64(rateLimitBaseBackoff)
+	backoff := time.Duration(exponential + jitter)
+
+	if backoff > rateLimitMaxBackoff {
+		return rateLimitMaxBackoff
+	}
+	return backoff
+}
+
+// bearerTokenPattern matches Bearer tokens in error messages.
+var bearerTokenPattern = regexp.MustCompile(`Bearer\s+[A-Za-z0-9\-._~+/]+=*`)
+
+// sanitiseGoError strips access tokens from error messages to prevent
+// credential leakage through error wrapping.
+func sanitiseGoError(err error) error {
+	msg := err.Error()
+	sanitised := bearerTokenPattern.ReplaceAllString(msg, "Bearer [REDACTED]")
+	if sanitised != msg {
+		return fmt.Errorf("%s", sanitised)
+	}
+	return err
+}

--- a/go/connector/gdrive_test.go
+++ b/go/connector/gdrive_test.go
@@ -15,25 +15,36 @@ import (
 	"time"
 )
 
+// mockResponseDef stores response definition data (not the response itself)
+// so fresh response bodies can be created on each request.
+type mockResponseDef struct {
+	statusCode int
+	body       []byte
+}
+
 // mockHTTPClient implements HTTPClient for testing with configurable
 // responses keyed by request URL substring.
 type mockHTTPClient struct {
-	responses map[string]*http.Response
-	requests  []*http.Request
+	responseDefs map[string]mockResponseDef
+	requests     []*http.Request
 }
 
 func newMockHTTPClient() *mockHTTPClient {
 	return &mockHTTPClient{
-		responses: make(map[string]*http.Response),
+		responseDefs: make(map[string]mockResponseDef),
 	}
 }
 
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	m.requests = append(m.requests, req)
 
-	for pattern, resp := range m.responses {
+	for pattern, def := range m.responseDefs {
 		if strings.Contains(req.URL.String(), pattern) {
-			return resp, nil
+			return &http.Response{
+				StatusCode: def.statusCode,
+				Body:       io.NopCloser(bytes.NewReader(def.body)),
+				Header:     http.Header{},
+			}, nil
 		}
 	}
 	return &http.Response{
@@ -43,19 +54,17 @@ func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (m *mockHTTPClient) addResponse(urlPattern string, statusCode int, body string) {
-	m.responses[urlPattern] = &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(strings.NewReader(body)),
-		Header:     http.Header{},
+	m.responseDefs[urlPattern] = mockResponseDef{
+		statusCode: statusCode,
+		body:       []byte(body),
 	}
 }
 
 func (m *mockHTTPClient) addJSONResponse(urlPattern string, statusCode int, payload any) {
 	data, _ := json.Marshal(payload)
-	m.responses[urlPattern] = &http.Response{
-		StatusCode: statusCode,
-		Body:       io.NopCloser(bytes.NewReader(data)),
-		Header:     http.Header{},
+	m.responseDefs[urlPattern] = mockResponseDef{
+		statusCode: statusCode,
+		body:       data,
 	}
 }
 
@@ -72,7 +81,7 @@ func newTestConnector(client *mockHTTPClient) *GDriveConnector {
 }
 
 func configureTestConnector(c *GDriveConnector) error {
-	return c.Configure(map[string]string{
+	return c.Configure(map[string]any{
 		"oauth2_client_id":     "test-client-id",
 		"oauth2_client_secret": "test-client-secret",
 		"access_token":         "test-access-token",
@@ -101,26 +110,26 @@ func TestGDriveConnector_Name(t *testing.T) {
 func TestGDriveConnector_Configure(t *testing.T) {
 	cases := []struct {
 		name    string
-		config  map[string]string
+		config  map[string]any
 		wantErr string
 	}{
 		{
 			name: "valid configuration",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "client-123",
 				"oauth2_client_secret": "secret-456",
 			},
 		},
 		{
 			name: "missing client ID",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_secret": "secret-456",
 			},
 			wantErr: "oauth2_client_id is required",
 		},
 		{
 			name: "empty client ID",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "",
 				"oauth2_client_secret": "secret-456",
 			},
@@ -128,14 +137,14 @@ func TestGDriveConnector_Configure(t *testing.T) {
 		},
 		{
 			name: "missing client secret",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id": "client-123",
 			},
 			wantErr: "oauth2_client_secret is required",
 		},
 		{
 			name: "with folder ID",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "client-123",
 				"oauth2_client_secret": "secret-456",
 				"folder_id":            "folder-789",
@@ -143,7 +152,7 @@ func TestGDriveConnector_Configure(t *testing.T) {
 		},
 		{
 			name: "with MIME type filter",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "client-123",
 				"oauth2_client_secret": "secret-456",
 				"mime_type_filter":     "application/pdf,text/plain",
@@ -151,7 +160,7 @@ func TestGDriveConnector_Configure(t *testing.T) {
 		},
 		{
 			name: "with shared drives",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":      "client-123",
 				"oauth2_client_secret":  "secret-456",
 				"include_shared_drives": "true",
@@ -159,7 +168,7 @@ func TestGDriveConnector_Configure(t *testing.T) {
 		},
 		{
 			name: "invalid max file size",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "client-123",
 				"oauth2_client_secret": "secret-456",
 				"max_file_size":        "not-a-number",
@@ -168,7 +177,7 @@ func TestGDriveConnector_Configure(t *testing.T) {
 		},
 		{
 			name: "custom max file size",
-			config: map[string]string{
+			config: map[string]any{
 				"oauth2_client_id":     "client-123",
 				"oauth2_client_secret": "secret-456",
 				"max_file_size":        "1048576",
@@ -256,7 +265,7 @@ func TestGDriveConnector_FetchAll_PaginatedFileListing(t *testing.T) {
 
 	// Use a stateful mock to return different pages.
 	callCount := 0
-	client.responses = nil
+	client.responseDefs = nil
 	originalClient := client
 	statefulClient := &statefulMockHTTPClient{
 		inner: originalClient,
@@ -496,7 +505,7 @@ func TestGDriveConnector_FetchAll_FileTooLargeSkipped(t *testing.T) {
 	client := newMockHTTPClient()
 	c := newTestConnector(client)
 
-	err := c.Configure(map[string]string{
+	err := c.Configure(map[string]any{
 		"oauth2_client_id":     "test-id",
 		"oauth2_client_secret": "test-secret",
 		"access_token":         "test-token",
@@ -537,17 +546,19 @@ func TestGDriveConnector_FetchAll_RateLimit403Handling(t *testing.T) {
 		t.Fatalf("Configure() failed: %v", err)
 	}
 
-	rateLimitBody := `{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}`
-	client.addResponse("drive/v3/files?", http.StatusForbidden, rateLimitBody)
+	// Use a non-retryable 403 (reason "forbidden", not "rateLimitExceeded")
+	// so the test completes immediately without backoff retries.
+	forbiddenBody := `{"error":{"message":"Forbidden","errors":[{"reason":"forbidden"}]}}`
+	client.addResponse("drive/v3/files?", http.StatusForbidden, forbiddenBody)
 
 	docCh, errCh := c.FetchAll(context.Background())
 	_, err := collectDocuments(docCh, errCh)
 
 	if err == nil {
-		t.Fatal("FetchAll() succeeded, want rate limit error")
+		t.Fatal("FetchAll() succeeded, want 403 error")
 	}
-	if !strings.Contains(err.Error(), "rate limit exceeded") {
-		t.Errorf("error = %q, want containing %q", err, "rate limit exceeded")
+	if !strings.Contains(err.Error(), "API error") {
+		t.Errorf("error = %q, want containing %q", err, "API error")
 	}
 }
 
@@ -555,7 +566,7 @@ func TestGDriveConnector_FetchAll_FolderIDFiltering(t *testing.T) {
 	client := newMockHTTPClient()
 	c := newTestConnector(client)
 
-	err := c.Configure(map[string]string{
+	err := c.Configure(map[string]any{
 		"oauth2_client_id":     "test-id",
 		"oauth2_client_secret": "test-secret",
 		"access_token":         "test-token",
@@ -589,7 +600,7 @@ func TestGDriveConnector_FetchAll_MIMETypeFiltering(t *testing.T) {
 	client := newMockHTTPClient()
 	c := newTestConnector(client)
 
-	err := c.Configure(map[string]string{
+	err := c.Configure(map[string]any{
 		"oauth2_client_id":     "test-id",
 		"oauth2_client_secret": "test-secret",
 		"access_token":         "test-token",
@@ -621,7 +632,7 @@ func TestGDriveConnector_FetchAll_SharedDriveInclusion(t *testing.T) {
 	client := newMockHTTPClient()
 	c := newTestConnector(client)
 
-	err := c.Configure(map[string]string{
+	err := c.Configure(map[string]any{
 		"oauth2_client_id":      "test-id",
 		"oauth2_client_secret":  "test-secret",
 		"access_token":          "test-token",
@@ -724,6 +735,7 @@ func TestGDriveConnector_BuildFileQuery(t *testing.T) {
 		config   GDriveConfig
 		contains []string
 		excludes []string
+		wantErr  string
 	}{
 		{
 			name:   "no filters",
@@ -748,6 +760,16 @@ func TestGDriveConnector_BuildFileQuery(t *testing.T) {
 				"mimeType = 'text/plain'",
 			},
 		},
+		{
+			name:    "rejects folder ID with single quotes",
+			config:  GDriveConfig{FolderID: "' or name contains '"},
+			wantErr: "invalid folder ID",
+		},
+		{
+			name:    "rejects invalid MIME type with quotes",
+			config:  GDriveConfig{MIMETypeFilter: []string{"application/pdf' or mimeType = '"}},
+			wantErr: "invalid MIME type",
+		},
 	}
 
 	for _, tc := range cases {
@@ -755,7 +777,18 @@ func TestGDriveConnector_BuildFileQuery(t *testing.T) {
 			client := newMockHTTPClient()
 			c := newTestConnector(client)
 			c.config = tc.config
-			query := c.buildFileQuery()
+			query, err := c.buildFileQuery()
+
+			switch {
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("buildFileQuery() succeeded, want error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("buildFileQuery() error = %q, want containing %q", err, tc.wantErr)
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("buildFileQuery() failed: %v", err)
+			case tc.wantErr != "":
+				return
+			}
 
 			for _, s := range tc.contains {
 				if !strings.Contains(query, s) {
@@ -854,6 +887,308 @@ func TestTruncateBody(t *testing.T) {
 	}
 }
 
+func TestGDriveConnector_FetchAll_ExportGoogleSlidesAsPlainText(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "slides1", Name: "Presentation", MIMEType: mimeGoogleSlides, ModifiedTime: "2026-01-15T10:00:00Z"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	client.addResponse("slides1/export", http.StatusOK, "Slide 1: Introduction\nSlide 2: Conclusion")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+
+	if docs[0].MIME != mimeTextPlain {
+		t.Errorf("docs[0].MIME = %q, want %q", docs[0].MIME, mimeTextPlain)
+	}
+
+	if !strings.Contains(string(docs[0].Content), "Introduction") {
+		t.Errorf("docs[0].Content = %q, want containing 'Introduction'", string(docs[0].Content))
+	}
+}
+
+func TestGDriveConnector_FetchAll_ExportExceedsLimit(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "bigdoc", Name: "Huge Document", MIMEType: mimeGoogleDoc, ModifiedTime: "2026-01-15T10:00:00Z"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	// Create an export response that exceeds the 10 MB export limit.
+	hugeBody := strings.Repeat("x", driveExportMaxBytes+1)
+	client.addResponse("bigdoc/export", http.StatusOK, hugeBody)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+
+	// The file should be skipped (logged as warning), not cause a fatal error.
+	// Since fileToDocument returns an error for over-limit exports, the goroutine
+	// logs a warning and continues.
+	_ = err
+	for _, doc := range docs {
+		if doc.ExternalID == "bigdoc" {
+			t.Error("export exceeding limit should not have been yielded as a document")
+		}
+	}
+}
+
+func TestGDriveConnector_FetchAll_RateLimitRetrySucceeds(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	rateLimitBody := `{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}`
+	successBody, _ := json.Marshal(driveListResponse{
+		Files: []driveFile{
+			{ID: "f1", Name: "doc.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-15T10:00:00Z", Size: "50"},
+		},
+	})
+
+	callCount := 0
+	stateful := &statefulMockHTTPClient{
+		inner: client,
+		handler: func(req *http.Request) (*http.Response, error) {
+			client.requests = append(client.requests, req)
+			reqURL := req.URL.String()
+
+			if strings.Contains(reqURL, "drive/v3/files?") {
+				callCount++
+				// First call returns rate limit, second succeeds.
+				switch {
+				case callCount == 1:
+					return &http.Response{
+						StatusCode: http.StatusTooManyRequests,
+						Body:       io.NopCloser(strings.NewReader(rateLimitBody)),
+						Header:     http.Header{},
+					}, nil
+				default:
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader(successBody)),
+						Header:     http.Header{},
+					}, nil
+				}
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("content")),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+	c.httpClient = stateful
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+	if docs[0].ExternalID != "f1" {
+		t.Errorf("docs[0].ExternalID = %q, want %q", docs[0].ExternalID, "f1")
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 API calls (1 rate-limited + 1 success), got %d", callCount)
+	}
+}
+
+func TestGDriveConnector_FetchAll_OAuth2TokenUsedInRequests(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	// Set a new access token (simulating a token refresh scenario).
+	c.SetAccessToken("refreshed-access-token-xyz")
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	authHeader := client.requests[0].Header.Get("Authorization")
+	if authHeader != "Bearer refreshed-access-token-xyz" {
+		t.Errorf("Authorization header = %q, want %q", authHeader, "Bearer refreshed-access-token-xyz")
+	}
+}
+
+func TestGDriveConnector_FetchAll_ResponseBodyExceedsSizeLimit(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-id",
+		"oauth2_client_secret": "test-secret",
+		"access_token":         "test-token",
+		"max_file_size":        "100",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "f1", Name: "small.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-15T10:00:00Z", Size: "50"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	// Download response exceeds configured max_file_size.
+	hugeBody := strings.Repeat("x", 200)
+	client.addResponse("f1?alt=media", http.StatusOK, hugeBody)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err = collectDocuments(docCh, errCh)
+
+	// The download should fail due to size limit enforcement at the read level.
+	// The file is skipped with a warning (fileToDocument error is logged and continued).
+	// We just verify no panic and the connector handled it gracefully.
+	_ = err
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		statusCode int
+		want       bool
+	}{
+		{
+			name:       "429 status code",
+			body:       `{"error":{"message":"too many requests"}}`,
+			statusCode: http.StatusTooManyRequests,
+			want:       true,
+		},
+		{
+			name:       "403 with rateLimitExceeded reason",
+			body:       `{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}`,
+			statusCode: http.StatusForbidden,
+			want:       true,
+		},
+		{
+			name:       "403 without rate limit reason",
+			body:       `{"error":{"message":"Forbidden","errors":[{"reason":"forbidden"}]}}`,
+			statusCode: http.StatusForbidden,
+			want:       false,
+		},
+		{
+			name:       "403 with userRateLimitExceeded reason",
+			body:       `{"error":{"message":"User Rate Limit","errors":[{"reason":"userRateLimitExceeded"}]}}`,
+			statusCode: http.StatusForbidden,
+			want:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRateLimitError([]byte(tc.body), tc.statusCode)
+			if got != tc.want {
+				t.Errorf("isRateLimitError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCalculateGoBackoff(t *testing.T) {
+	// With Retry-After header.
+	backoff := calculateGoBackoff(0, "5")
+	if backoff != 5*time.Second {
+		t.Errorf("calculateGoBackoff(0, '5') = %v, want 5s", backoff)
+	}
+
+	// Without Retry-After header, should return exponential backoff.
+	backoff = calculateGoBackoff(0, "")
+	if backoff < rateLimitBaseBackoff || backoff > 2*rateLimitBaseBackoff+rateLimitBaseBackoff {
+		t.Errorf("calculateGoBackoff(0, '') = %v, want roughly %v", backoff, rateLimitBaseBackoff)
+	}
+
+	// Large Retry-After should be capped.
+	backoff = calculateGoBackoff(0, "120")
+	if backoff != rateLimitMaxBackoff {
+		t.Errorf("calculateGoBackoff(0, '120') = %v, want %v", backoff, rateLimitMaxBackoff)
+	}
+}
+
+func TestSanitiseGoError(t *testing.T) {
+	errWithToken := fmt.Errorf("request failed: Bearer ya29.A0ARrdaM-xyz123 unauthorized")
+	sanitised := sanitiseGoError(errWithToken)
+	if strings.Contains(sanitised.Error(), "ya29") {
+		t.Errorf("sanitised error still contains token: %q", sanitised)
+	}
+	if !strings.Contains(sanitised.Error(), "[REDACTED]") {
+		t.Errorf("sanitised error missing [REDACTED]: %q", sanitised)
+	}
+
+	// Error without token should pass through unchanged.
+	normalErr := fmt.Errorf("connection refused")
+	result := sanitiseGoError(normalErr)
+	if result.Error() != "connection refused" {
+		t.Errorf("sanitiseGoError() changed a clean error: %q", result)
+	}
+}
+
+func TestValidateFolderIDInConfigure(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-id",
+		"oauth2_client_secret": "test-secret",
+		"access_token":         "test-token",
+		"folder_id":            "' or name contains '",
+	})
+	// Configure itself does not validate folder ID -- buildFileQuery does.
+	if err != nil {
+		t.Fatalf("Configure() should not fail on folder ID: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr == nil {
+		t.Fatal("FetchAll() with injected folder ID should fail")
+	}
+	if !strings.Contains(fetchErr.Error(), "invalid folder ID") {
+		t.Errorf("error = %q, want containing 'invalid folder ID'", fetchErr)
+	}
+}
+
 // statefulMockHTTPClient allows per-request response customisation.
 type statefulMockHTTPClient struct {
 	inner   *mockHTTPClient
@@ -862,4 +1197,248 @@ type statefulMockHTTPClient struct {
 
 func (s *statefulMockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return s.handler(req)
+}
+
+// mockTokenExchanger implements TokenExchanger for testing.
+type mockTokenExchanger struct {
+	refreshFn  func(ctx context.Context, refreshToken string) (OAuth2Token, error)
+	exchangeFn func(ctx context.Context, code string) (OAuth2Token, error)
+}
+
+func (m *mockTokenExchanger) Exchange(ctx context.Context, code string) (OAuth2Token, error) {
+	if m.exchangeFn != nil {
+		return m.exchangeFn(ctx, code)
+	}
+	return OAuth2Token{}, fmt.Errorf("exchange not implemented")
+}
+
+func (m *mockTokenExchanger) Refresh(ctx context.Context, refreshToken string) (OAuth2Token, error) {
+	if m.refreshFn != nil {
+		return m.refreshFn(ctx, refreshToken)
+	}
+	return OAuth2Token{}, fmt.Errorf("refresh not implemented")
+}
+
+func TestGDriveConnector_TokenRefreshOnExpiry(t *testing.T) {
+	refreshCalled := false
+	exchanger := &mockTokenExchanger{
+		refreshFn: func(_ context.Context, rt string) (OAuth2Token, error) {
+			refreshCalled = true
+			if rt != "test-refresh-token" {
+				t.Errorf("unexpected refresh token: %s", rt)
+			}
+			return OAuth2Token{
+				AccessToken:  "refreshed-access-token",
+				RefreshToken: "test-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+				TokenType:    "Bearer",
+			}, nil
+		},
+	}
+
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "expired-access-token",
+		"refresh_token":        "test-refresh-token",
+		"token_expires_at":     time.Now().Add(-time.Hour).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr != nil {
+		t.Fatalf("FetchAll() error: %v", fetchErr)
+	}
+
+	if !refreshCalled {
+		t.Error("expected refresh to be called for expired token")
+	}
+
+	// Verify the refreshed token was used in the request.
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	authHeader := client.requests[0].Header.Get("Authorization")
+	if authHeader != "Bearer refreshed-access-token" {
+		t.Errorf("Authorization header = %q, want %q", authHeader, "Bearer refreshed-access-token")
+	}
+}
+
+func TestGDriveConnector_TokenRefreshFailurePropagates(t *testing.T) {
+	exchanger := &mockTokenExchanger{
+		refreshFn: func(_ context.Context, _ string) (OAuth2Token, error) {
+			return OAuth2Token{}, fmt.Errorf("invalid_grant: token revoked")
+		},
+	}
+
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "expired-access-token",
+		"refresh_token":        "revoked-refresh-token",
+		"token_expires_at":     time.Now().Add(-time.Hour).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr == nil {
+		t.Fatal("expected error when token refresh fails")
+	}
+	if !strings.Contains(fetchErr.Error(), "token refresh failed") {
+		t.Errorf("error = %q, want containing 'token refresh failed'", fetchErr)
+	}
+}
+
+func TestGDriveConnector_NoRefreshWhenTokenValid(t *testing.T) {
+	refreshCalled := false
+	exchanger := &mockTokenExchanger{
+		refreshFn: func(_ context.Context, _ string) (OAuth2Token, error) {
+			refreshCalled = true
+			return OAuth2Token{}, fmt.Errorf("should not be called")
+		},
+	}
+
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "valid-access-token",
+		"refresh_token":        "test-refresh-token",
+		"token_expires_at":     time.Now().Add(time.Hour).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr != nil {
+		t.Fatalf("FetchAll() error: %v", fetchErr)
+	}
+
+	if refreshCalled {
+		t.Error("refresh should not be called for valid token")
+	}
+}
+
+func TestGDriveConnector_RefreshWithinBuffer(t *testing.T) {
+	refreshCalled := false
+	exchanger := &mockTokenExchanger{
+		refreshFn: func(_ context.Context, _ string) (OAuth2Token, error) {
+			refreshCalled = true
+			return OAuth2Token{
+				AccessToken:  "refreshed-token",
+				RefreshToken: "test-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+				TokenType:    "Bearer",
+			}, nil
+		},
+	}
+
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	// Token expires in 3 minutes -- within the 5-minute buffer.
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "expiring-access-token",
+		"refresh_token":        "test-refresh-token",
+		"token_expires_at":     time.Now().Add(3 * time.Minute).Format(time.RFC3339),
+		"token_exchanger":      exchanger,
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr != nil {
+		t.Fatalf("FetchAll() error: %v", fetchErr)
+	}
+
+	if !refreshCalled {
+		t.Error("expected refresh to be called for token within expiry buffer")
+	}
+}
+
+func TestGDriveConnector_StaticTokenNoRefresh(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	// No refresh_token -> no OAuth2Client -> no refresh happens.
+	err := c.Configure(map[string]any{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "static-token",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, fetchErr := collectDocuments(docCh, errCh)
+	if fetchErr != nil {
+		t.Fatalf("FetchAll() error: %v", fetchErr)
+	}
+
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	authHeader := client.requests[0].Header.Get("Authorization")
+	if authHeader != "Bearer static-token" {
+		t.Errorf("Authorization header = %q, want %q", authHeader, "Bearer static-token")
+	}
+}
+
+func TestGDriveConnector_Health(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	// Before configuration.
+	health := c.Health()
+	if health.Status != StatusDisconnected {
+		t.Errorf("Health().Status = %q, want %q", health.Status, StatusDisconnected)
+	}
+
+	// After configuration.
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+	health = c.Health()
+	if health.Status != StatusConnected {
+		t.Errorf("Health().Status = %q, want %q", health.Status, StatusConnected)
+	}
+	if health.RateLimitRemaining != -1 {
+		t.Errorf("Health().RateLimitRemaining = %d, want -1", health.RateLimitRemaining)
+	}
 }

--- a/go/connector/gdrive_test.go
+++ b/go/connector/gdrive_test.go
@@ -1,0 +1,865 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockHTTPClient implements HTTPClient for testing with configurable
+// responses keyed by request URL substring.
+type mockHTTPClient struct {
+	responses map[string]*http.Response
+	requests  []*http.Request
+}
+
+func newMockHTTPClient() *mockHTTPClient {
+	return &mockHTTPClient{
+		responses: make(map[string]*http.Response),
+	}
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+
+	for pattern, resp := range m.responses {
+		if strings.Contains(req.URL.String(), pattern) {
+			return resp, nil
+		}
+	}
+	return &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"not found"}}`)),
+	}, nil
+}
+
+func (m *mockHTTPClient) addResponse(urlPattern string, statusCode int, body string) {
+	m.responses[urlPattern] = &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{},
+	}
+}
+
+func (m *mockHTTPClient) addJSONResponse(urlPattern string, statusCode int, payload any) {
+	data, _ := json.Marshal(payload)
+	m.responses[urlPattern] = &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(bytes.NewReader(data)),
+		Header:     http.Header{},
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestConnector(client *mockHTTPClient) *GDriveConnector {
+	deps := ConnectorConfig{
+		Name:    "gdrive",
+		BrainID: "test-brain",
+	}
+	return NewGDriveConnector(deps, testLogger(), client)
+}
+
+func configureTestConnector(c *GDriveConnector) error {
+	return c.Configure(map[string]string{
+		"oauth2_client_id":     "test-client-id",
+		"oauth2_client_secret": "test-client-secret",
+		"access_token":         "test-access-token",
+	})
+}
+
+func collectDocuments(docCh <-chan ConnectorDocument, errCh <-chan error) ([]ConnectorDocument, error) {
+	var docs []ConnectorDocument
+	for doc := range docCh {
+		docs = append(docs, doc)
+	}
+	if err, ok := <-errCh; ok && err != nil {
+		return docs, err
+	}
+	return docs, nil
+}
+
+func TestGDriveConnector_Name(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if got := c.Name(); got != "gdrive" {
+		t.Fatalf("Name() = %q, want %q", got, "gdrive")
+	}
+}
+
+func TestGDriveConnector_Configure(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  map[string]string
+		wantErr string
+	}{
+		{
+			name: "valid configuration",
+			config: map[string]string{
+				"oauth2_client_id":     "client-123",
+				"oauth2_client_secret": "secret-456",
+			},
+		},
+		{
+			name: "missing client ID",
+			config: map[string]string{
+				"oauth2_client_secret": "secret-456",
+			},
+			wantErr: "oauth2_client_id is required",
+		},
+		{
+			name: "empty client ID",
+			config: map[string]string{
+				"oauth2_client_id":     "",
+				"oauth2_client_secret": "secret-456",
+			},
+			wantErr: "oauth2_client_id is required",
+		},
+		{
+			name: "missing client secret",
+			config: map[string]string{
+				"oauth2_client_id": "client-123",
+			},
+			wantErr: "oauth2_client_secret is required",
+		},
+		{
+			name: "with folder ID",
+			config: map[string]string{
+				"oauth2_client_id":     "client-123",
+				"oauth2_client_secret": "secret-456",
+				"folder_id":            "folder-789",
+			},
+		},
+		{
+			name: "with MIME type filter",
+			config: map[string]string{
+				"oauth2_client_id":     "client-123",
+				"oauth2_client_secret": "secret-456",
+				"mime_type_filter":     "application/pdf,text/plain",
+			},
+		},
+		{
+			name: "with shared drives",
+			config: map[string]string{
+				"oauth2_client_id":      "client-123",
+				"oauth2_client_secret":  "secret-456",
+				"include_shared_drives": "true",
+			},
+		},
+		{
+			name: "invalid max file size",
+			config: map[string]string{
+				"oauth2_client_id":     "client-123",
+				"oauth2_client_secret": "secret-456",
+				"max_file_size":        "not-a-number",
+			},
+			wantErr: "invalid max_file_size",
+		},
+		{
+			name: "custom max file size",
+			config: map[string]string{
+				"oauth2_client_id":     "client-123",
+				"oauth2_client_secret": "secret-456",
+				"max_file_size":        "1048576",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newMockHTTPClient()
+			c := newTestConnector(client)
+			err := c.Configure(tc.config)
+
+			switch {
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("Configure() succeeded, want error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Fatalf("Configure() error = %q, want containing %q", err, tc.wantErr)
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("Configure() failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestGDriveConnector_FetchAll_ListsFilesInFolder(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "f1", Name: "doc1.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-15T10:00:00Z", Size: "100"},
+			{ID: "f2", Name: "doc2.pdf", MIMEType: "application/pdf", ModifiedTime: "2026-01-16T10:00:00Z", Size: "200"},
+			{ID: "f3", Name: "image.png", MIMEType: "image/png", ModifiedTime: "2026-01-17T10:00:00Z", Size: "300"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	// Mock download responses for each file.
+	client.addResponse("f1?alt=media", http.StatusOK, "file one content")
+	client.addResponse("f2?alt=media", http.StatusOK, "file two content")
+	client.addResponse("f3?alt=media", http.StatusOK, "file three content")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 3 {
+		t.Fatalf("FetchAll() yielded %d documents, want 3", len(docs))
+	}
+
+	if docs[0].ExternalID != "f1" {
+		t.Errorf("docs[0].ExternalID = %q, want %q", docs[0].ExternalID, "f1")
+	}
+	if docs[0].Title != "doc1.txt" {
+		t.Errorf("docs[0].Title = %q, want %q", docs[0].Title, "doc1.txt")
+	}
+}
+
+func TestGDriveConnector_FetchAll_PaginatedFileListing(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	// First page returns a next page token.
+	page1 := driveListResponse{
+		NextPageToken: "page2token",
+		Files: []driveFile{
+			{ID: "f1", Name: "doc1.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-15T10:00:00Z", Size: "100"},
+		},
+	}
+	// Second page has no next token (final page).
+	page2 := driveListResponse{
+		Files: []driveFile{
+			{ID: "f2", Name: "doc2.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-16T10:00:00Z", Size: "200"},
+		},
+	}
+
+	// Use a stateful mock to return different pages.
+	callCount := 0
+	client.responses = nil
+	originalClient := client
+	statefulClient := &statefulMockHTTPClient{
+		inner: originalClient,
+		handler: func(req *http.Request) (*http.Response, error) {
+			originalClient.requests = append(originalClient.requests, req)
+			if strings.Contains(req.URL.String(), "drive/v3/files") {
+				callCount++
+				var data []byte
+				switch {
+				case callCount == 1:
+					data, _ = json.Marshal(page1)
+				default:
+					data, _ = json.Marshal(page2)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader(data)),
+					Header:     http.Header{},
+				}, nil
+			}
+			// Download responses.
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("content")),
+				Header:     http.Header{},
+			}, nil
+		},
+	}
+	c.httpClient = statefulClient
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 2 {
+		t.Fatalf("FetchAll() yielded %d documents, want 2", len(docs))
+	}
+}
+
+func TestGDriveConnector_FetchAll_ExportGoogleDocAsMarkdown(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "doc1", Name: "My Document", MIMEType: mimeGoogleDoc, ModifiedTime: "2026-01-15T10:00:00Z"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	client.addResponse("doc1/export", http.StatusOK, "# My Document\n\nHello world")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+
+	if docs[0].MIME != mimeTextMarkdown {
+		t.Errorf("docs[0].MIME = %q, want %q", docs[0].MIME, mimeTextMarkdown)
+	}
+
+	if string(docs[0].Content) != "# My Document\n\nHello world" {
+		t.Errorf("docs[0].Content = %q, want markdown content", string(docs[0].Content))
+	}
+}
+
+func TestGDriveConnector_FetchAll_ExportGoogleSheetAsCSV(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "sheet1", Name: "Budget", MIMEType: mimeGoogleSheet, ModifiedTime: "2026-01-15T10:00:00Z"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	client.addResponse("sheet1/export", http.StatusOK, "Name,Amount\nRent,1500\nFood,500")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+
+	if docs[0].MIME != mimeTextCSV {
+		t.Errorf("docs[0].MIME = %q, want %q", docs[0].MIME, mimeTextCSV)
+	}
+}
+
+func TestGDriveConnector_FetchAll_DirectDownloadOfPDF(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "pdf1", Name: "report.pdf", MIMEType: "application/pdf", ModifiedTime: "2026-01-15T10:00:00Z", Size: "5000"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	client.addResponse("pdf1?alt=media", http.StatusOK, "%PDF-1.4 binary content")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+
+	if docs[0].MIME != "application/pdf" {
+		t.Errorf("docs[0].MIME = %q, want %q", docs[0].MIME, "application/pdf")
+	}
+
+	if !strings.HasPrefix(string(docs[0].Content), "%PDF") {
+		t.Errorf("docs[0].Content does not start with %%PDF")
+	}
+}
+
+func TestGDriveConnector_FetchSince_IncrementalSync(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	changesResp := driveChangesResponse{
+		NewStartPageToken: "new-token-abc",
+		Changes: []driveChange{
+			{
+				FileID: "f1",
+				File: &driveFile{
+					ID: "f1", Name: "updated.txt", MIMEType: "text/plain",
+					ModifiedTime: "2026-01-20T10:00:00Z", Size: "150",
+				},
+			},
+			{
+				FileID:  "f2",
+				Removed: true,
+			},
+		},
+	}
+	client.addJSONResponse("drive/v3/changes?", http.StatusOK, changesResp)
+	client.addResponse("f1?alt=media", http.StatusOK, "updated content")
+
+	cursor := SyncCursor{
+		Value:     "old-token-xyz",
+		UpdatedAt: time.Now(),
+	}
+
+	docCh, errCh := c.FetchSince(context.Background(), cursor)
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchSince() error: %v", err)
+	}
+
+	// Expect 3 documents: 1 modified, 1 deleted, 1 cursor update.
+	if len(docs) != 3 {
+		t.Fatalf("FetchSince() yielded %d documents, want 3", len(docs))
+	}
+
+	// First: modified file.
+	if docs[0].ExternalID != "f1" {
+		t.Errorf("docs[0].ExternalID = %q, want %q", docs[0].ExternalID, "f1")
+	}
+	if docs[0].Deleted {
+		t.Errorf("docs[0].Deleted = true, want false")
+	}
+
+	// Second: deleted file.
+	if docs[1].ExternalID != "f2" {
+		t.Errorf("docs[1].ExternalID = %q, want %q", docs[1].ExternalID, "f2")
+	}
+	if !docs[1].Deleted {
+		t.Errorf("docs[1].Deleted = false, want true")
+	}
+
+	// Third: cursor update.
+	if docs[2].ExternalID != "__cursor_update__" {
+		t.Errorf("docs[2].ExternalID = %q, want %q", docs[2].ExternalID, "__cursor_update__")
+	}
+	if docs[2].Metadata["new_start_page_token"] != "new-token-abc" {
+		t.Errorf("cursor token = %q, want %q", docs[2].Metadata["new_start_page_token"], "new-token-abc")
+	}
+}
+
+func TestGDriveConnector_FetchSince_CursorUpdated(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	changesResp := driveChangesResponse{
+		NewStartPageToken: "updated-cursor-token",
+		Changes:           []driveChange{},
+	}
+	client.addJSONResponse("drive/v3/changes?", http.StatusOK, changesResp)
+
+	cursor := SyncCursor{Value: "initial-token", UpdatedAt: time.Now()}
+	docCh, errCh := c.FetchSince(context.Background(), cursor)
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchSince() error: %v", err)
+	}
+
+	// Should have just the cursor update document.
+	if len(docs) != 1 {
+		t.Fatalf("FetchSince() yielded %d documents, want 1", len(docs))
+	}
+	if docs[0].Metadata["new_start_page_token"] != "updated-cursor-token" {
+		t.Errorf("cursor = %q, want %q", docs[0].Metadata["new_start_page_token"], "updated-cursor-token")
+	}
+}
+
+func TestGDriveConnector_FetchAll_FileTooLargeSkipped(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]string{
+		"oauth2_client_id":     "test-id",
+		"oauth2_client_secret": "test-secret",
+		"access_token":         "test-token",
+		"max_file_size":        "100",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{
+		Files: []driveFile{
+			{ID: "small", Name: "small.txt", MIMEType: "text/plain", ModifiedTime: "2026-01-15T10:00:00Z", Size: "50"},
+			{ID: "large", Name: "large.bin", MIMEType: "application/octet-stream", ModifiedTime: "2026-01-15T10:00:00Z", Size: "500"},
+		},
+	}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	client.addResponse("small?alt=media", http.StatusOK, "small content")
+
+	docCh, errCh := c.FetchAll(context.Background())
+	docs, err := collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	// Only the small file should be included.
+	if len(docs) != 1 {
+		t.Fatalf("FetchAll() yielded %d documents, want 1", len(docs))
+	}
+	if docs[0].ExternalID != "small" {
+		t.Errorf("docs[0].ExternalID = %q, want %q", docs[0].ExternalID, "small")
+	}
+}
+
+func TestGDriveConnector_FetchAll_RateLimit403Handling(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	rateLimitBody := `{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}`
+	client.addResponse("drive/v3/files?", http.StatusForbidden, rateLimitBody)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err := collectDocuments(docCh, errCh)
+
+	if err == nil {
+		t.Fatal("FetchAll() succeeded, want rate limit error")
+	}
+	if !strings.Contains(err.Error(), "rate limit exceeded") {
+		t.Errorf("error = %q, want containing %q", err, "rate limit exceeded")
+	}
+}
+
+func TestGDriveConnector_FetchAll_FolderIDFiltering(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]string{
+		"oauth2_client_id":     "test-id",
+		"oauth2_client_secret": "test-secret",
+		"access_token":         "test-token",
+		"folder_id":            "folder-abc",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err = collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	// Verify the request includes the folder filter in the query.
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	// The statefulMockHTTPClient won't record here; check the mock's requests.
+	reqURL := client.requests[0].URL.String()
+	if !strings.Contains(reqURL, "folder-abc") {
+		t.Errorf("request URL %q does not contain folder ID filter", reqURL)
+	}
+}
+
+func TestGDriveConnector_FetchAll_MIMETypeFiltering(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]string{
+		"oauth2_client_id":     "test-id",
+		"oauth2_client_secret": "test-secret",
+		"access_token":         "test-token",
+		"mime_type_filter":     "application/pdf",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err = collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	reqURL := client.requests[0].URL.String()
+	if !strings.Contains(reqURL, "application%2Fpdf") && !strings.Contains(reqURL, "application/pdf") {
+		t.Errorf("request URL %q does not contain MIME type filter", reqURL)
+	}
+}
+
+func TestGDriveConnector_FetchAll_SharedDriveInclusion(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	err := c.Configure(map[string]string{
+		"oauth2_client_id":      "test-id",
+		"oauth2_client_secret":  "test-secret",
+		"access_token":          "test-token",
+		"include_shared_drives": "true",
+	})
+	if err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	listResp := driveListResponse{Files: []driveFile{}}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err = collectDocuments(docCh, errCh)
+	if err != nil {
+		t.Fatalf("FetchAll() error: %v", err)
+	}
+
+	if len(client.requests) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	reqURL := client.requests[0].URL.String()
+	if !strings.Contains(reqURL, "supportsAllDrives=true") {
+		t.Errorf("request URL %q does not contain supportsAllDrives=true", reqURL)
+	}
+}
+
+func TestGDriveConnector_FetchAll_NotConfigured(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+
+	docCh, errCh := c.FetchAll(context.Background())
+	_, err := collectDocuments(docCh, errCh)
+	if err == nil {
+		t.Fatal("FetchAll() succeeded without Configure(), want error")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("error = %q, want containing %q", err, "not configured")
+	}
+}
+
+func TestGDriveConnector_FetchAll_ContextCancellation(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	// Create a large list to ensure we hit context cancellation mid-stream.
+	files := make([]driveFile, 50)
+	for i := range files {
+		files[i] = driveFile{
+			ID:           fmt.Sprintf("f%d", i),
+			Name:         fmt.Sprintf("doc%d.txt", i),
+			MIMEType:     "text/plain",
+			ModifiedTime: "2026-01-15T10:00:00Z",
+			Size:         "100",
+		}
+	}
+	listResp := driveListResponse{Files: files}
+	client.addJSONResponse("drive/v3/files?", http.StatusOK, listResp)
+	for i := range files {
+		client.addResponse(fmt.Sprintf("f%d?alt=media", i), http.StatusOK, "content")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	docCh, errCh := c.FetchAll(ctx)
+	_, err := collectDocuments(docCh, errCh)
+
+	// Should get a context cancellation error or empty results.
+	if err != nil && !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGDriveConnector_GetStartPageToken(t *testing.T) {
+	client := newMockHTTPClient()
+	c := newTestConnector(client)
+	if err := configureTestConnector(c); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	client.addJSONResponse("changes/startPageToken", http.StatusOK,
+		driveStartPageTokenResponse{StartPageToken: "token-12345"})
+
+	token, err := c.GetStartPageToken(context.Background())
+	if err != nil {
+		t.Fatalf("GetStartPageToken() error: %v", err)
+	}
+	if token != "token-12345" {
+		t.Errorf("token = %q, want %q", token, "token-12345")
+	}
+}
+
+func TestGDriveConnector_BuildFileQuery(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   GDriveConfig
+		contains []string
+		excludes []string
+	}{
+		{
+			name:   "no filters",
+			config: GDriveConfig{},
+			contains: []string{
+				"mimeType != 'application/vnd.google-apps.folder'",
+				"trashed = false",
+			},
+		},
+		{
+			name:   "with folder ID",
+			config: GDriveConfig{FolderID: "folder-abc"},
+			contains: []string{
+				"'folder-abc' in parents",
+			},
+		},
+		{
+			name:   "with MIME type filter",
+			config: GDriveConfig{MIMETypeFilter: []string{"application/pdf", "text/plain"}},
+			contains: []string{
+				"mimeType = 'application/pdf'",
+				"mimeType = 'text/plain'",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newMockHTTPClient()
+			c := newTestConnector(client)
+			c.config = tc.config
+			query := c.buildFileQuery()
+
+			for _, s := range tc.contains {
+				if !strings.Contains(query, s) {
+					t.Errorf("query %q does not contain %q", query, s)
+				}
+			}
+			for _, s := range tc.excludes {
+				if strings.Contains(query, s) {
+					t.Errorf("query %q should not contain %q", query, s)
+				}
+			}
+		})
+	}
+}
+
+func TestIsGoogleNativeFormat(t *testing.T) {
+	cases := []struct {
+		mime string
+		want bool
+	}{
+		{mimeGoogleDoc, true},
+		{mimeGoogleSheet, true},
+		{mimeGoogleSlides, true},
+		{mimeGoogleDrawing, true},
+		{"application/pdf", false},
+		{"text/plain", false},
+		{mimeGoogleFolder, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.mime, func(t *testing.T) {
+			if got := isGoogleNativeFormat(tc.mime); got != tc.want {
+				t.Errorf("isGoogleNativeFormat(%q) = %v, want %v", tc.mime, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseFileSize(t *testing.T) {
+	cases := []struct {
+		input string
+		want  int64
+	}{
+		{"", 0},
+		{"0", 0},
+		{"100", 100},
+		{"1048576", 1048576},
+		{"not-a-number", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
+			if got := parseFileSize(tc.input); got != tc.want {
+				t.Errorf("parseFileSize(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildFileMetadata(t *testing.T) {
+	f := &driveFile{
+		ID:       "file-123",
+		MIMEType: "text/plain",
+		Parents:  []string{"parent-456"},
+		Size:     "1024",
+	}
+
+	meta := buildFileMetadata(f)
+	if meta["source"] != "gdrive" {
+		t.Errorf("source = %q, want %q", meta["source"], "gdrive")
+	}
+	if meta["file_id"] != "file-123" {
+		t.Errorf("file_id = %q, want %q", meta["file_id"], "file-123")
+	}
+	if meta["parent_id"] != "parent-456" {
+		t.Errorf("parent_id = %q, want %q", meta["parent_id"], "parent-456")
+	}
+	if meta["size"] != "1024" {
+		t.Errorf("size = %q, want %q", meta["size"], "1024")
+	}
+}
+
+func TestTruncateBody(t *testing.T) {
+	short := "short body"
+	if got := truncateBody([]byte(short)); got != short {
+		t.Errorf("truncateBody(%q) = %q, want %q", short, got, short)
+	}
+
+	long := strings.Repeat("x", 300)
+	got := truncateBody([]byte(long))
+	if len(got) > 210 {
+		t.Errorf("truncateBody() returned %d chars, want <= 210", len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("truncateBody() = %q, want suffix %q", got, "...")
+	}
+}
+
+// statefulMockHTTPClient allows per-request response customisation.
+type statefulMockHTTPClient struct {
+	inner   *mockHTTPClient
+	handler func(req *http.Request) (*http.Response, error)
+}
+
+func (s *statefulMockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return s.handler(req)
+}

--- a/sdks/ts/memory/src/connector/gdrive-helpers.ts
+++ b/sdks/ts/memory/src/connector/gdrive-helpers.ts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure helper functions for the Google Drive connector. Extracted to
+ * keep the main connector file under the 700-line limit.
+ */
+
+import type { GDriveConnectorConfig } from './gdrive.js'
+
+// -- Constants ----------------------------------------------------------------
+
+/** Maximum response body length for error message truncation. */
+const MAX_ERROR_BODY_LENGTH = 200
+
+/** Maximum number of retry attempts on rate-limit errors. */
+export const RATE_LIMIT_MAX_RETRIES = 5
+
+/** Base backoff duration in milliseconds for rate-limit retries. */
+export const RATE_LIMIT_BASE_BACKOFF_MS = 1_000
+
+/** Maximum backoff duration in milliseconds for rate-limit retries. */
+export const RATE_LIMIT_MAX_BACKOFF_MS = 60_000
+
+/** Pattern that valid Google Drive folder IDs must match. */
+const FOLDER_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+/** Pattern that valid MIME types must match. */
+const MIME_TYPE_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9!#$&\-.^_+]+\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-.^_+]+$/
+
+const MIME_GOOGLE_FOLDER = 'application/vnd.google-apps.folder'
+
+// -- Types --------------------------------------------------------------------
+
+type DriveAPIError = {
+  readonly error: {
+    readonly message: string
+    readonly errors?: readonly { readonly reason: string }[] | undefined
+  }
+}
+
+type DriveFile = {
+  readonly id: string
+  readonly name: string
+  readonly mimeType: string
+  readonly modifiedTime: string
+  readonly size?: string | undefined
+  readonly parents?: readonly string[] | undefined
+  readonly webViewLink?: string | undefined
+}
+
+export type RateLimitParseResult = {
+  readonly isRateLimit: boolean
+  readonly message: string
+}
+
+// -- Functions ----------------------------------------------------------------
+
+export const parseFileSize = (sizeStr: string | undefined): number => {
+  if (sizeStr === undefined || sizeStr === '') return 0
+  const parsed = Number(sizeStr)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+export const buildFileQuery = (cfg: GDriveConnectorConfig): string => {
+  const parts: string[] = []
+
+  parts.push(`mimeType != '${MIME_GOOGLE_FOLDER}'`)
+
+  if (cfg.folderId) {
+    validateFolderId(cfg.folderId)
+    parts.push(`'${cfg.folderId}' in parents`)
+  }
+
+  if (cfg.mimeTypeFilter !== undefined && cfg.mimeTypeFilter.length > 0) {
+    const mimeConditions = cfg.mimeTypeFilter.map((mime) => {
+      validateMimeType(mime)
+      return `mimeType = '${mime}'`
+    })
+    parts.push(`(${mimeConditions.join(' or ')})`)
+  }
+
+  parts.push('trashed = false')
+
+  return parts.join(' and ')
+}
+
+/**
+ * Validate that a folder ID matches the expected pattern to prevent
+ * query injection via the Drive API query string.
+ */
+const validateFolderId = (folderId: string): void => {
+  if (!FOLDER_ID_PATTERN.test(folderId)) {
+    throw new Error(`gdrive: invalid folder ID "${folderId}" — must be alphanumeric with hyphens/underscores`)
+  }
+}
+
+/**
+ * Validate that a MIME type matches the expected format to prevent
+ * query injection via the Drive API query string.
+ */
+const validateMimeType = (mimeType: string): void => {
+  if (!MIME_TYPE_PATTERN.test(mimeType)) {
+    throw new Error(`gdrive: invalid MIME type "${mimeType}"`)
+  }
+}
+
+export const buildFileMetadata = (file: DriveFile): Readonly<Record<string, string>> => {
+  const meta: Record<string, string> = {
+    source: 'gdrive',
+    mime_type: file.mimeType,
+    file_id: file.id,
+  }
+  if (file.parents !== undefined && file.parents.length > 0) {
+    const firstParent = file.parents[0]
+    if (firstParent !== undefined) {
+      meta['parent_id'] = firstParent
+    }
+  }
+  if (file.size !== undefined && file.size !== '') {
+    meta['size'] = file.size
+  }
+  return meta
+}
+
+export const truncateBody = (body: string): string => {
+  if (body.length <= MAX_ERROR_BODY_LENGTH) return body
+  return body.slice(0, MAX_ERROR_BODY_LENGTH) + '...'
+}
+
+/**
+ * Parse a rate limit error response body and determine whether it is
+ * a retryable rate limit error.
+ */
+export const parseRateLimitError = (body: string, statusCode: number): RateLimitParseResult => {
+  try {
+    const apiErr = JSON.parse(body) as DriveAPIError
+    const reasons = apiErr.error.errors ?? []
+
+    const rateLimitReasons: ReadonlySet<string> = new Set([
+      'rateLimitExceeded',
+      'userRateLimitExceeded',
+    ])
+
+    for (const entry of reasons) {
+      if (rateLimitReasons.has(entry.reason)) {
+        return {
+          isRateLimit: true,
+          message: `gdrive: rate limit exceeded: ${apiErr.error.message}`,
+        }
+      }
+    }
+
+    return {
+      isRateLimit: statusCode === 429,
+      message: `gdrive: API error (status ${statusCode}): ${apiErr.error.message}`,
+    }
+  } catch {
+    return {
+      isRateLimit: statusCode === 429,
+      message: `gdrive: rate limit error (status ${statusCode}): ${truncateBody(body)}`,
+    }
+  }
+}
+
+/**
+ * Calculate backoff duration with exponential increase and jitter.
+ * Respects the Retry-After header when present.
+ */
+export const calculateBackoff = (attempt: number, retryAfterHeader: string | null | undefined): number => {
+  if (retryAfterHeader !== null && retryAfterHeader !== undefined) {
+    const retryAfterSeconds = Number(retryAfterHeader)
+    if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds > 0) {
+      return Math.min(retryAfterSeconds * 1_000, RATE_LIMIT_MAX_BACKOFF_MS)
+    }
+  }
+
+  const exponential = RATE_LIMIT_BASE_BACKOFF_MS * Math.pow(2, attempt)
+  const jitter = Math.random() * RATE_LIMIT_BASE_BACKOFF_MS
+  return Math.min(exponential + jitter, RATE_LIMIT_MAX_BACKOFF_MS)
+}
+
+/**
+ * Read a response body with a size limit to prevent unbounded memory
+ * allocation. Reads incrementally and aborts if the limit is exceeded.
+ */
+export const readResponseWithLimit = async (resp: Response, maxBytes: number): Promise<string> => {
+  const reader = resp.body?.getReader()
+  if (reader === undefined) {
+    return resp.text()
+  }
+
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+  const decoder = new TextDecoder()
+
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    totalBytes += value.byteLength
+    if (totalBytes > maxBytes) {
+      reader.cancel().catch(() => {})
+      throw new Error(
+        `gdrive: response body exceeds ${maxBytes} byte limit (received ${totalBytes} bytes so far)`,
+      )
+    }
+    chunks.push(value)
+  }
+
+  const combined = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    combined.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  return decoder.decode(combined)
+}
+
+/**
+ * Strip access tokens and authorisation headers from error messages
+ * to prevent credential leakage through error wrapping.
+ */
+export const sanitiseError = (err: unknown): Error => {
+  if (!(err instanceof Error)) {
+    return new Error(`gdrive: unknown error: ${String(err)}`)
+  }
+
+  const bearerPattern = /Bearer\s+[A-Za-z0-9\-._~+/]+=*/g
+  const sanitised = err.message.replace(bearerPattern, 'Bearer [REDACTED]')
+
+  if (sanitised !== err.message) {
+    return new Error(sanitised)
+  }
+  return err
+}
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))

--- a/sdks/ts/memory/src/connector/gdrive.test.ts
+++ b/sdks/ts/memory/src/connector/gdrive.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { GDriveConnector } from './gdrive.js'
-import type { ConnectorConfig, ConnectorDocument, HTTPClient } from './types.js'
+import type { ConnectorConfig, ConnectorDocument, HTTPClient, SyncCursor } from './types.js'
 import { noopLogger } from '../llm/types.js'
 
 // -- Test helpers -------------------------------------------------------------
@@ -297,18 +297,18 @@ describe('GDriveConnector', () => {
       expect(docs[0].externalId).toBe('small')
     })
 
-    it('throws on rate limit 403', async () => {
+    it('throws on non-retryable 403', async () => {
       await connector.configure(defaultConfig())
 
       client.addResponse(
         'drive/v3/files?',
         403,
-        '{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}',
+        '{"error":{"message":"Forbidden","errors":[{"reason":"forbidden"}]}}',
       )
 
       await expect(
         collectDocuments(connector.fetchAll(makeAbortSignal())),
-      ).rejects.toThrow('rate limit exceeded')
+      ).rejects.toThrow('API error')
     })
 
     it('includes folder ID in query parameter', async () => {
@@ -383,7 +383,7 @@ describe('GDriveConnector', () => {
       })
       client.addResponse('f1?alt=media', 200, 'updated content')
 
-      const cursor: SyncCursor = { value: 'old-token-xyz', updatedAt: new Date() }
+      const cursor = { value: 'old-token-xyz', updatedAt: new Date() } satisfies SyncCursor
       const docs = await collectDocuments(connector.fetchSince(makeAbortSignal(), cursor))
 
       // Modified file + deleted file + cursor update = 3
@@ -410,7 +410,7 @@ describe('GDriveConnector', () => {
         changes: [],
       })
 
-      const cursor: SyncCursor = { value: 'initial-token', updatedAt: new Date() }
+      const cursor = { value: 'initial-token', updatedAt: new Date() } satisfies SyncCursor
       const docs = await collectDocuments(connector.fetchSince(makeAbortSignal(), cursor))
 
       expect(docs).toHaveLength(1)
@@ -489,7 +489,117 @@ describe('GDriveConnector', () => {
       expect(docs[0].metadata['size']).toBe('1024')
     })
   })
-})
 
-// Type import for the test file scope.
-type SyncCursor = { value: string; updatedAt: Date }
+  describe('fetchAll - Slides export', () => {
+    it('exports Google Slides as plain text', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'slides1', name: 'Presentation', mimeType: 'application/vnd.google-apps.presentation', modifiedTime: '2026-01-15T10:00:00Z' },
+        ],
+      })
+      client.addResponse('slides1/export', 200, 'Slide 1: Introduction\nSlide 2: Conclusion')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].mime).toBe('text/plain')
+      expect(docs[0].content).toContain('Introduction')
+    })
+  })
+
+  describe('fetchAll - export exceeds limit', () => {
+    it('throws when export exceeds 10 MB limit', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'bigdoc', name: 'Huge Document', mimeType: 'application/vnd.google-apps.document', modifiedTime: '2026-01-15T10:00:00Z' },
+        ],
+      })
+      // 10 MB + 1 byte
+      const hugeBody = 'x'.repeat(10 * 1024 * 1024 + 1)
+      client.addResponse('bigdoc/export', 200, hugeBody)
+
+      await expect(
+        collectDocuments(connector.fetchAll(makeAbortSignal())),
+      ).rejects.toThrow('exceeds')
+    })
+  })
+
+  describe('fetchAll - rate limit retry', () => {
+    it('retries on 429 and succeeds on subsequent attempt', async () => {
+      await connector.configure(defaultConfig())
+
+      let callCount = 0
+      client.fetch = async (url: string, init: RequestInit): Promise<Response> => {
+        client.requests.push({ url, init })
+
+        if (url.includes('drive/v3/files?')) {
+          callCount++
+          if (callCount === 1) {
+            return new Response(
+              '{"error":{"message":"Rate Limit","errors":[{"reason":"rateLimitExceeded"}]}}',
+              { status: 429 },
+            )
+          }
+          return new Response(
+            JSON.stringify({ files: [{ id: 'f1', name: 'doc.txt', mimeType: 'text/plain', modifiedTime: '2026-01-15T10:00:00Z', size: '50' }] }),
+            { status: 200 },
+          )
+        }
+        return new Response('content', { status: 200 })
+      }
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].externalId).toBe('f1')
+      expect(callCount).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('fetchAll - OAuth2 token used in requests', () => {
+    it('uses the set access token for API requests', async () => {
+      await connector.configure(defaultConfig())
+      connector.setAccessToken('refreshed-token-abc')
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(client.requests.length).toBeGreaterThan(0)
+      const authHeader = (client.requests[0].init.headers as Record<string, string>)['Authorization']
+      expect(authHeader).toBe('Bearer refreshed-token-abc')
+    })
+  })
+
+  describe('input validation', () => {
+    it('rejects folder ID with injection characters', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        folder_id: "' or name contains '",
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await expect(
+        collectDocuments(connector.fetchAll(makeAbortSignal())),
+      ).rejects.toThrow('invalid folder ID')
+    })
+
+    it('rejects MIME type filter with injection characters', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        mime_type_filter: "application/pdf' or mimeType = '",
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await expect(
+        collectDocuments(connector.fetchAll(makeAbortSignal())),
+      ).rejects.toThrow('invalid MIME type')
+    })
+  })
+})

--- a/sdks/ts/memory/src/connector/gdrive.test.ts
+++ b/sdks/ts/memory/src/connector/gdrive.test.ts
@@ -1,0 +1,495 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { GDriveConnector } from './gdrive.js'
+import type { ConnectorConfig, ConnectorDocument, HTTPClient } from './types.js'
+import { noopLogger } from '../llm/types.js'
+
+// -- Test helpers -------------------------------------------------------------
+
+type MockResponse = {
+  status: number
+  body: string
+}
+
+/**
+ * Mock HTTP client that returns pre-configured responses based on URL
+ * pattern matching. Tracks all requests for assertion.
+ */
+const createMockHTTPClient = (): HTTPClient & {
+  requests: { url: string; init: RequestInit }[]
+  responses: Map<string, MockResponse>
+  addResponse: (pattern: string, status: number, body: string) => void
+  addJSONResponse: (pattern: string, status: number, payload: unknown) => void
+} => {
+  const responses = new Map<string, MockResponse>()
+  const requests: { url: string; init: RequestInit }[] = []
+
+  return {
+    requests,
+    responses,
+    addResponse(pattern: string, status: number, body: string) {
+      responses.set(pattern, { status, body })
+    },
+    addJSONResponse(pattern: string, status: number, payload: unknown) {
+      responses.set(pattern, { status, body: JSON.stringify(payload) })
+    },
+    async fetch(url: string, init: RequestInit): Promise<Response> {
+      requests.push({ url, init })
+
+      for (const [pattern, resp] of responses) {
+        if (url.includes(pattern)) {
+          return new Response(resp.body, {
+            status: resp.status,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+      }
+
+      return new Response('{"error":{"message":"not found"}}', { status: 404 })
+    },
+  }
+}
+
+const createTestDeps = (): ConnectorConfig => ({
+  name: 'gdrive',
+  brainId: 'test-brain',
+  logger: noopLogger,
+  store: {} as ConnectorConfig['store'],
+})
+
+const defaultConfig = (): Record<string, string> => ({
+  oauth2_client_id: 'test-client-id',
+  oauth2_client_secret: 'test-client-secret',
+  access_token: 'test-access-token',
+})
+
+const collectDocuments = async (
+  iterable: AsyncIterable<ConnectorDocument>,
+): Promise<ConnectorDocument[]> => {
+  const docs: ConnectorDocument[] = []
+  for await (const doc of iterable) {
+    docs.push(doc)
+  }
+  return docs
+}
+
+const makeAbortSignal = (): AbortSignal => new AbortController().signal
+
+// -- Tests --------------------------------------------------------------------
+
+describe('GDriveConnector', () => {
+  let client: ReturnType<typeof createMockHTTPClient>
+  let connector: GDriveConnector
+
+  beforeEach(() => {
+    client = createMockHTTPClient()
+    connector = new GDriveConnector(createTestDeps(), client)
+  })
+
+  describe('name', () => {
+    it('returns gdrive', () => {
+      expect(connector.name).toBe('gdrive')
+    })
+  })
+
+  describe('configure', () => {
+    it('accepts valid configuration', async () => {
+      await expect(connector.configure(defaultConfig())).resolves.toBeUndefined()
+    })
+
+    it('rejects missing client ID', async () => {
+      await expect(
+        connector.configure({
+          oauth2_client_secret: 'secret',
+        }),
+      ).rejects.toThrow('oauth2_client_id is required')
+    })
+
+    it('rejects empty client ID', async () => {
+      await expect(
+        connector.configure({
+          oauth2_client_id: '',
+          oauth2_client_secret: 'secret',
+        }),
+      ).rejects.toThrow('oauth2_client_id is required')
+    })
+
+    it('rejects missing client secret', async () => {
+      await expect(
+        connector.configure({
+          oauth2_client_id: 'id',
+        }),
+      ).rejects.toThrow('oauth2_client_secret is required')
+    })
+
+    it('accepts folder ID', async () => {
+      await expect(
+        connector.configure({
+          ...defaultConfig(),
+          folder_id: 'folder-123',
+        }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('accepts MIME type filter', async () => {
+      await expect(
+        connector.configure({
+          ...defaultConfig(),
+          mime_type_filter: 'application/pdf,text/plain',
+        }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('accepts shared drives flag', async () => {
+      await expect(
+        connector.configure({
+          ...defaultConfig(),
+          include_shared_drives: 'true',
+        }),
+      ).resolves.toBeUndefined()
+    })
+
+    it('rejects invalid max file size', async () => {
+      await expect(
+        connector.configure({
+          ...defaultConfig(),
+          max_file_size: 'not-a-number',
+        }),
+      ).rejects.toThrow('invalid max_file_size')
+    })
+
+    it('accepts custom max file size', async () => {
+      await expect(
+        connector.configure({
+          ...defaultConfig(),
+          max_file_size: '1048576',
+        }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('fetchAll', () => {
+    it('lists files in folder and yields documents', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'f1', name: 'doc1.txt', mimeType: 'text/plain', modifiedTime: '2026-01-15T10:00:00Z', size: '100' },
+          { id: 'f2', name: 'doc2.pdf', mimeType: 'application/pdf', modifiedTime: '2026-01-16T10:00:00Z', size: '200' },
+          { id: 'f3', name: 'image.png', mimeType: 'image/png', modifiedTime: '2026-01-17T10:00:00Z', size: '300' },
+        ],
+      })
+      client.addResponse('f1?alt=media', 200, 'file one content')
+      client.addResponse('f2?alt=media', 200, 'file two content')
+      client.addResponse('f3?alt=media', 200, 'file three content')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(3)
+      expect(docs[0].externalId).toBe('f1')
+      expect(docs[0].title).toBe('doc1.txt')
+      expect(docs[1].externalId).toBe('f2')
+      expect(docs[2].externalId).toBe('f3')
+    })
+
+    it('handles paginated file listing', async () => {
+      await connector.configure(defaultConfig())
+
+      let callCount = 0
+      const originalFetch = client.fetch.bind(client)
+      client.fetch = async (url: string, init: RequestInit): Promise<Response> => {
+        client.requests.push({ url, init })
+        if (url.includes('drive/v3/files?')) {
+          callCount++
+          const body =
+            callCount === 1
+              ? JSON.stringify({
+                  nextPageToken: 'page2token',
+                  files: [
+                    { id: 'f1', name: 'doc1.txt', mimeType: 'text/plain', modifiedTime: '2026-01-15T10:00:00Z', size: '100' },
+                  ],
+                })
+              : JSON.stringify({
+                  files: [
+                    { id: 'f2', name: 'doc2.txt', mimeType: 'text/plain', modifiedTime: '2026-01-16T10:00:00Z', size: '200' },
+                  ],
+                })
+          return new Response(body, { status: 200 })
+        }
+        return new Response('content', { status: 200 })
+      }
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(2)
+      expect(docs[0].externalId).toBe('f1')
+      expect(docs[1].externalId).toBe('f2')
+    })
+
+    it('exports Google Doc as markdown', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'doc1', name: 'My Document', mimeType: 'application/vnd.google-apps.document', modifiedTime: '2026-01-15T10:00:00Z' },
+        ],
+      })
+      client.addResponse('doc1/export', 200, '# My Document\n\nHello world')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].mime).toBe('text/markdown')
+      expect(docs[0].content).toBe('# My Document\n\nHello world')
+    })
+
+    it('exports Google Sheet as CSV', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'sheet1', name: 'Budget', mimeType: 'application/vnd.google-apps.spreadsheet', modifiedTime: '2026-01-15T10:00:00Z' },
+        ],
+      })
+      client.addResponse('sheet1/export', 200, 'Name,Amount\nRent,1500')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].mime).toBe('text/csv')
+    })
+
+    it('directly downloads PDF files', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'pdf1', name: 'report.pdf', mimeType: 'application/pdf', modifiedTime: '2026-01-15T10:00:00Z', size: '5000' },
+        ],
+      })
+      client.addResponse('pdf1?alt=media', 200, '%PDF-1.4 binary content')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].mime).toBe('application/pdf')
+      expect(docs[0].content).toContain('%PDF')
+    })
+
+    it('skips files exceeding size limit', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        max_file_size: '100',
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          { id: 'small', name: 'small.txt', mimeType: 'text/plain', modifiedTime: '2026-01-15T10:00:00Z', size: '50' },
+          { id: 'large', name: 'large.bin', mimeType: 'application/octet-stream', modifiedTime: '2026-01-15T10:00:00Z', size: '500' },
+        ],
+      })
+      client.addResponse('small?alt=media', 200, 'small content')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].externalId).toBe('small')
+    })
+
+    it('throws on rate limit 403', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addResponse(
+        'drive/v3/files?',
+        403,
+        '{"error":{"message":"Rate Limit Exceeded","errors":[{"reason":"rateLimitExceeded"}]}}',
+      )
+
+      await expect(
+        collectDocuments(connector.fetchAll(makeAbortSignal())),
+      ).rejects.toThrow('rate limit exceeded')
+    })
+
+    it('includes folder ID in query parameter', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        folder_id: 'folder-abc',
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(client.requests.length).toBeGreaterThan(0)
+      const reqUrl = client.requests[0].url
+      expect(reqUrl).toContain('folder-abc')
+    })
+
+    it('includes MIME type filter in query', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        mime_type_filter: 'application/pdf',
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(client.requests.length).toBeGreaterThan(0)
+      const reqUrl = client.requests[0].url
+      expect(reqUrl).toContain('application%2Fpdf')
+    })
+
+    it('sets supportsAllDrives when shared drives enabled', async () => {
+      await connector.configure({
+        ...defaultConfig(),
+        include_shared_drives: 'true',
+      })
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(client.requests.length).toBeGreaterThan(0)
+      const reqUrl = client.requests[0].url
+      expect(reqUrl).toContain('supportsAllDrives=true')
+    })
+
+    it('throws when not configured', async () => {
+      await expect(
+        collectDocuments(connector.fetchAll(makeAbortSignal())),
+      ).rejects.toThrow('not configured')
+    })
+  })
+
+  describe('fetchSince', () => {
+    it('processes incremental changes with modified and deleted files', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/changes?', 200, {
+        newStartPageToken: 'new-token-abc',
+        changes: [
+          {
+            fileId: 'f1',
+            file: { id: 'f1', name: 'updated.txt', mimeType: 'text/plain', modifiedTime: '2026-01-20T10:00:00Z', size: '150' },
+            removed: false,
+          },
+          {
+            fileId: 'f2',
+            removed: true,
+          },
+        ],
+      })
+      client.addResponse('f1?alt=media', 200, 'updated content')
+
+      const cursor: SyncCursor = { value: 'old-token-xyz', updatedAt: new Date() }
+      const docs = await collectDocuments(connector.fetchSince(makeAbortSignal(), cursor))
+
+      // Modified file + deleted file + cursor update = 3
+      expect(docs).toHaveLength(3)
+
+      // First: modified file.
+      expect(docs[0].externalId).toBe('f1')
+      expect(docs[0].deleted).toBeFalsy()
+
+      // Second: deleted file.
+      expect(docs[1].externalId).toBe('f2')
+      expect(docs[1].deleted).toBe(true)
+
+      // Third: cursor update.
+      expect(docs[2].externalId).toBe('__cursor_update__')
+      expect(docs[2].metadata['new_start_page_token']).toBe('new-token-abc')
+    })
+
+    it('updates cursor after sync with no changes', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/changes?', 200, {
+        newStartPageToken: 'updated-cursor-token',
+        changes: [],
+      })
+
+      const cursor: SyncCursor = { value: 'initial-token', updatedAt: new Date() }
+      const docs = await collectDocuments(connector.fetchSince(makeAbortSignal(), cursor))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].metadata['new_start_page_token']).toBe('updated-cursor-token')
+    })
+  })
+
+  describe('getStartPageToken', () => {
+    it('retrieves the start page token', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('changes/startPageToken', 200, {
+        startPageToken: 'token-12345',
+      })
+
+      const token = await connector.getStartPageToken(makeAbortSignal())
+      expect(token).toBe('token-12345')
+    })
+  })
+
+  describe('start', () => {
+    it('throws not supported error', async () => {
+      await connector.configure(defaultConfig())
+      await expect(connector.start(makeAbortSignal())).rejects.toThrow(
+        'continuous sync not yet supported',
+      )
+    })
+  })
+
+  describe('stop', () => {
+    it('resolves without error', async () => {
+      await expect(connector.stop()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('setAccessToken', () => {
+    it('updates the access token used for requests', async () => {
+      await connector.configure(defaultConfig())
+      connector.setAccessToken('new-token-value')
+
+      client.addJSONResponse('drive/v3/files?', 200, { files: [] })
+
+      await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(client.requests.length).toBeGreaterThan(0)
+      const authHeader = (client.requests[0].init.headers as Record<string, string>)['Authorization']
+      expect(authHeader).toBe('Bearer new-token-value')
+    })
+  })
+
+  describe('metadata', () => {
+    it('includes source, file_id, mime_type, parent_id, and size', async () => {
+      await connector.configure(defaultConfig())
+
+      client.addJSONResponse('drive/v3/files?', 200, {
+        files: [
+          {
+            id: 'file-123',
+            name: 'test.txt',
+            mimeType: 'text/plain',
+            modifiedTime: '2026-01-15T10:00:00Z',
+            size: '1024',
+            parents: ['parent-456'],
+          },
+        ],
+      })
+      client.addResponse('file-123?alt=media', 200, 'content')
+
+      const docs = await collectDocuments(connector.fetchAll(makeAbortSignal()))
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].metadata['source']).toBe('gdrive')
+      expect(docs[0].metadata['file_id']).toBe('file-123')
+      expect(docs[0].metadata['mime_type']).toBe('text/plain')
+      expect(docs[0].metadata['parent_id']).toBe('parent-456')
+      expect(docs[0].metadata['size']).toBe('1024')
+    })
+  })
+})
+
+// Type import for the test file scope.
+type SyncCursor = { value: string; updatedAt: Date }

--- a/sdks/ts/memory/src/connector/gdrive.ts
+++ b/sdks/ts/memory/src/connector/gdrive.ts
@@ -14,6 +14,18 @@ import type {
   HTTPClient,
   SyncCursor,
 } from './types.js'
+import {
+  RATE_LIMIT_MAX_RETRIES,
+  buildFileMetadata,
+  buildFileQuery,
+  calculateBackoff,
+  parseFileSize,
+  parseRateLimitError,
+  readResponseWithLimit,
+  sanitiseError,
+  sleep,
+  truncateBody,
+} from './gdrive-helpers.js'
 
 // -- Google Drive API constants -----------------------------------------------
 
@@ -50,9 +62,6 @@ const HTTP_REQUEST_TIMEOUT_MS = 30_000
 
 /** Timeout for file download/export requests (5 minutes). */
 const HTTP_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000
-
-/** Maximum response body length for error message truncation. */
-const MAX_ERROR_BODY_LENGTH = 200
 
 // -- Google MIME types --------------------------------------------------------
 
@@ -172,10 +181,11 @@ export class GDriveConnector implements Connector {
 
   /**
    * Validate and store Google Drive-specific settings.
+   * Accepts Record<string, unknown> to match the P5-1 Connector interface.
    */
-  async configure(rawConfig: Record<string, string>): Promise<void> {
-    const clientId = rawConfig['oauth2_client_id'] ?? ''
-    const clientSecret = rawConfig['oauth2_client_secret'] ?? ''
+  async configure(rawConfig: Record<string, unknown>): Promise<void> {
+    const clientId = typeof rawConfig['oauth2_client_id'] === 'string' ? rawConfig['oauth2_client_id'] : ''
+    const clientSecret = typeof rawConfig['oauth2_client_secret'] === 'string' ? rawConfig['oauth2_client_secret'] : ''
 
     if (clientId === '') {
       throw new Error('gdrive: oauth2_client_id is required')
@@ -184,26 +194,39 @@ export class GDriveConnector implements Connector {
       throw new Error('gdrive: oauth2_client_secret is required')
     }
 
-    const mimeFilter = rawConfig['mime_type_filter']
-    const maxFileSize = rawConfig['max_file_size']
+    const mimeFilterRaw = rawConfig['mime_type_filter']
+    const mimeFilter = typeof mimeFilterRaw === 'string' ? mimeFilterRaw : undefined
 
+    const maxFileSizeRaw = rawConfig['max_file_size']
     let parsedMaxFileSize = DEFAULT_MAX_FILE_SIZE
-    if (maxFileSize !== undefined && maxFileSize !== '') {
-      const parsed = Number(maxFileSize)
+    if (typeof maxFileSizeRaw === 'string' && maxFileSizeRaw !== '') {
+      const parsed = Number(maxFileSizeRaw)
       if (Number.isNaN(parsed)) {
-        throw new Error(`gdrive: invalid max_file_size "${maxFileSize}"`)
+        throw new Error(`gdrive: invalid max_file_size "${maxFileSizeRaw}"`)
       }
       parsedMaxFileSize = parsed
+    } else if (typeof maxFileSizeRaw === 'number') {
+      parsedMaxFileSize = maxFileSizeRaw
     }
+
+    const redirectUri = typeof rawConfig['oauth2_redirect_uri'] === 'string' ? rawConfig['oauth2_redirect_uri'] : undefined
+    const accessToken = typeof rawConfig['access_token'] === 'string' ? rawConfig['access_token'] : undefined
+    const folderId = typeof rawConfig['folder_id'] === 'string' ? rawConfig['folder_id'] : undefined
+
+    const includeSharedRaw = rawConfig['include_shared_drives']
+    const includeSharedDrives =
+      typeof includeSharedRaw === 'boolean'
+        ? includeSharedRaw
+        : (typeof includeSharedRaw === 'string' ? includeSharedRaw === 'true' : false)
 
     const cfg: GDriveConnectorConfig = {
       oauth2ClientId: clientId,
       oauth2ClientSecret: clientSecret,
-      oauth2RedirectUri: rawConfig['oauth2_redirect_uri'],
-      accessToken: rawConfig['access_token'],
-      folderId: rawConfig['folder_id'],
+      oauth2RedirectUri: redirectUri,
+      accessToken,
+      folderId,
       mimeTypeFilter: mimeFilter ? mimeFilter.split(',') : undefined,
-      includeSharedDrives: rawConfig['include_shared_drives'] === 'true',
+      includeSharedDrives,
       maxFileSize: parsedMaxFileSize,
       exportFormats: undefined,
     }
@@ -265,13 +288,8 @@ export class GDriveConnector implements Connector {
       for (const change of resp.changes) {
         if (signal.aborted) return
 
-        const doc = this.changeToDocument(cfg, signal, change)
-        if (doc instanceof Promise) {
-          const resolved = await doc
-          if (resolved !== undefined) {
-            yield resolved
-          }
-        } else if (doc !== undefined) {
+        const doc = await this.changeToDocument(cfg, signal, change)
+        if (doc !== undefined) {
           yield doc
         }
       }
@@ -428,11 +446,11 @@ export class GDriveConnector implements Connector {
     }
   }
 
-  private changeToDocument(
+  private async changeToDocument(
     cfg: GDriveConnectorConfig,
     signal: AbortSignal,
     change: DriveChange,
-  ): ConnectorDocument | Promise<ConnectorDocument | undefined> {
+  ): Promise<ConnectorDocument | undefined> {
     if (change.removed || change.file === undefined) {
       return {
         externalId: change.fileId,
@@ -469,7 +487,7 @@ export class GDriveConnector implements Connector {
     targetMime: string,
   ): Promise<{ content: string; mime: string }> {
     const exportUrl = `${DRIVE_FILES_URL}/${encodeURIComponent(fileId)}/export?mimeType=${encodeURIComponent(targetMime)}`
-    const body = await this.doAPIGet(exportUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS)
+    const body = await this.doAPIGet(exportUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS, DRIVE_EXPORT_MAX_BYTES)
 
     if (body.length > DRIVE_EXPORT_MAX_BYTES) {
       throw new Error(`gdrive: export of ${fileId} exceeds ${DRIVE_EXPORT_MAX_BYTES} byte limit`)
@@ -484,112 +502,72 @@ export class GDriveConnector implements Connector {
     mime: string,
   ): Promise<{ content: string; mime: string }> {
     const downloadUrl = `${DRIVE_FILES_URL}/${encodeURIComponent(fileId)}?alt=media`
-    const body = await this.doAPIGet(downloadUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS)
+    const maxSize = this.driveConfig?.maxFileSize ?? DEFAULT_MAX_FILE_SIZE
+    const body = await this.doAPIGet(downloadUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS, maxSize)
     return { content: body, mime }
   }
 
+  /**
+   * Perform an authenticated GET to the Google Drive API with retry,
+   * exponential backoff on rate-limit errors, and bounded reads.
+   * maxBodyBytes controls the response body size limit; defaults to 50 MB.
+   */
   private async doAPIGet(
     reqUrl: string,
     signal: AbortSignal,
     timeoutMs: number,
+    maxBodyBytes?: number,
   ): Promise<string> {
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    const maxSize = maxBodyBytes ?? DEFAULT_MAX_FILE_SIZE
 
-    // Compose abort: external signal or internal timeout.
-    const onAbort = (): void => controller.abort()
-    signal.addEventListener('abort', onAbort, { once: true })
+    for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
-    try {
-      const resp = await this.httpClient.fetch(reqUrl, {
-        method: 'GET',
-        headers: { Authorization: `Bearer ${this.accessToken}` },
-        signal: controller.signal,
-      })
+      const onAbort = (): void => controller.abort()
+      signal.addEventListener('abort', onAbort, { once: true })
 
-      const body = await resp.text()
+      try {
+        const resp = await this.httpClient.fetch(reqUrl, {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${this.accessToken}` },
+          signal: controller.signal,
+        })
 
-      if (resp.status === 403 || resp.status === 429) {
-        throw this.handleRateLimitError(body, resp.status)
-      }
+        if (resp.status === 403 || resp.status === 429) {
+          const errorBody = await resp.text()
+          const rateLimitErr = parseRateLimitError(errorBody, resp.status)
 
-      if (resp.status < 200 || resp.status >= 300) {
-        throw new Error(`gdrive: API returned status ${resp.status}: ${truncateBody(body)}`)
-      }
+          if (rateLimitErr.isRateLimit && attempt < RATE_LIMIT_MAX_RETRIES) {
+            const retryAfterHeader = resp.headers?.get?.('Retry-After')
+            const backoff = calculateBackoff(attempt, retryAfterHeader)
+            this.deps.logger.warn('gdrive: rate limited, retrying', {
+              attempt: attempt + 1,
+              maxRetries: RATE_LIMIT_MAX_RETRIES,
+              backoffMs: backoff,
+            })
+            await sleep(backoff)
+            continue
+          }
 
-      return body
-    } finally {
-      clearTimeout(timeoutId)
-      signal.removeEventListener('abort', onAbort)
-    }
-  }
-
-  private handleRateLimitError(body: string, statusCode: number): Error {
-    try {
-      const apiErr = JSON.parse(body) as DriveAPIError
-      const reasons = apiErr.error.errors ?? []
-
-      for (const entry of reasons) {
-        if (entry.reason === 'rateLimitExceeded' || entry.reason === 'userRateLimitExceeded') {
-          return new Error(`gdrive: rate limit exceeded: ${apiErr.error.message}`)
+          throw new Error(rateLimitErr.message)
         }
+
+        const body = await readResponseWithLimit(resp, maxSize)
+
+        if (resp.status < 200 || resp.status >= 300) {
+          throw new Error(`gdrive: API returned status ${resp.status}: ${truncateBody(body)}`)
+        }
+
+        return body
+      } catch (err) {
+        throw sanitiseError(err)
+      } finally {
+        clearTimeout(timeoutId)
+        signal.removeEventListener('abort', onAbort)
       }
-
-      return new Error(`gdrive: API error (status ${statusCode}): ${apiErr.error.message}`)
-    } catch {
-      return new Error(`gdrive: rate limit error (status ${statusCode}): ${truncateBody(body)}`)
     }
+
+    throw new Error('gdrive: rate limit retries exhausted')
   }
-}
-
-// -- Pure helper functions ----------------------------------------------------
-
-const parseFileSize = (sizeStr: string | undefined): number => {
-  if (sizeStr === undefined || sizeStr === '') return 0
-  const parsed = Number(sizeStr)
-  return Number.isNaN(parsed) ? 0 : parsed
-}
-
-const buildFileQuery = (cfg: GDriveConnectorConfig): string => {
-  const parts: string[] = []
-
-  parts.push(`mimeType != '${MIME_GOOGLE_FOLDER}'`)
-
-  if (cfg.folderId) {
-    parts.push(`'${cfg.folderId}' in parents`)
-  }
-
-  if (cfg.mimeTypeFilter !== undefined && cfg.mimeTypeFilter.length > 0) {
-    const mimeConditions = cfg.mimeTypeFilter.map(
-      (mime) => `mimeType = '${mime}'`,
-    )
-    parts.push(`(${mimeConditions.join(' or ')})`)
-  }
-
-  parts.push('trashed = false')
-
-  return parts.join(' and ')
-}
-
-const buildFileMetadata = (file: DriveFile): Readonly<Record<string, string>> => {
-  const meta: Record<string, string> = {
-    source: 'gdrive',
-    mime_type: file.mimeType,
-    file_id: file.id,
-  }
-  if (file.parents !== undefined && file.parents.length > 0) {
-    const firstParent = file.parents[0]
-    if (firstParent !== undefined) {
-      meta['parent_id'] = firstParent
-    }
-  }
-  if (file.size !== undefined && file.size !== '') {
-    meta['size'] = file.size
-  }
-  return meta
-}
-
-const truncateBody = (body: string): string => {
-  if (body.length <= MAX_ERROR_BODY_LENGTH) return body
-  return body.slice(0, MAX_ERROR_BODY_LENGTH) + '...'
 }

--- a/sdks/ts/memory/src/connector/gdrive.ts
+++ b/sdks/ts/memory/src/connector/gdrive.ts
@@ -1,0 +1,595 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Google Drive connector implementing the Connector interface. Supports
+ * full sync via files.list and incremental sync via the Changes API with
+ * startPageToken cursors. Google-native formats (Docs, Sheets, Slides)
+ * are exported to markdown, CSV, and plain text respectively.
+ */
+
+import type {
+  Connector,
+  ConnectorConfig,
+  ConnectorDocument,
+  HTTPClient,
+  SyncCursor,
+} from './types.js'
+
+// -- Google Drive API constants -----------------------------------------------
+
+/** Base endpoint for Drive files.list. */
+const DRIVE_FILES_URL = 'https://www.googleapis.com/drive/v3/files'
+
+/** Base endpoint for Drive changes.list. */
+const DRIVE_CHANGES_URL = 'https://www.googleapis.com/drive/v3/changes'
+
+/** Endpoint for fetching the initial changes start token. */
+const DRIVE_START_PAGE_TOKEN_URL = 'https://www.googleapis.com/drive/v3/changes/startPageToken'
+
+/** Fields requested for each file in list/changes responses. */
+const DRIVE_FILE_FIELDS = 'id,name,mimeType,modifiedTime,size,parents,webViewLink'
+
+/** Top-level response fields for files.list. */
+const DRIVE_LIST_FIELDS = `nextPageToken,files(${DRIVE_FILE_FIELDS})`
+
+/** Response fields for changes.list. */
+const DRIVE_CHANGES_FIELDS =
+  `nextPageToken,newStartPageToken,changes(fileId,removed,file(${DRIVE_FILE_FIELDS}))`
+
+/** Number of results per API page. */
+const DRIVE_DEFAULT_PAGE_SIZE = 100
+
+/** Google-imposed limit on file exports (10 MB). */
+const DRIVE_EXPORT_MAX_BYTES = 10 * 1024 * 1024
+
+/** Default maximum file size to download (50 MB). */
+const DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024
+
+/** Per-request timeout for Google API calls (30 seconds). */
+const HTTP_REQUEST_TIMEOUT_MS = 30_000
+
+/** Timeout for file download/export requests (5 minutes). */
+const HTTP_DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000
+
+/** Maximum response body length for error message truncation. */
+const MAX_ERROR_BODY_LENGTH = 200
+
+// -- Google MIME types --------------------------------------------------------
+
+const MIME_GOOGLE_DOC = 'application/vnd.google-apps.document'
+const MIME_GOOGLE_SHEET = 'application/vnd.google-apps.spreadsheet'
+const MIME_GOOGLE_SLIDES = 'application/vnd.google-apps.presentation'
+const MIME_GOOGLE_DRAWING = 'application/vnd.google-apps.drawing'
+const MIME_GOOGLE_FOLDER = 'application/vnd.google-apps.folder'
+const MIME_TEXT_MARKDOWN = 'text/markdown'
+const MIME_TEXT_PLAIN = 'text/plain'
+const MIME_TEXT_CSV = 'text/csv'
+const MIME_IMAGE_PNG = 'image/png'
+
+/** Default export format mapping for Google-native document types. */
+const DEFAULT_EXPORT_FORMATS: Readonly<Record<string, string>> = {
+  [MIME_GOOGLE_DOC]: MIME_TEXT_MARKDOWN,
+  [MIME_GOOGLE_SHEET]: MIME_TEXT_CSV,
+  [MIME_GOOGLE_SLIDES]: MIME_TEXT_PLAIN,
+  [MIME_GOOGLE_DRAWING]: MIME_IMAGE_PNG,
+}
+
+/** Set of Google-native MIME types that require export instead of download. */
+const GOOGLE_NATIVE_FORMATS: ReadonlySet<string> = new Set([
+  MIME_GOOGLE_DOC,
+  MIME_GOOGLE_SHEET,
+  MIME_GOOGLE_SLIDES,
+  MIME_GOOGLE_DRAWING,
+])
+
+// -- Drive API response types -------------------------------------------------
+
+type DriveFile = {
+  readonly id: string
+  readonly name: string
+  readonly mimeType: string
+  readonly modifiedTime: string
+  readonly size?: string | undefined
+  readonly parents?: readonly string[] | undefined
+  readonly webViewLink?: string | undefined
+}
+
+type DriveChange = {
+  readonly fileId: string
+  readonly file?: DriveFile | undefined
+  readonly removed: boolean
+}
+
+type DriveListResponse = {
+  readonly nextPageToken?: string | undefined
+  readonly files: readonly DriveFile[]
+}
+
+type DriveChangesResponse = {
+  readonly nextPageToken?: string | undefined
+  readonly newStartPageToken?: string | undefined
+  readonly changes: readonly DriveChange[]
+}
+
+type DriveStartPageTokenResponse = {
+  readonly startPageToken: string
+}
+
+type DriveAPIError = {
+  readonly error: {
+    readonly message: string
+    readonly errors?: readonly { readonly reason: string }[] | undefined
+  }
+}
+
+// -- GDrive connector configuration -------------------------------------------
+
+/**
+ * Google Drive-specific connector settings. All optional fields
+ * explicitly accept undefined to satisfy exactOptionalPropertyTypes.
+ */
+export type GDriveConnectorConfig = {
+  readonly oauth2ClientId: string
+  readonly oauth2ClientSecret: string
+  readonly oauth2RedirectUri: string | undefined
+  readonly accessToken: string | undefined
+  readonly folderId: string | undefined
+  readonly mimeTypeFilter: readonly string[] | undefined
+  readonly includeSharedDrives: boolean
+  readonly maxFileSize: number
+  readonly exportFormats: Readonly<Record<string, string>> | undefined
+}
+
+// -- Implementation -----------------------------------------------------------
+
+/**
+ * Create a Google Drive connector with the given shared dependencies.
+ * Call configure() before fetching documents.
+ */
+export const createGDriveConnector = (
+  deps: ConnectorConfig,
+  httpClient: HTTPClient,
+): GDriveConnector => new GDriveConnector(deps, httpClient)
+
+/**
+ * GDriveConnector implements the Connector interface for Google Drive.
+ * It supports full sync via files.list and incremental sync via the
+ * Changes API with startPageToken cursors.
+ */
+export class GDriveConnector implements Connector {
+  readonly name = 'gdrive' as const
+
+  private readonly deps: ConnectorConfig
+  private readonly httpClient: HTTPClient
+  private driveConfig: GDriveConnectorConfig | undefined
+  private accessToken = ''
+  private exportFormats: Readonly<Record<string, string>> = DEFAULT_EXPORT_FORMATS
+
+  constructor(deps: ConnectorConfig, httpClient: HTTPClient) {
+    this.deps = deps
+    this.httpClient = httpClient
+  }
+
+  /**
+   * Validate and store Google Drive-specific settings.
+   */
+  async configure(rawConfig: Record<string, string>): Promise<void> {
+    const clientId = rawConfig['oauth2_client_id'] ?? ''
+    const clientSecret = rawConfig['oauth2_client_secret'] ?? ''
+
+    if (clientId === '') {
+      throw new Error('gdrive: oauth2_client_id is required')
+    }
+    if (clientSecret === '') {
+      throw new Error('gdrive: oauth2_client_secret is required')
+    }
+
+    const mimeFilter = rawConfig['mime_type_filter']
+    const maxFileSize = rawConfig['max_file_size']
+
+    let parsedMaxFileSize = DEFAULT_MAX_FILE_SIZE
+    if (maxFileSize !== undefined && maxFileSize !== '') {
+      const parsed = Number(maxFileSize)
+      if (Number.isNaN(parsed)) {
+        throw new Error(`gdrive: invalid max_file_size "${maxFileSize}"`)
+      }
+      parsedMaxFileSize = parsed
+    }
+
+    const cfg: GDriveConnectorConfig = {
+      oauth2ClientId: clientId,
+      oauth2ClientSecret: clientSecret,
+      oauth2RedirectUri: rawConfig['oauth2_redirect_uri'],
+      accessToken: rawConfig['access_token'],
+      folderId: rawConfig['folder_id'],
+      mimeTypeFilter: mimeFilter ? mimeFilter.split(',') : undefined,
+      includeSharedDrives: rawConfig['include_shared_drives'] === 'true',
+      maxFileSize: parsedMaxFileSize,
+      exportFormats: undefined,
+    }
+
+    this.driveConfig = cfg
+
+    if (cfg.accessToken !== undefined) {
+      this.accessToken = cfg.accessToken
+    }
+
+    this.exportFormats = { ...DEFAULT_EXPORT_FORMATS }
+  }
+
+  /**
+   * Set the OAuth2 access token directly. Used when the caller manages
+   * token lifecycle externally.
+   */
+  setAccessToken(token: string): void {
+    this.accessToken = token
+  }
+
+  /**
+   * Perform a full sync of all files from the configured Drive scope.
+   */
+  async *fetchAll(signal: AbortSignal): AsyncIterable<ConnectorDocument> {
+    const cfg = this.getConfig()
+
+    let pageToken: string | undefined
+    do {
+      const resp = await this.listFiles(cfg, signal, pageToken)
+
+      for (const file of resp.files) {
+        if (signal.aborted) return
+
+        const doc = await this.fileToDocument(cfg, signal, file)
+        if (doc !== undefined) {
+          yield doc
+        }
+      }
+
+      pageToken = resp.nextPageToken
+    } while (pageToken)
+  }
+
+  /**
+   * Perform an incremental sync using the Drive Changes API.
+   */
+  async *fetchSince(signal: AbortSignal, cursor: SyncCursor): AsyncIterable<ConnectorDocument> {
+    const cfg = this.getConfig()
+
+    let pageToken: string | undefined = cursor.value
+    let processingChanges = true
+
+    while (processingChanges) {
+      if (signal.aborted) return
+
+      const resp: DriveChangesResponse = await this.listChanges(cfg, signal, pageToken ?? '')
+
+      for (const change of resp.changes) {
+        if (signal.aborted) return
+
+        const doc = this.changeToDocument(cfg, signal, change)
+        if (doc instanceof Promise) {
+          const resolved = await doc
+          if (resolved !== undefined) {
+            yield resolved
+          }
+        } else if (doc !== undefined) {
+          yield doc
+        }
+      }
+
+      if (resp.newStartPageToken) {
+        yield {
+          externalId: '__cursor_update__',
+          content: '',
+          mime: '',
+          title: '',
+          metadata: { new_start_page_token: resp.newStartPageToken },
+          modifiedAt: new Date(),
+        }
+        processingChanges = false
+      } else if (resp.nextPageToken) {
+        pageToken = resp.nextPageToken
+      } else {
+        processingChanges = false
+      }
+    }
+  }
+
+  /**
+   * Retrieve the current Changes API start page token. Used as the
+   * initial cursor for incremental sync.
+   */
+  async getStartPageToken(signal: AbortSignal): Promise<string> {
+    let reqUrl = DRIVE_START_PAGE_TOKEN_URL
+    if (this.driveConfig?.includeSharedDrives) {
+      reqUrl += '?supportsAllDrives=true'
+    }
+
+    const body = await this.doAPIGet(reqUrl, signal, HTTP_REQUEST_TIMEOUT_MS)
+    const resp = JSON.parse(body) as DriveStartPageTokenResponse
+    return resp.startPageToken
+  }
+
+  /**
+   * Begin a continuous sync loop. Not implemented without P5-1
+   * SyncStateManager integration.
+   */
+  async start(_signal: AbortSignal): Promise<void> {
+    throw new Error('gdrive: continuous sync not yet supported without P5-1 SyncStateManager')
+  }
+
+  /** Halt the continuous sync loop. */
+  async stop(): Promise<void> {
+    // No-op until continuous sync is implemented.
+  }
+
+  // -- Private helpers --------------------------------------------------------
+
+  /**
+   * Return the validated config or throw. Replaces the asserts-this
+   * pattern which conflicts with private properties under strict mode.
+   */
+  private getConfig(): GDriveConnectorConfig {
+    const cfg = this.driveConfig
+    if (cfg === undefined) {
+      throw new Error('gdrive: connector not configured')
+    }
+    return cfg
+  }
+
+  private async listFiles(
+    cfg: GDriveConnectorConfig,
+    signal: AbortSignal,
+    pageToken?: string | undefined,
+  ): Promise<DriveListResponse> {
+    const params = new URLSearchParams({
+      pageSize: String(DRIVE_DEFAULT_PAGE_SIZE),
+      fields: DRIVE_LIST_FIELDS,
+    })
+
+    if (pageToken) {
+      params.set('pageToken', pageToken)
+    }
+
+    const query = buildFileQuery(cfg)
+    if (query !== '') {
+      params.set('q', query)
+    }
+
+    if (cfg.includeSharedDrives) {
+      params.set('supportsAllDrives', 'true')
+      params.set('includeItemsFromAllDrives', 'true')
+    }
+
+    const body = await this.doAPIGet(
+      `${DRIVE_FILES_URL}?${params.toString()}`,
+      signal,
+      HTTP_REQUEST_TIMEOUT_MS,
+    )
+    return JSON.parse(body) as DriveListResponse
+  }
+
+  private async listChanges(
+    cfg: GDriveConnectorConfig,
+    signal: AbortSignal,
+    pageToken: string,
+  ): Promise<DriveChangesResponse> {
+    const params = new URLSearchParams({
+      pageToken,
+      pageSize: String(DRIVE_DEFAULT_PAGE_SIZE),
+      fields: DRIVE_CHANGES_FIELDS,
+    })
+
+    if (cfg.includeSharedDrives) {
+      params.set('supportsAllDrives', 'true')
+      params.set('includeItemsFromAllDrives', 'true')
+    }
+
+    const body = await this.doAPIGet(
+      `${DRIVE_CHANGES_URL}?${params.toString()}`,
+      signal,
+      HTTP_REQUEST_TIMEOUT_MS,
+    )
+    return JSON.parse(body) as DriveChangesResponse
+  }
+
+  private async fileToDocument(
+    cfg: GDriveConnectorConfig,
+    signal: AbortSignal,
+    file: DriveFile,
+  ): Promise<ConnectorDocument | undefined> {
+    if (file.mimeType === MIME_GOOGLE_FOLDER) {
+      return undefined
+    }
+
+    const fileSize = parseFileSize(file.size)
+    const maxSize = cfg.maxFileSize
+
+    if (fileSize > maxSize && !GOOGLE_NATIVE_FORMATS.has(file.mimeType)) {
+      this.deps.logger.warn('gdrive: file exceeds size limit, skipping', {
+        fileId: file.id,
+        name: file.name,
+        size: fileSize,
+        limit: maxSize,
+      })
+      return undefined
+    }
+
+    const { content, mime } = await this.downloadOrExport(signal, file)
+    const modifiedAt = new Date(file.modifiedTime)
+
+    return {
+      externalId: file.id,
+      content,
+      mime,
+      title: file.name,
+      url: file.webViewLink ?? '',
+      metadata: buildFileMetadata(file),
+      modifiedAt,
+    }
+  }
+
+  private changeToDocument(
+    cfg: GDriveConnectorConfig,
+    signal: AbortSignal,
+    change: DriveChange,
+  ): ConnectorDocument | Promise<ConnectorDocument | undefined> {
+    if (change.removed || change.file === undefined) {
+      return {
+        externalId: change.fileId,
+        content: '',
+        mime: '',
+        title: '',
+        metadata: { source: 'gdrive' },
+        modifiedAt: new Date(),
+        deleted: true,
+      }
+    }
+
+    return this.fileToDocument(cfg, signal, change.file)
+  }
+
+  private async downloadOrExport(
+    signal: AbortSignal,
+    file: DriveFile,
+  ): Promise<{ content: string; mime: string }> {
+    const exportMime = this.resolveExportFormat(file.mimeType)
+    if (exportMime !== undefined) {
+      return this.exportFile(signal, file.id, exportMime)
+    }
+    return this.downloadFile(signal, file.id, file.mimeType)
+  }
+
+  private resolveExportFormat(sourceMime: string): string | undefined {
+    return this.exportFormats[sourceMime]
+  }
+
+  private async exportFile(
+    signal: AbortSignal,
+    fileId: string,
+    targetMime: string,
+  ): Promise<{ content: string; mime: string }> {
+    const exportUrl = `${DRIVE_FILES_URL}/${encodeURIComponent(fileId)}/export?mimeType=${encodeURIComponent(targetMime)}`
+    const body = await this.doAPIGet(exportUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS)
+
+    if (body.length > DRIVE_EXPORT_MAX_BYTES) {
+      throw new Error(`gdrive: export of ${fileId} exceeds ${DRIVE_EXPORT_MAX_BYTES} byte limit`)
+    }
+
+    return { content: body, mime: targetMime }
+  }
+
+  private async downloadFile(
+    signal: AbortSignal,
+    fileId: string,
+    mime: string,
+  ): Promise<{ content: string; mime: string }> {
+    const downloadUrl = `${DRIVE_FILES_URL}/${encodeURIComponent(fileId)}?alt=media`
+    const body = await this.doAPIGet(downloadUrl, signal, HTTP_DOWNLOAD_TIMEOUT_MS)
+    return { content: body, mime }
+  }
+
+  private async doAPIGet(
+    reqUrl: string,
+    signal: AbortSignal,
+    timeoutMs: number,
+  ): Promise<string> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+    // Compose abort: external signal or internal timeout.
+    const onAbort = (): void => controller.abort()
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    try {
+      const resp = await this.httpClient.fetch(reqUrl, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${this.accessToken}` },
+        signal: controller.signal,
+      })
+
+      const body = await resp.text()
+
+      if (resp.status === 403 || resp.status === 429) {
+        throw this.handleRateLimitError(body, resp.status)
+      }
+
+      if (resp.status < 200 || resp.status >= 300) {
+        throw new Error(`gdrive: API returned status ${resp.status}: ${truncateBody(body)}`)
+      }
+
+      return body
+    } finally {
+      clearTimeout(timeoutId)
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+
+  private handleRateLimitError(body: string, statusCode: number): Error {
+    try {
+      const apiErr = JSON.parse(body) as DriveAPIError
+      const reasons = apiErr.error.errors ?? []
+
+      for (const entry of reasons) {
+        if (entry.reason === 'rateLimitExceeded' || entry.reason === 'userRateLimitExceeded') {
+          return new Error(`gdrive: rate limit exceeded: ${apiErr.error.message}`)
+        }
+      }
+
+      return new Error(`gdrive: API error (status ${statusCode}): ${apiErr.error.message}`)
+    } catch {
+      return new Error(`gdrive: rate limit error (status ${statusCode}): ${truncateBody(body)}`)
+    }
+  }
+}
+
+// -- Pure helper functions ----------------------------------------------------
+
+const parseFileSize = (sizeStr: string | undefined): number => {
+  if (sizeStr === undefined || sizeStr === '') return 0
+  const parsed = Number(sizeStr)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
+const buildFileQuery = (cfg: GDriveConnectorConfig): string => {
+  const parts: string[] = []
+
+  parts.push(`mimeType != '${MIME_GOOGLE_FOLDER}'`)
+
+  if (cfg.folderId) {
+    parts.push(`'${cfg.folderId}' in parents`)
+  }
+
+  if (cfg.mimeTypeFilter !== undefined && cfg.mimeTypeFilter.length > 0) {
+    const mimeConditions = cfg.mimeTypeFilter.map(
+      (mime) => `mimeType = '${mime}'`,
+    )
+    parts.push(`(${mimeConditions.join(' or ')})`)
+  }
+
+  parts.push('trashed = false')
+
+  return parts.join(' and ')
+}
+
+const buildFileMetadata = (file: DriveFile): Readonly<Record<string, string>> => {
+  const meta: Record<string, string> = {
+    source: 'gdrive',
+    mime_type: file.mimeType,
+    file_id: file.id,
+  }
+  if (file.parents !== undefined && file.parents.length > 0) {
+    const firstParent = file.parents[0]
+    if (firstParent !== undefined) {
+      meta['parent_id'] = firstParent
+    }
+  }
+  if (file.size !== undefined && file.size !== '') {
+    meta['size'] = file.size
+  }
+  return meta
+}
+
+const truncateBody = (body: string): string => {
+  if (body.length <= MAX_ERROR_BODY_LENGTH) return body
+  return body.slice(0, MAX_ERROR_BODY_LENGTH) + '...'
+}

--- a/sdks/ts/memory/src/connector/index.ts
+++ b/sdks/ts/memory/src/connector/index.ts
@@ -68,3 +68,6 @@ export {
   validateDownloadURL,
   readResponseWithLimit,
 } from './slack_helpers.js'
+
+export { GDriveConnector, createGDriveConnector } from './gdrive.js'
+export type { GDriveConnectorConfig } from './gdrive.js'


### PR DESCRIPTION
## What
Google Drive connector syncing files from configured folders with incremental change detection.

## Why
Documents stored in Google Drive need to be searchable in the memory system, with efficient incremental updates.

## How
- `files.list` with pagination for full sync, Changes API with `startPageToken` for incremental
- Google format export: Docs->markdown, Sheets->CSV, Slides->text
- OAuth2 token refresh with 5-min expiry buffer, concurrent refresh deduplication, 401 forced refresh
- Query injection protection: folder IDs validated against `^[a-zA-Z0-9_-]+$`
- Streaming response with size limit via `LimitReader` (Go) / `readResponseWithLimit` (TS)
- Retry with exponential backoff on 429/403 rate limits, `Retry-After` header support
- Access token sanitised from error messages (`Bearer [REDACTED]`)
- Shared drive support, MIME type filtering, configurable max file size

| Language | Tests |
|----------|-------|
| Go | `go/connector/` — gdrive.go, gdrive_helpers.go, oauth2.go | 37 tests |
| TypeScript | `sdks/ts/memory/src/connector/` — gdrive.ts, gdrive-helpers.ts | 34 tests |

## Ticket
LLE-9813