### PR TITLE
feat(go): add conversations storage and search scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### memory (Go) 0.3.1
+
+#### Added
+
+- `conversations` storage scope. A first-class top-level `conversations/`
+  tree (laid out by channel then date) is now discovered, indexed, and
+  retrievable alongside `wiki`, `memory`, `raw`, and `sources`. Adds
+  `brain.ConversationsPrefix()` and `brain.Conversation(rel)`, wires the
+  scope through `search.Index` (classify, discover, FTS filter, scope
+  matching) and `retrieval` (exact-scope and scope-filter aliases), and
+  parses conversation-article frontmatter (`title` / `summary` /
+  `modified`) the same as wiki articles so search results carry titles
+  and summaries. Lets hosts persist synthesised session-learning
+  articles under the brain and surface them through hybrid retrieval
+  with no host-side index workaround. (Go)
+
 ### memory-pi 0.2.2
 
 #### Added

--- a/go/brain/paths.go
+++ b/go/brain/paths.go
@@ -9,12 +9,13 @@ import (
 
 // Logical path roots. Every [Path] starts with one of these prefixes.
 const (
-	memoryRoot       = "memory"
-	wikiRoot         = "wiki"
-	rawRoot          = "raw"
-	rawDocumentsRoot = "raw/documents"
-	sourcesRoot      = "raw/.sources"
-	schemaFile       = "kb-schema.md"
+	memoryRoot        = "memory"
+	wikiRoot          = "wiki"
+	rawRoot           = "raw"
+	rawDocumentsRoot  = "raw/documents"
+	sourcesRoot       = "raw/.sources"
+	conversationsRoot = "conversations"
+	schemaFile        = "kb-schema.md"
 
 	// schemaVersionName is the root-level schema version marker. Kept here
 	// alongside the other root constants so store path resolution stays in
@@ -209,6 +210,19 @@ func RawLMEPrefix() Path { return Path(path.Join(rawRoot, "lme")) }
 // IsSourceRaw reports whether p lies under the .sources prefix.
 func IsSourceRaw(p Path) bool {
 	return strings.HasPrefix(string(p), sourcesRoot+"/") || string(p) == sourcesRoot
+}
+
+// ---------- Conversations ----------
+
+// ConversationsPrefix returns the logical root of the conversations tree.
+// Search indexes this tree under the "conversations" scope so synthesised
+// session-learning articles are discoverable via BM25 and hybrid retrieval.
+func ConversationsPrefix() Path { return Path(conversationsRoot) }
+
+// Conversation returns the path of a conversation article from a
+// conversations-relative path like "slack/2026/05/2026-05-30-id-slug.md".
+func Conversation(rel string) Path {
+	return Path(path.Join(conversationsRoot, rel))
 }
 
 // ---------- Schema ----------

--- a/go/brain/paths_test.go
+++ b/go/brain/paths_test.go
@@ -41,6 +41,8 @@ func TestPathHelpers(t *testing.T) {
 		{"raw prefix", RawPrefix(), "raw"},
 		{"raw documents prefix", RawDocumentsPrefix(), "raw/documents"},
 		{"sources prefix", SourcesPrefix(), "raw/.sources"},
+		{"conversations prefix", ConversationsPrefix(), "conversations"},
+		{"conversation article", Conversation("slack/2026/05/2026-05-30-5a948-brain.md"), "conversations/slack/2026/05/2026-05-30-5a948-brain.md"},
 		{"schema", Schema(), "kb-schema.md"},
 	}
 	for _, tc := range cases {

--- a/go/brain/storeutil/paths.go
+++ b/go/brain/storeutil/paths.go
@@ -25,6 +25,7 @@ import (
 //   - memory/project/<s>/X  -> projects/<s>/memory/X
 //   - wiki/X                -> wiki/X
 //   - raw/X                 -> raw/X
+//   - conversations/X       -> conversations/X
 //   - kb-schema.md          -> kb-schema.md
 //   - schema-version.yaml   -> schema-version.yaml
 func Relative(p brain.Path) (string, error) {
@@ -50,6 +51,8 @@ func Relative(p brain.Path) (string, error) {
 	case strings.HasPrefix(lp, "wiki/") || lp == "wiki":
 		return lp, nil
 	case strings.HasPrefix(lp, "raw/") || lp == "raw":
+		return lp, nil
+	case strings.HasPrefix(lp, "conversations/") || lp == "conversations":
 		return lp, nil
 	default:
 		return "", fmt.Errorf("%w: unknown root in %q", brain.ErrInvalidPath, lp)
@@ -87,6 +90,8 @@ func LogicalFromRel(rel string) brain.Path {
 	case rel == "wiki" || strings.HasPrefix(rel, "wiki/"):
 		return brain.Path(rel)
 	case rel == "raw" || strings.HasPrefix(rel, "raw/"):
+		return brain.Path(rel)
+	case rel == "conversations" || strings.HasPrefix(rel, "conversations/"):
 		return brain.Path(rel)
 	default:
 		return brain.Path(rel)

--- a/go/brain/storeutil/paths_test.go
+++ b/go/brain/storeutil/paths_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package storeutil
+
+import (
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/brain"
+)
+
+func TestRelative_Conversations(t *testing.T) {
+	cases := []struct {
+		in   brain.Path
+		want string
+	}{
+		{"conversations", "conversations"},
+		{"conversations/slack/2026/05/2026-05-30-id-slug.md", "conversations/slack/2026/05/2026-05-30-id-slug.md"},
+		{"conversations/_index.md", "conversations/_index.md"},
+	}
+	for _, tc := range cases {
+		got, err := Relative(tc.in)
+		if err != nil {
+			t.Fatalf("Relative(%q) error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("Relative(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLogicalFromRel_Conversations_RoundTrips(t *testing.T) {
+	for _, p := range []brain.Path{
+		"conversations",
+		"conversations/telegram/2026/05/2026-05-30-id-slug.md",
+		"conversations/slack/_index.md",
+	} {
+		rel, err := Relative(p)
+		if err != nil {
+			t.Fatalf("Relative(%q) error: %v", p, err)
+		}
+		if back := LogicalFromRel(rel); back != p {
+			t.Errorf("round trip %q -> %q -> %q", p, rel, back)
+		}
+	}
+}
+
+func TestResolve_Conversations(t *testing.T) {
+	abs, err := Resolve("/brain", "conversations/slack/2026/05/x.md")
+	if err != nil {
+		t.Fatalf("Resolve conversations path: %v", err)
+	}
+	if abs != "/brain/conversations/slack/2026/05/x.md" {
+		t.Errorf("Resolve = %q, want /brain/conversations/slack/2026/05/x.md", abs)
+	}
+}

--- a/go/cmd/memory/version.go
+++ b/go/cmd/memory/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // version is the released Go CLI version.
-const version = "0.3.0"
+const version = "0.3.1"
 
 func versionCmd() *cobra.Command {
 	return &cobra.Command{

--- a/go/retrieval/index_source.go
+++ b/go/retrieval/index_source.go
@@ -400,6 +400,8 @@ func exactSearchScope(scope string) (string, bool) {
 		return "raw_lme", true
 	case "sources":
 		return "sources", true
+	case "conversation", "conversations":
+		return "conversations", true
 	default:
 		return "", false
 	}
@@ -548,6 +550,12 @@ func scopeMatchesFilter(rowScope, want string) bool {
 		},
 		"sources": {
 			"sources": true,
+		},
+		"conversation": {
+			"conversations": true,
+		},
+		"conversations": {
+			"conversations": true,
 		},
 	}
 	allowed, ok := aliases[trimmed]

--- a/go/retrieval/index_source_scope_test.go
+++ b/go/retrieval/index_source_scope_test.go
@@ -26,3 +26,31 @@ func TestScopeMatchesFilterRawMatchesRawLME(t *testing.T) {
 		t.Fatal("scopeMatchesFilter(raw_lme, raw_lme) = false, want true")
 	}
 }
+
+func TestExactSearchScopeConversations(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"conversations", "conversation"} {
+		got, ok := exactSearchScope(in)
+		if !ok {
+			t.Fatalf("exactSearchScope(%q) = not ok, want ok", in)
+		}
+		if got != "conversations" {
+			t.Fatalf("exactSearchScope(%q) = %q, want conversations", in, got)
+		}
+	}
+}
+
+func TestScopeMatchesFilterConversations(t *testing.T) {
+	t.Parallel()
+
+	if !scopeMatchesFilter("conversations", "conversations") {
+		t.Fatal("scopeMatchesFilter(conversations, conversations) = false, want true")
+	}
+	if !scopeMatchesFilter("conversations", "conversation") {
+		t.Fatal("scopeMatchesFilter(conversations, conversation) = false, want true")
+	}
+	if scopeMatchesFilter("wiki", "conversations") {
+		t.Fatal("scopeMatchesFilter(wiki, conversations) = true, want false")
+	}
+}

--- a/go/search/index.go
+++ b/go/search/index.go
@@ -216,7 +216,7 @@ type Index struct {
 
 // SearchOpts controls filtering and pagination for searches.
 type SearchOpts struct {
-	Scope       string // "" for all, "wiki", "global_memory", "project_memory", "raw_document", "sources"
+	Scope       string // "" for all, "wiki", "global_memory", "project_memory", "raw_document", "sources", "conversations"
 	ProjectSlug string // filter by project (only for project_memory scope)
 	MaxResults  int    // default 20
 	Sort        SortMode
@@ -510,6 +510,8 @@ func buildSearchSQL(expr string, from, to time.Time, scope, projectSlug string, 
 		clauses = append(clauses, "scope = 'raw_lme'")
 	case "sources":
 		clauses = append(clauses, "scope = 'sources'")
+	case "conversation", "conversations":
+		clauses = append(clauses, "scope = 'conversations'")
 	default:
 		if scope != "" {
 			clauses = append(clauses, "scope = ?")
@@ -595,6 +597,8 @@ func searchScopeMatches(rowScope, want string) bool {
 		return rowScope == "project_memory"
 	case "raw":
 		return rowScope == "raw_document" || rowScope == "raw_lme"
+	case "conversation", "conversations":
+		return rowScope == "conversations"
 	default:
 		return rowScope == trimmed
 	}
@@ -672,7 +676,7 @@ func (idx *Index) hydrateModified(results []SearchResult) {
 // zero + false when the field is absent or unparseable.
 func extractModified(raw []byte, scope string) (time.Time, bool) {
 	switch scope {
-	case "wiki":
+	case "wiki", "conversations":
 		fm, _ := parseWikiFrontmatter(string(raw))
 		return parseModifiedString(fm.Modified)
 	default:
@@ -1318,6 +1322,11 @@ func classifyPath(p brain.Path) (scope, projectSlug string, ok bool) {
 		// when the extraction pass produced no facts (e.g. small
 		// extraction models that repeatedly return `{"memories": []}`).
 		return "raw_lme", "", true
+	case strings.HasPrefix(s, "conversations/"):
+		// Synthesised session-learning articles, laid out by channel and
+		// date. Indexed so whole-conversation narratives and learnings are
+		// retrievable alongside wiki and memory.
+		return "conversations", "", true
 	}
 	return "", "", false
 }
@@ -1384,6 +1393,11 @@ func (idx *Index) discoverFiles(ctx context.Context) []discoveredFile {
 
 	// Compiled sources (originals preserved after compilation).
 	files = append(files, idx.walkPrefix(ctx, brain.SourcesPrefix(), "sources", "")...)
+
+	// Synthesised session-learning conversation articles (laid out by
+	// channel and date). Indexing here surfaces them through hybrid
+	// retrieval the same as wiki and raw content.
+	files = append(files, idx.walkPrefix(ctx, brain.ConversationsPrefix(), "conversations", "")...)
 
 	return files
 }
@@ -1623,7 +1637,7 @@ func firstFrontmatterString(raw string, keys ...string) string {
 // tuple.
 func parseFrontmatterGeneric(content, scope string) (title, summary string, tags []string, body string) {
 	switch scope {
-	case "wiki":
+	case "wiki", "conversations":
 		fm, b := parseWikiFrontmatter(content)
 		return fm.Title, fm.Summary, fm.Tags, b
 	default:

--- a/go/search/index_test.go
+++ b/go/search/index_test.go
@@ -1128,6 +1128,94 @@ Hedgehogs live in hedgerows and gardens.`)); err != nil {
 	}
 }
 
+// TestRebuild_IndexesConversations verifies that synthesised
+// session-learning articles persisted under conversations/ are
+// discovered, indexed under the conversations scope, and isolated
+// by a conversations scope filter.
+func TestRebuild_IndexesConversations(t *testing.T) {
+	store := newWikiTestStore(t,
+		wikiTestDoc{path: "conversations/slack/2026/05/2026-05-30-abc-brain-repair.md", title: "Brain corruption repair", body: "Repaired the gitstore after a corrupted commit using the cli fallback."},
+		wikiTestDoc{path: "wiki/platform/go.md", title: "Go", body: "Go is a fast systems language."},
+	)
+
+	db := openTestDB(t)
+	idx, err := NewIndex(db, store)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := idx.RebuildWithStats(ctx); err != nil {
+		t.Fatalf("RebuildWithStats: %v", err)
+	}
+
+	scoped, err := idx.Search("gitstore", SearchOpts{Scope: "conversations"})
+	if err != nil {
+		t.Fatalf("Search scope filter: %v", err)
+	}
+	if len(scoped) != 1 {
+		t.Fatalf("scoped results = %d, want 1", len(scoped))
+	}
+	if scoped[0].Path != "conversations/slack/2026/05/2026-05-30-abc-brain-repair.md" {
+		t.Errorf("scoped path = %q, want the conversations article", scoped[0].Path)
+	}
+	if scoped[0].Scope != "conversations" {
+		t.Errorf("scope = %q, want %q", scoped[0].Scope, "conversations")
+	}
+	if scoped[0].Title != "Brain corruption repair" {
+		t.Errorf("title = %q, want %q", scoped[0].Title, "Brain corruption repair")
+	}
+}
+
+// TestSubscribe_IndexesConversation verifies the event sink path
+// covers the conversations/ tree so writes via the brain store land
+// in the FTS index without an explicit Rebuild.
+func TestSubscribe_IndexesConversation(t *testing.T) {
+	store := newTestStore()
+	t.Cleanup(func() { _ = store.Close() })
+
+	db := openTestDB(t)
+	idx, err := NewIndex(db, store)
+	if err != nil {
+		t.Fatalf("NewIndex: %v", err)
+	}
+	unsub := idx.Subscribe(store)
+	t.Cleanup(unsub)
+
+	ctx := context.Background()
+	if err := store.Write(ctx, "conversations/telegram/2026/05/2026-05-30-xyz-deploy.md", []byte(`---
+title: Deploy walkthrough
+summary: How the deploy went
+session_date: 2026-05-30
+---
+Walked through the staging deploy and the rollback plan.`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := idx.Search("rollback", SearchOpts{Scope: "conversations"})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected a hit after a conversations write")
+	}
+	if results[0].Path != "conversations/telegram/2026/05/2026-05-30-xyz-deploy.md" {
+		t.Errorf("path = %q, want the conversations article", results[0].Path)
+	}
+	if results[0].Scope != "conversations" {
+		t.Errorf("scope = %q, want %q", results[0].Scope, "conversations")
+	}
+	if results[0].SessionDate != "2026-05-30" {
+		t.Errorf("session_date = %q, want 2026-05-30", results[0].SessionDate)
+	}
+	if results[0].Title != "Deploy walkthrough" {
+		t.Errorf("title = %q, want %q", results[0].Title, "Deploy walkthrough")
+	}
+	if results[0].Summary != "How the deploy went" {
+		t.Errorf("summary = %q, want %q", results[0].Summary, "How the deploy went")
+	}
+}
+
 // TestDiscoverFiles_ExcludesUnderscorePrefixed verifies that
 // markdown files whose basename starts with an underscore are
 // filtered out of the FTS discovery path.

--- a/go/search/subscribe_test.go
+++ b/go/search/subscribe_test.go
@@ -29,6 +29,8 @@ func TestClassifyPath(t *testing.T) {
 		{"raw/.sources/web/foo.md", "sources", "", true},
 		{"raw/lme/sess-001.md", "raw_lme", "", true},
 		{"raw/lme/nested/sess.md", "raw_lme", "", true},
+		{"conversations/slack/2026/05/2026-05-30-id-slug.md", "conversations", "", true},
+		{"conversations/_index.md", "conversations", "", true},
 		{"raw/web/foo.md", "", "", false},
 		{"memory/global/not-md.txt", "", "", false},
 		{"memory/project/", "", "", false},


### PR DESCRIPTION
## What

Adds a first-class top-level `conversations/` scope to the Go SDK: a tree laid out by channel then date that is **discovered, indexed, and retrievable** alongside `wiki`, `memory`, `raw`, and `sources`.

```
conversations/
  slack/2026/05/2026-05-30-<id>-<slug>.md
  telegram/2026/05/...
  linear/  tui/  heartbeat/
```

## Why

The Jeff/Jill session-learning pipeline analyses each conversation when it ends and writes a structured "learning article" into the brain. Those articles need to live under a clean, self-describing namespace and be retrievable through the normal hybrid-retrieval path. Before this change the only indexed prefixes were `memory/`, `wiki/`, `raw/documents/`, `raw/.sources/`, and `raw/lme/`, so a top-level `conversations/` tree was written but never indexed. This wires the scope end to end so hosts need no index workaround.

## Changes

- **brain**: `ConversationsPrefix()` and `Conversation(rel)` path helpers; `storeutil` `Relative` / `LogicalFromRel` round-trip the new root.
- **search**: `classifyPath` and `discoverFiles` cover `conversations/`; the FTS scope filter (`buildSearchSQL`) and `searchScopeMatches` accept `conversation`/`conversations`; conversation-article frontmatter (`title` / `summary` / `modified`) is parsed like wiki so search results carry titles and summaries.
- **retrieval**: `exactSearchScope` and `scopeMatchesFilter` accept the scope and its singular alias.
- **cmd/memory**: version bumped to `0.3.1` (matches the `go/v0.3.1` release-tag check in `release.yml`).

## Tests

- `brain`: prefix/article path helpers; `storeutil` round-trips for `conversations/`.
- `search`: `classifyPath` recognises `conversations/`; `TestRebuild_IndexesConversations` and `TestSubscribe_IndexesConversation` assert path, scope, `session_date`, **and** title/summary populate via the FTS index.
- `retrieval`: `exactSearchScope` and `scopeMatchesFilter` accept the scope/alias and reject mismatches.

## Verification

`go build ./...`, `go vet ./...`, `go test -race -timeout 10m ./...` (all pass), `go mod tidy` (clean), `gofmt` clean on all touched files. No new `staticcheck` findings introduced by this diff.

## Compatibility

Purely additive. No existing scope, path, or wire behaviour changes; the search-scope vocabulary is an SDK indexing concern (not pinned in `spec/`), and the MCP search tool's `all|global|project|agent` enum is unchanged (`all` already covers the new scope).