### PR TITLE
feat(memory): optional codec extraction priors (Go + TS, Option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### memory (Go + TypeScript) — codec extraction priors
+
+#### Added
+
+- Optional codec priors on the memory-note extraction path. `extract`
+  now accepts a `CodecPriors` value (plain string lists: `entities`,
+  `relations`, `domainTerms`) that is folded into the extraction system
+  prompt as a bounded, deduplicated, truncated block of SOFT
+  known-entity hints, so extraction reuses the project's canonical
+  entity / relation / term names. TypeScript: `ExtractArgs.priors` on
+  `createMemory().extract` plus exported `buildCodecPriorsBlock`,
+  `applyCodecPriors`, and `CodecPriorsError`. Go: new
+  `ExtractFromMessagesWithPriors` entry point plus the `CodecPriors`
+  type and `ErrInvalidCodecPriors`. Priors are deliberately distinct
+  from the typed `ResolvedOntology` used by the ontology-type extractor.
+  Omitting or supplying empty priors is byte-identical to previous
+  behaviour. Malformed priors (line breaks; non-string items in
+  TypeScript) raise a typed error before any LLM call. A Go↔TS golden
+  parity test pins the rendered block byte-for-byte. (Go + TypeScript)
+- Cancellation on the TypeScript memory-note extraction path.
+  `ExtractArgs.signal` threads an `AbortSignal` into the extraction LLM
+  call and is honoured before and during the call; the Go path already
+  honoured `context.Context` cancellation. (TypeScript)
+
 ### memory (Go) 0.3.1
 
 #### Added

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
     },
     "sdks/ts/memory": {
       "name": "@jeffs-brain/memory",
-      "version": "0.4.0-rc.1",
+      "version": "0.4.0-rc.3",
       "bin": {
         "memory": "./dist/cli.js",
       },
@@ -101,7 +101,7 @@
     },
     "sdks/ts/memory-postgres": {
       "name": "@jeffs-brain/memory-postgres",
-      "version": "0.2.0-rc.1",
+      "version": "0.2.0-rc.2",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9",

--- a/go/cmd/memory/version.go
+++ b/go/cmd/memory/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // version is the released Go CLI version.
-const version = "0.4.0-rc.1"
+const version = "0.4.0-rc.3"
 
 func versionCmd() *cobra.Command {
 	return &cobra.Command{

--- a/go/memory/codec_priors.go
+++ b/go/memory/codec_priors.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Codec priors bounds. Mirrors the TypeScript implementation in
+// sdks/ts/memory/src/memory/codec-priors.ts so both languages render an
+// identical priors block.
+const (
+	codecPriorsMaxItemsPerList = 64
+	codecPriorsMaxItemLength   = 80
+	codecPriorsMaxBlockChars   = 4000
+)
+
+// ErrInvalidCodecPriors is returned when codec priors are structurally
+// malformed. The package never silently coerces bad input.
+var ErrInvalidCodecPriors = errors.New("memory: invalid codec priors")
+
+// CodecPriors are the project's canonical vocabulary, folded into the
+// extraction prompt as SOFT known-entity hints. They mirror the codec
+// `ontology:` frontmatter block (plain string lists) and are deliberately
+// distinct from the typed ontology.ResolvedOntology used by the
+// ontology-type extractor — codec priors carry no types, attributes, or
+// endpoints.
+//
+// All three lists are optional; an absent or wholly empty value leaves
+// extraction behaviour byte-identical to the no-priors baseline.
+type CodecPriors struct {
+	// Entities are canonical entity names, e.g. {"Person", "Organisation"}.
+	Entities []string
+	// Relations are canonical relation names, e.g. {"worksAt", "owns"}.
+	Relations []string
+	// DomainTerms is domain vocabulary / shorthand, e.g. {"sprint"}.
+	DomainTerms []string
+}
+
+type codecPriorList struct {
+	heading string
+	items   []string
+}
+
+// buildCodecPriorsBlock renders the soft known-entity priors block that is
+// appended to the extraction system prompt. It returns an empty string
+// when there is nothing to render (nil priors, or all lists empty after
+// sanitisation), guaranteeing the baseline prompt is unchanged.
+//
+// Items are trimmed, empties dropped, deduplicated case-insensitively
+// (first occurrence wins), truncated per-item, and capped per-list and by
+// an overall character budget so priors can never grow the prompt without
+// limit. A list that is present but unusable raises ErrInvalidCodecPriors;
+// because Go slices are already typed there is no non-string case, so the
+// error surfaces only on a future validation extension and keeps parity
+// with the TypeScript typed-error contract.
+func buildCodecPriorsBlock(priors *CodecPriors) (string, error) {
+	if priors == nil {
+		return "", nil
+	}
+
+	lists := []codecPriorList{
+		{heading: "Entities", items: priors.Entities},
+		{heading: "Relations", items: priors.Relations},
+		{heading: "Domain terms", items: priors.DomainTerms},
+	}
+
+	sections := make([]string, 0, len(lists))
+	remainingBudget := codecPriorsMaxBlockChars
+
+	for _, list := range lists {
+		items, err := sanitiseCodecPriorList(list.heading, list.items)
+		if err != nil {
+			return "", err
+		}
+		if len(items) == 0 {
+			continue
+		}
+		lines := make([]string, 0, len(items))
+		for _, item := range items {
+			line := "- " + item
+			if len(line) > remainingBudget {
+				break
+			}
+			lines = append(lines, line)
+			remainingBudget -= len(line)
+		}
+		if len(lines) == 0 {
+			continue
+		}
+		sections = append(sections, fmt.Sprintf("### %s\n%s", list.heading, strings.Join(lines, "\n")))
+	}
+
+	if len(sections) == 0 {
+		return "", nil
+	}
+
+	parts := []string{
+		"",
+		"## Project codec priors",
+		"The following are the project’s canonical entities, relations, and domain terms. Treat them as SOFT hints: when a saved fact references one of these, prefer the canonical name below. Do NOT invent facts to match them, and do NOT discard durable knowledge that falls outside this list.",
+		"",
+	}
+	parts = append(parts, sections...)
+	return strings.Join(parts, "\n"), nil
+}
+
+// applyCodecPriors composes the effective extraction system prompt from the
+// verbatim base prompt and the optional codec priors block.
+func applyCodecPriors(basePrompt string, priors *CodecPriors) (string, error) {
+	block, err := buildCodecPriorsBlock(priors)
+	if err != nil {
+		return "", err
+	}
+	if block == "" {
+		return basePrompt, nil
+	}
+	return basePrompt + "\n" + block, nil
+}
+
+func sanitiseCodecPriorList(heading string, values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
+		if strings.ContainsAny(raw, "\n\r") {
+			return nil, fmt.Errorf("%w: %s must not contain line breaks", ErrInvalidCodecPriors, strings.ToLower(heading))
+		}
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		item := truncateCodecPriorItem(trimmed)
+		key := strings.ToLower(item)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item)
+		if len(out) >= codecPriorsMaxItemsPerList {
+			break
+		}
+	}
+	return out, nil
+}
+
+// truncateCodecPriorItem caps an item at codecPriorsMaxItemLength runes,
+// truncating on a rune boundary so the result is always valid UTF-8. For
+// the canonical-name domain (ASCII / Latin) this matches the TypeScript
+// code-unit cap exactly.
+func truncateCodecPriorItem(value string) string {
+	runes := []rune(value)
+	if len(runes) <= codecPriorsMaxItemLength {
+		return value
+	}
+	return string(runes[:codecPriorsMaxItemLength])
+}

--- a/go/memory/codec_priors_test.go
+++ b/go/memory/codec_priors_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func priorLines(block string) []string {
+	var out []string
+	for _, line := range strings.Split(block, "\n") {
+		if strings.HasPrefix(line, "- ") {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func TestBuildCodecPriorsBlock_Positive(t *testing.T) {
+	block, err := buildCodecPriorsBlock(&CodecPriors{
+		Entities:    []string{"Person", "Organisation", "Product"},
+		Relations:   []string{"worksAt", "owns", "dependsOn"},
+		DomainTerms: []string{"sprint", "deployment", "incident"},
+	})
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	for _, want := range []string{
+		"## Project codec priors",
+		"### Entities",
+		"- Person",
+		"### Relations",
+		"- worksAt",
+		"### Domain terms",
+		"- sprint",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("block missing %q\n%s", want, block)
+		}
+	}
+}
+
+func TestApplyCodecPriors_AppendsBlock(t *testing.T) {
+	composed, err := applyCodecPriors(extractionPrompt, &CodecPriors{Entities: []string{"Person"}})
+	if err != nil {
+		t.Fatalf("applyCodecPriors: %v", err)
+	}
+	if !strings.HasPrefix(composed, extractionPrompt) {
+		t.Fatalf("composed prompt does not start with the base prompt")
+	}
+	if !strings.Contains(composed, "- Person") {
+		t.Fatalf("composed prompt missing prior")
+	}
+	if len(composed) <= len(extractionPrompt) {
+		t.Fatalf("composed prompt did not grow")
+	}
+}
+
+func TestBuildCodecPriorsBlock_BackwardCompatible(t *testing.T) {
+	cases := map[string]*CodecPriors{
+		"nil":         nil,
+		"empty":       {},
+		"empty lists": {Entities: []string{}, Relations: []string{}, DomainTerms: []string{}},
+		"blank items": {Entities: []string{"   ", ""}},
+	}
+	for name, priors := range cases {
+		t.Run(name, func(t *testing.T) {
+			block, err := buildCodecPriorsBlock(priors)
+			if err != nil {
+				t.Fatalf("buildCodecPriorsBlock: %v", err)
+			}
+			if block != "" {
+				t.Fatalf("expected empty block, got %q", block)
+			}
+			composed, err := applyCodecPriors(extractionPrompt, priors)
+			if err != nil {
+				t.Fatalf("applyCodecPriors: %v", err)
+			}
+			if composed != extractionPrompt {
+				t.Fatalf("expected byte-identical base prompt for %s", name)
+			}
+		})
+	}
+}
+
+func TestBuildCodecPriorsBlock_MalformedLineBreakIsTypedError(t *testing.T) {
+	_, err := buildCodecPriorsBlock(&CodecPriors{Entities: []string{"Person\nInjected heading"}})
+	if err == nil {
+		t.Fatalf("expected error for line break in prior")
+	}
+	if !errors.Is(err, ErrInvalidCodecPriors) {
+		t.Fatalf("error = %v, want ErrInvalidCodecPriors", err)
+	}
+}
+
+func TestBuildCodecPriorsBlock_DeduplicatesCaseInsensitively(t *testing.T) {
+	block, err := buildCodecPriorsBlock(&CodecPriors{Entities: []string{"Person", "person", "PERSON", "Org"}})
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	got := priorLines(block)
+	want := []string{"- Person", "- Org"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("dedup lines = %v, want %v", got, want)
+	}
+}
+
+func TestBuildCodecPriorsBlock_CapsItemsPerList(t *testing.T) {
+	items := make([]string, 0, codecPriorsMaxItemsPerList+50)
+	for i := 0; i < codecPriorsMaxItemsPerList+50; i++ {
+		items = append(items, "Entity"+strings.Repeat("x", 0)+itoa(i))
+	}
+	block, err := buildCodecPriorsBlock(&CodecPriors{Entities: items})
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	if got := len(priorLines(block)); got != codecPriorsMaxItemsPerList {
+		t.Fatalf("rendered %d items, want %d", got, codecPriorsMaxItemsPerList)
+	}
+}
+
+func TestBuildCodecPriorsBlock_TruncatesItem(t *testing.T) {
+	long := strings.Repeat("A", codecPriorsMaxItemLength+40)
+	block, err := buildCodecPriorsBlock(&CodecPriors{Entities: []string{long}})
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	want := "- " + strings.Repeat("A", codecPriorsMaxItemLength)
+	got := priorLines(block)
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("truncated line = %v, want %q", got, want)
+	}
+}
+
+func TestBuildCodecPriorsBlock_BoundsTotalGrowth(t *testing.T) {
+	huge := make([]string, 0, 500)
+	for i := 0; i < 500; i++ {
+		huge = append(huge, strings.Repeat("X", 80)+itoa(i))
+	}
+	block, err := buildCodecPriorsBlock(&CodecPriors{Entities: huge, Relations: huge, DomainTerms: huge})
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	if len(block) >= 6000 {
+		t.Fatalf("block length %d not bounded", len(block))
+	}
+}
+
+// GO ↔ TS PARITY: this golden string is asserted byte-for-byte in the TS
+// test "buildCodecPriorsBlock — Go/TS parity"
+// (sdks/ts/memory/src/memory/codec-priors.test.ts). Any change here MUST be
+// mirrored there, and vice-versa.
+func TestBuildCodecPriorsBlock_GoldenParity(t *testing.T) {
+	priors := &CodecPriors{
+		Entities:    []string{"Person", "person", "Organisation"},
+		Relations:   []string{"worksAt"},
+		DomainTerms: []string{"sprint", "deployment"},
+	}
+	golden := strings.Join([]string{
+		"",
+		"## Project codec priors",
+		"The following are the project’s canonical entities, relations, and domain terms. Treat them as SOFT hints: when a saved fact references one of these, prefer the canonical name below. Do NOT invent facts to match them, and do NOT discard durable knowledge that falls outside this list.",
+		"",
+		"### Entities",
+		"- Person",
+		"- Organisation",
+		"### Relations",
+		"- worksAt",
+		"### Domain terms",
+		"- sprint",
+		"- deployment",
+	}, "\n")
+
+	block, err := buildCodecPriorsBlock(priors)
+	if err != nil {
+		t.Fatalf("buildCodecPriorsBlock: %v", err)
+	}
+	if block != golden {
+		t.Fatalf("golden parity mismatch:\n got: %q\nwant: %q", block, golden)
+	}
+}
+
+// itoa avoids importing strconv solely for the test loop counters.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	return string(digits)
+}

--- a/go/memory/extract.go
+++ b/go/memory/extract.go
@@ -598,7 +598,25 @@ func ExtractFromMessages(
 	projectPath string,
 	messages []Message,
 ) ([]ExtractedMemory, error) {
-	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, "", messages, "", "")
+	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, "", messages, "", "", nil)
+}
+
+// ExtractFromMessagesWithPriors runs the extraction LLM call with optional
+// codec priors folded into the system prompt as soft known-entity hints.
+// Passing nil priors is byte-identical to ExtractFromMessages. Honours
+// ctx cancellation via the provider call.
+func ExtractFromMessagesWithPriors(
+	ctx context.Context,
+	provider llm.Provider,
+	model string,
+	mem *Memory,
+	projectPath string,
+	messages []Message,
+	sessionID string,
+	sessionDate string,
+	priors *CodecPriors,
+) ([]ExtractedMemory, error) {
+	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, "", messages, sessionID, sessionDate, priors)
 }
 
 // ExtractFromMessagesWithProjectSlug runs the extraction LLM call using
@@ -612,7 +630,7 @@ func ExtractFromMessagesWithProjectSlug(
 	projectSlug string,
 	messages []Message,
 ) ([]ExtractedMemory, error) {
-	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, projectSlug, messages, "", "")
+	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, projectSlug, messages, "", "", nil)
 }
 
 // ExtractFromMessagesWithSession runs the extraction LLM call and
@@ -628,7 +646,7 @@ func ExtractFromMessagesWithSession(
 	sessionID string,
 	sessionDate string,
 ) ([]ExtractedMemory, error) {
-	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, "", messages, sessionID, sessionDate)
+	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, "", messages, sessionID, sessionDate, nil)
 }
 
 // ExtractFromMessagesWithSessionAndProjectSlug runs the extraction LLM
@@ -645,7 +663,7 @@ func ExtractFromMessagesWithSessionAndProjectSlug(
 	sessionID string,
 	sessionDate string,
 ) ([]ExtractedMemory, error) {
-	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, projectSlug, messages, sessionID, sessionDate)
+	return extractFromMessagesWithSession(ctx, provider, model, mem, projectPath, projectSlug, messages, sessionID, sessionDate, nil)
 }
 
 func extractFromMessagesWithSession(
@@ -658,12 +676,25 @@ func extractFromMessagesWithSession(
 	messages []Message,
 	sessionID string,
 	sessionDate string,
+	priors *CodecPriors,
 ) ([]ExtractedMemory, error) {
 	if len(messages) < 2 {
 		return nil, nil
 	}
 	if strings.TrimSpace(projectSlug) == "" {
 		projectSlug = ProjectSlug(projectPath)
+	}
+
+	// Compose the effective system prompt first so a malformed-priors
+	// error surfaces to the caller before any LLM call or store read.
+	systemPrompt, err := applyCodecPriors(extractionPrompt, priors)
+	if err != nil {
+		return nil, err
+	}
+
+	// Honour cancellation before doing any work.
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	recent := messages
@@ -677,7 +708,7 @@ func extractFromMessagesWithSession(
 	resp, err := provider.Complete(ctx, llm.CompleteRequest{
 		Model: model,
 		Messages: []llm.Message{
-			{Role: RoleSystem, Content: extractionPrompt},
+			{Role: RoleSystem, Content: systemPrompt},
 			{Role: RoleUser, Content: userPrompt},
 		},
 		MaxTokens:          extractMaxTokens,

--- a/go/memory/extract_priors_test.go
+++ b/go/memory/extract_priors_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jeffs-brain/memory/go/llm"
+)
+
+// capturingProvider records the request it received and replies with a
+// fixed payload.
+type capturingProvider struct {
+	mu    sync.Mutex
+	reply string
+	calls int
+	req   llm.CompleteRequest
+}
+
+func (p *capturingProvider) Complete(ctx context.Context, req llm.CompleteRequest) (llm.CompleteResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return llm.CompleteResponse{}, err
+	}
+	p.mu.Lock()
+	p.calls++
+	p.req = req
+	p.mu.Unlock()
+	return llm.CompleteResponse{Text: p.reply}, nil
+}
+
+func (p *capturingProvider) CompleteStream(_ context.Context, _ llm.CompleteRequest) (<-chan llm.StreamChunk, error) {
+	return nil, nil
+}
+
+func (p *capturingProvider) Close() error { return nil }
+
+func (p *capturingProvider) systemPrompt() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, m := range p.req.Messages {
+		if m.Role == RoleSystem {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func (p *capturingProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+const priorsExtractReply = `{"memories":[{"action":"create","filename":"project-note.md","name":"Note","description":"a note","type":"project","scope":"project","content":"A durable project fact.","index_entry":"- project-note.md: note"}]}`
+
+func priorsMessages() []Message {
+	return []Message{
+		{Role: RoleUser, Content: "msg 0"},
+		{Role: RoleAssistant, Content: "msg 1"},
+		{Role: RoleUser, Content: "msg 2"},
+		{Role: RoleAssistant, Content: "msg 3"},
+	}
+}
+
+func TestExtractFromMessagesWithPriors_InjectsBlock(t *testing.T) {
+	mem, _ := newTestMemory(t)
+	provider := &capturingProvider{reply: priorsExtractReply}
+	priors := &CodecPriors{
+		Entities:    []string{"RoyalAWare", "Sprint"},
+		Relations:   []string{"dependsOn"},
+		DomainTerms: []string{"deployment"},
+	}
+
+	_, err := ExtractFromMessagesWithPriors(context.Background(), provider, "test-model", mem, "/project", priorsMessages(), "", "", priors)
+	if err != nil {
+		t.Fatalf("ExtractFromMessagesWithPriors: %v", err)
+	}
+
+	system := provider.systemPrompt()
+	if !strings.HasPrefix(system, extractionPrompt) {
+		t.Fatalf("system prompt does not start with base prompt")
+	}
+	for _, want := range []string{"## Project codec priors", "- RoyalAWare", "- dependsOn", "- deployment"} {
+		if !strings.Contains(system, want) {
+			t.Fatalf("system prompt missing %q", want)
+		}
+	}
+}
+
+func TestExtractFromMessagesWithPriors_NilIsBaseline(t *testing.T) {
+	mem, _ := newTestMemory(t)
+	provider := &capturingProvider{reply: priorsExtractReply}
+
+	_, err := ExtractFromMessagesWithPriors(context.Background(), provider, "test-model", mem, "/project", priorsMessages(), "", "", nil)
+	if err != nil {
+		t.Fatalf("ExtractFromMessagesWithPriors: %v", err)
+	}
+	if got := provider.systemPrompt(); got != extractionPrompt {
+		t.Fatalf("expected byte-identical base prompt with nil priors")
+	}
+}
+
+func TestExtractFromMessagesWithPriors_EmptyIsBaseline(t *testing.T) {
+	mem, _ := newTestMemory(t)
+	provider := &capturingProvider{reply: priorsExtractReply}
+
+	_, err := ExtractFromMessagesWithPriors(context.Background(), provider, "test-model", mem, "/project", priorsMessages(), "", "", &CodecPriors{Entities: []string{}, Relations: []string{}})
+	if err != nil {
+		t.Fatalf("ExtractFromMessagesWithPriors: %v", err)
+	}
+	if got := provider.systemPrompt(); got != extractionPrompt {
+		t.Fatalf("expected byte-identical base prompt with empty priors")
+	}
+}
+
+func TestExtractFromMessagesWithPriors_MalformedReturnsTypedErrorNoCall(t *testing.T) {
+	mem, _ := newTestMemory(t)
+	provider := &capturingProvider{reply: priorsExtractReply}
+	malformed := &CodecPriors{Entities: []string{"ok", "bad\ninjection"}}
+
+	_, err := ExtractFromMessagesWithPriors(context.Background(), provider, "test-model", mem, "/project", priorsMessages(), "", "", malformed)
+	if !errors.Is(err, ErrInvalidCodecPriors) {
+		t.Fatalf("err = %v, want ErrInvalidCodecPriors", err)
+	}
+	if provider.callCount() != 0 {
+		t.Fatalf("provider was called %d times for malformed priors", provider.callCount())
+	}
+}
+
+func TestExtractFromMessagesWithPriors_HonoursCancelledContext(t *testing.T) {
+	mem, _ := newTestMemory(t)
+	provider := &capturingProvider{reply: priorsExtractReply}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ExtractFromMessagesWithPriors(ctx, provider, "test-model", mem, "/project", priorsMessages(), "", "", &CodecPriors{Entities: []string{"Person"}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if provider.callCount() != 0 {
+		t.Fatalf("provider was called despite cancelled context")
+	}
+}
+
+func TestExtractFromMessagesWithPriors_ConcurrentCallsIndependent(t *testing.T) {
+	memA, _ := newTestMemory(t)
+	memB, _ := newTestMemory(t)
+	provA := &capturingProvider{reply: priorsExtractReply}
+	provB := &capturingProvider{reply: priorsExtractReply}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = ExtractFromMessagesWithPriors(context.Background(), provA, "test-model", memA, "/a", priorsMessages(), "", "", &CodecPriors{Entities: []string{"Alpha"}})
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = ExtractFromMessagesWithPriors(context.Background(), provB, "test-model", memB, "/b", priorsMessages(), "", "", &CodecPriors{Entities: []string{"Beta"}})
+	}()
+	wg.Wait()
+
+	sysA := provA.systemPrompt()
+	sysB := provB.systemPrompt()
+	if !strings.Contains(sysA, "- Alpha") || strings.Contains(sysA, "- Beta") {
+		t.Fatalf("provider A bled state: %q", sysA)
+	}
+	if !strings.Contains(sysB, "- Beta") || strings.Contains(sysB, "- Alpha") {
+		t.Fatalf("provider B bled state: %q", sysB)
+	}
+}

--- a/sdks/ts/memory/package.json
+++ b/sdks/ts/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory",
-  "version": "0.4.0-rc.2",
+  "version": "0.4.0-rc.3",
   "description": "Local-first memory and hybrid retrieval library for LLM agents with pluggable stores, BM25 plus vector search, and a four-stage memory pipeline.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",

--- a/sdks/ts/memory/src/memory/codec-priors.test.ts
+++ b/sdks/ts/memory/src/memory/codec-priors.test.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  CODEC_PRIORS_MAX_ITEMS_PER_LIST,
+  CODEC_PRIORS_MAX_ITEM_LENGTH,
+  CodecPriorsError,
+  applyCodecPriors,
+  buildCodecPriorsBlock,
+} from './codec-priors.js'
+import { EXTRACTION_SYSTEM_PROMPT } from './prompts.js'
+import type { CodecPriors } from './types.js'
+
+describe('buildCodecPriorsBlock — positive', () => {
+  it('renders the canonical entities, relations, and domain terms', () => {
+    const priors: CodecPriors = {
+      entities: ['Person', 'Organisation', 'Product'],
+      relations: ['worksAt', 'owns', 'dependsOn'],
+      domainTerms: ['sprint', 'deployment', 'incident'],
+    }
+    const block = buildCodecPriorsBlock(priors)
+    expect(block).toContain('## Project codec priors')
+    expect(block).toContain('### Entities')
+    expect(block).toContain('- Person')
+    expect(block).toContain('### Relations')
+    expect(block).toContain('- worksAt')
+    expect(block).toContain('### Domain terms')
+    expect(block).toContain('- sprint')
+  })
+
+  it('applyCodecPriors appends the block to the base prompt', () => {
+    const priors: CodecPriors = { entities: ['Person'] }
+    const composed = applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, priors)
+    expect(composed.startsWith(EXTRACTION_SYSTEM_PROMPT)).toBe(true)
+    expect(composed).toContain('- Person')
+    expect(composed.length).toBeGreaterThan(EXTRACTION_SYSTEM_PROMPT.length)
+  })
+
+  it('renders only the lists that are present', () => {
+    const block = buildCodecPriorsBlock({ entities: ['Person'] })
+    expect(block).toContain('### Entities')
+    expect(block).not.toContain('### Relations')
+    expect(block).not.toContain('### Domain terms')
+  })
+})
+
+describe('buildCodecPriorsBlock — negative / backward compatibility', () => {
+  it('returns empty string when priors are undefined', () => {
+    expect(buildCodecPriorsBlock(undefined)).toBe('')
+  })
+
+  it('returns empty string for an empty object', () => {
+    expect(buildCodecPriorsBlock({})).toBe('')
+  })
+
+  it('returns empty string when every list is empty', () => {
+    expect(buildCodecPriorsBlock({ entities: [], relations: [], domainTerms: [] })).toBe('')
+  })
+
+  it('leaves the base prompt byte-identical when priors are absent or empty', () => {
+    expect(applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, undefined)).toBe(EXTRACTION_SYSTEM_PROMPT)
+    expect(applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, {})).toBe(EXTRACTION_SYSTEM_PROMPT)
+    expect(applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, { entities: ['   '] })).toBe(
+      EXTRACTION_SYSTEM_PROMPT,
+    )
+  })
+
+  it('throws a typed error for a non-array list', () => {
+    // Simulate malformed runtime input that bypasses the type system.
+    const malformed = { entities: 'Person' } as unknown as CodecPriors
+    expect(() => buildCodecPriorsBlock(malformed)).toThrow(CodecPriorsError)
+  })
+
+  it('throws a typed error for a non-string item', () => {
+    const malformed = { entities: ['Person', 42] } as unknown as CodecPriors
+    expect(() => buildCodecPriorsBlock(malformed)).toThrow(CodecPriorsError)
+  })
+
+  it('throws a typed error for an item containing a line break', () => {
+    expect(() => buildCodecPriorsBlock({ entities: ['Person\nInjected heading'] })).toThrow(
+      CodecPriorsError,
+    )
+  })
+})
+
+// GO ↔ TS PARITY: this golden string is asserted byte-for-byte in the Go
+// test TestBuildCodecPriorsBlock_GoldenParity (go/memory/codec_priors_test.go).
+// Any change here MUST be mirrored there, and vice-versa.
+const GOLDEN_PRIORS: CodecPriors = {
+  entities: ['Person', 'person', 'Organisation'],
+  relations: ['worksAt'],
+  domainTerms: ['sprint', 'deployment'],
+}
+const GOLDEN_BLOCK = [
+  '',
+  '## Project codec priors',
+  'The following are the project’s canonical entities, relations, and domain terms. Treat them as SOFT hints: when a saved fact references one of these, prefer the canonical name below. Do NOT invent facts to match them, and do NOT discard durable knowledge that falls outside this list.',
+  '',
+  '### Entities',
+  '- Person',
+  '- Organisation',
+  '### Relations',
+  '- worksAt',
+  '### Domain terms',
+  '- sprint',
+  '- deployment',
+].join('\n')
+
+describe('buildCodecPriorsBlock — Go/TS parity', () => {
+  it('renders the golden block byte-for-byte', () => {
+    expect(buildCodecPriorsBlock(GOLDEN_PRIORS)).toBe(GOLDEN_BLOCK)
+  })
+})
+
+describe('buildCodecPriorsBlock — edge', () => {
+  it('deduplicates case-insensitively, first occurrence wins', () => {
+    const block = buildCodecPriorsBlock({ entities: ['Person', 'person', 'PERSON', 'Org'] })
+    const lines = block.split('\n').filter((line) => line.startsWith('- '))
+    expect(lines).toEqual(['- Person', '- Org'])
+  })
+
+  it('caps the number of items per list', () => {
+    const many = Array.from(
+      { length: CODEC_PRIORS_MAX_ITEMS_PER_LIST + 50 },
+      (_v, i) => `Entity${i}`,
+    )
+    const block = buildCodecPriorsBlock({ entities: many })
+    const lines = block.split('\n').filter((line) => line.startsWith('- '))
+    expect(lines.length).toBe(CODEC_PRIORS_MAX_ITEMS_PER_LIST)
+  })
+
+  it('truncates an oversized item to the per-item length cap', () => {
+    const long = 'A'.repeat(CODEC_PRIORS_MAX_ITEM_LENGTH + 40)
+    const block = buildCodecPriorsBlock({ entities: [long] })
+    const line = block.split('\n').find((l) => l.startsWith('- ')) ?? ''
+    expect(line).toBe(`- ${'A'.repeat(CODEC_PRIORS_MAX_ITEM_LENGTH)}`)
+  })
+
+  it('bounds total prompt growth even with pathological input', () => {
+    const huge = Array.from({ length: 500 }, (_v, i) => 'X'.repeat(80) + i)
+    const block = buildCodecPriorsBlock({
+      entities: huge,
+      relations: huge,
+      domainTerms: huge,
+    })
+    // Body budget plus fixed framing; never unbounded.
+    expect(block.length).toBeLessThan(6000)
+  })
+
+  it('drops blank and whitespace-only items', () => {
+    const block = buildCodecPriorsBlock({ entities: ['', '   ', 'Person'] })
+    const lines = block.split('\n').filter((line) => line.startsWith('- '))
+    expect(lines).toEqual(['- Person'])
+  })
+})

--- a/sdks/ts/memory/src/memory/codec-priors.ts
+++ b/sdks/ts/memory/src/memory/codec-priors.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Codec priors adapter for the memory-note extraction path.
+ *
+ * Codec priors are the project's canonical vocabulary (the codec
+ * `ontology:` block) expressed as plain string lists. This module turns
+ * them into a bounded, deduplicated, truncated SOFT priors block that is
+ * appended to the extraction system prompt so the extractor reuses the
+ * project's canonical entity / relation / term names.
+ *
+ * Design invariants:
+ * - Pure and side-effect free; no I/O, no provider calls.
+ * - Backward compatible: an absent or wholly empty priors object yields
+ *   an empty block, so the extraction prompt is byte-identical to the
+ *   no-priors baseline.
+ * - Bounded output: per-list item count, per-item length, and total
+ *   character budget are all capped so priors can never grow the prompt
+ *   without limit.
+ * - Deduplication is case-insensitive and O(n) using a Set; first
+ *   occurrence wins so caller ordering is preserved.
+ * - Malformed input (non-array list, non-string item) raises a typed
+ *   error rather than crashing or silently coercing.
+ */
+
+import type { CodecPriors } from './types.js'
+
+/** Maximum number of items rendered per prior list. */
+export const CODEC_PRIORS_MAX_ITEMS_PER_LIST = 64
+/** Maximum rendered length of a single prior item, in characters. */
+export const CODEC_PRIORS_MAX_ITEM_LENGTH = 80
+/** Overall character budget for the rendered priors block body. */
+export const CODEC_PRIORS_MAX_BLOCK_CHARS = 4000
+
+/** Typed error raised when codec priors are structurally malformed. */
+export class CodecPriorsError extends Error {
+  constructor(message: string) {
+    super(`memory: invalid codec priors: ${message}`)
+    this.name = 'CodecPriorsError'
+  }
+}
+
+type PriorList = {
+  readonly heading: string
+  readonly label: keyof CodecPriors
+}
+
+const PRIOR_LISTS: readonly PriorList[] = [
+  { heading: 'Entities', label: 'entities' },
+  { heading: 'Relations', label: 'relations' },
+  { heading: 'Domain terms', label: 'domainTerms' },
+] as const
+
+/**
+ * Build the soft known-entity priors block appended to the extraction
+ * system prompt. Returns an empty string when there is nothing to render
+ * (no priors, or all lists empty after sanitisation), guaranteeing the
+ * baseline prompt is unchanged.
+ *
+ * @throws {CodecPriorsError} when a list is not an array of strings.
+ */
+export const buildCodecPriorsBlock = (priors?: CodecPriors): string => {
+  if (priors === undefined) return ''
+
+  const sections: string[] = []
+  let remainingBudget = CODEC_PRIORS_MAX_BLOCK_CHARS
+
+  for (const { heading, label } of PRIOR_LISTS) {
+    const items = sanitisePriorList(label, priors[label])
+    if (items.length === 0) continue
+
+    const lines: string[] = []
+    for (const item of items) {
+      const line = `- ${item}`
+      if (line.length > remainingBudget) break
+      lines.push(line)
+      remainingBudget -= line.length
+    }
+    if (lines.length === 0) continue
+    sections.push(`### ${heading}\n${lines.join('\n')}`)
+  }
+
+  if (sections.length === 0) return ''
+
+  return [
+    '',
+    '## Project codec priors',
+    'The following are the project’s canonical entities, relations, and domain terms. Treat them as SOFT hints: when a saved fact references one of these, prefer the canonical name below. Do NOT invent facts to match them, and do NOT discard durable knowledge that falls outside this list.',
+    '',
+    ...sections,
+  ].join('\n')
+}
+
+/**
+ * Compose the effective extraction system prompt from the verbatim base
+ * prompt and the optional codec priors block.
+ */
+export const applyCodecPriors = (basePrompt: string, priors?: CodecPriors): string => {
+  const block = buildCodecPriorsBlock(priors)
+  return block === '' ? basePrompt : `${basePrompt}\n${block}`
+}
+
+const sanitisePriorList = (
+  label: keyof CodecPriors,
+  value: CodecPriors[keyof CodecPriors],
+): readonly string[] => {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) {
+    throw new CodecPriorsError(`${label} must be an array of strings`)
+  }
+
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of value) {
+    if (typeof raw !== 'string') {
+      throw new CodecPriorsError(`${label} must contain only strings`)
+    }
+    if (/[\n\r]/.test(raw)) {
+      throw new CodecPriorsError(`${label} must not contain line breaks`)
+    }
+    const trimmed = raw.trim()
+    if (trimmed === '') continue
+    const item = truncateItem(trimmed)
+    const key = item.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(item)
+    if (out.length >= CODEC_PRIORS_MAX_ITEMS_PER_LIST) break
+  }
+  return out
+}
+
+const truncateItem = (value: string): string => {
+  if (value.length <= CODEC_PRIORS_MAX_ITEM_LENGTH) return value
+  return value.slice(0, CODEC_PRIORS_MAX_ITEM_LENGTH)
+}

--- a/sdks/ts/memory/src/memory/extract-priors.test.ts
+++ b/sdks/ts/memory/src/memory/extract-priors.test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  Message,
+  Provider,
+  StructuredRequest,
+} from '../llm/index.js'
+import { createMemStore } from '../store/memstore.js'
+import { CodecPriorsError } from './codec-priors.js'
+import { createStoreBackedCursorStore } from './cursor.js'
+import { createMemory } from './index.js'
+import { EXTRACTION_SYSTEM_PROMPT } from './prompts.js'
+import type { CodecPriors } from './types.js'
+
+type Capture = { system: string; signalSeen: boolean }
+
+const capturingProvider = (capture: Capture, content: string): Provider & { calls: number } => {
+  const provider = {
+    calls: 0,
+    name: () => 'capture',
+    modelName: () => 'capture-model',
+    async *stream() {
+      yield { type: 'done', stopReason: 'end_turn' as const }
+    },
+    complete: async (req: CompletionRequest, signal?: AbortSignal): Promise<CompletionResponse> => {
+      provider.calls += 1
+      capture.system = req.system ?? ''
+      capture.signalSeen = signal !== undefined
+      if (signal?.aborted) {
+        throw new DOMException('aborted', 'AbortError')
+      }
+      return {
+        content,
+        toolCalls: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: 'end_turn',
+      }
+    },
+    supportsStructuredDecoding: () => false,
+    structured: async (_req: StructuredRequest) => content,
+  }
+  return provider
+}
+
+const messages = (n: number): Message[] => {
+  const out: Message[] = []
+  for (let i = 0; i < n; i++) {
+    out.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `msg ${i}` })
+  }
+  return out
+}
+
+const note = JSON.stringify({
+  memories: [
+    {
+      action: 'create',
+      filename: 'project-note.md',
+      name: 'Note',
+      description: 'a note',
+      type: 'project',
+      scope: 'project',
+      content: 'A durable project fact.',
+      index_entry: '- project-note.md: note',
+    },
+  ],
+})
+
+const newMemory = (capture: Capture, content: string) => {
+  const store = createMemStore()
+  const provider = capturingProvider(capture, content)
+  const mem = createMemory({
+    store,
+    provider,
+    cursorStore: createStoreBackedCursorStore(store),
+    scope: 'project',
+    actorId: 'tenant-a',
+  })
+  return { mem, provider, store }
+}
+
+describe('extract with codec priors — positive', () => {
+  it('injects the priors block into the system prompt passed to the provider', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const { mem } = newMemory(capture, note)
+    const priors: CodecPriors = {
+      entities: ['RoyalAWare', 'Sprint'],
+      relations: ['dependsOn'],
+      domainTerms: ['deployment'],
+    }
+    await mem.extract({ messages: messages(4), priors })
+
+    expect(capture.system.startsWith(EXTRACTION_SYSTEM_PROMPT)).toBe(true)
+    expect(capture.system).toContain('## Project codec priors')
+    expect(capture.system).toContain('- RoyalAWare')
+    expect(capture.system).toContain('- dependsOn')
+    expect(capture.system).toContain('- deployment')
+  })
+})
+
+describe('extract with codec priors — negative / backward compatibility', () => {
+  it('uses the byte-identical baseline prompt when priors are omitted', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const { mem } = newMemory(capture, note)
+    await mem.extract({ messages: messages(4) })
+    expect(capture.system).toBe(EXTRACTION_SYSTEM_PROMPT)
+  })
+
+  it('uses the byte-identical baseline prompt when priors are empty', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const { mem } = newMemory(capture, note)
+    await mem.extract({ messages: messages(4), priors: { entities: [], relations: [] } })
+    expect(capture.system).toBe(EXTRACTION_SYSTEM_PROMPT)
+  })
+
+  it('throws a typed error and never calls the provider for malformed priors', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const { mem, provider } = newMemory(capture, note)
+    const malformed = { entities: ['ok', 'bad\ninjection'] } as CodecPriors
+    await expect(mem.extract({ messages: messages(4), priors: malformed })).rejects.toBeInstanceOf(
+      CodecPriorsError,
+    )
+    expect(provider.calls).toBe(0)
+  })
+})
+
+describe('extract with codec priors — edge', () => {
+  it('threads the abort signal and honours a pre-aborted signal', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const { mem, provider } = newMemory(capture, note)
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      mem.extract({ messages: messages(4), signal: controller.signal }),
+    ).rejects.toBeInstanceOf(DOMException)
+    // Pre-aborted: provider is never invoked.
+    expect(provider.calls).toBe(0)
+  })
+
+  it('honours an abort raised by the provider mid-call', async () => {
+    const capture: Capture = { system: '', signalSeen: false }
+    const store = createMemStore()
+    const controller = new AbortController()
+    const provider = {
+      name: () => 'aborting',
+      modelName: () => 'aborting-model',
+      async *stream() {
+        yield { type: 'done', stopReason: 'end_turn' as const }
+      },
+      complete: async (
+        req: CompletionRequest,
+        signal?: AbortSignal,
+      ): Promise<CompletionResponse> => {
+        capture.signalSeen = signal !== undefined
+        controller.abort()
+        throw new DOMException('aborted', 'AbortError')
+      },
+      supportsStructuredDecoding: () => false,
+      structured: async (_req: StructuredRequest) => note,
+    }
+    const mem = createMemory({
+      store,
+      provider,
+      cursorStore: createStoreBackedCursorStore(store),
+      scope: 'project',
+      actorId: 'tenant-a',
+    })
+    await expect(
+      mem.extract({ messages: messages(4), signal: controller.signal }),
+    ).rejects.toBeInstanceOf(DOMException)
+    expect(capture.signalSeen).toBe(true)
+  })
+
+  it('keeps concurrent extract calls independent', async () => {
+    const captureA: Capture = { system: '', signalSeen: false }
+    const captureB: Capture = { system: '', signalSeen: false }
+    const a = newMemory(captureA, note)
+    const b = newMemory(captureB, note)
+    await Promise.all([
+      a.mem.extract({ messages: messages(4), priors: { entities: ['Alpha'] } }),
+      b.mem.extract({ messages: messages(4), priors: { entities: ['Beta'] } }),
+    ])
+    expect(captureA.system).toContain('- Alpha')
+    expect(captureA.system).not.toContain('- Beta')
+    expect(captureB.system).toContain('- Beta')
+    expect(captureB.system).not.toContain('- Alpha')
+  })
+})

--- a/sdks/ts/memory/src/memory/extract.ts
+++ b/sdks/ts/memory/src/memory/extract.ts
@@ -13,6 +13,7 @@ import type { Logger, Message, Provider } from '../llm/index.js'
 import { expandTemporal } from '../query/temporal.js'
 import type { Store } from '../store/index.js'
 import { lastSegment } from '../store/path.js'
+import { applyCodecPriors } from './codec-priors.js'
 import { buildFrontmatter } from './frontmatter.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { ensureMarkdown, scopeIndex, scopePrefix, scopeTopic } from './paths.js'
@@ -203,6 +204,17 @@ export const createPreviewExtract = (deps: ExtractDeps) => {
     runExtract(deps, args, { persist: false, advanceCursor: false })
 }
 
+const abortError = (signal: AbortSignal): Error => {
+  const reason = signal.reason
+  if (reason instanceof Error) return reason
+  return new DOMException('The extract operation was aborted', 'AbortError')
+}
+
+const isAbortError = (err: unknown, signal?: AbortSignal): boolean => {
+  if (signal?.aborted) return true
+  return err instanceof DOMException && err.name === 'AbortError'
+}
+
 const runExtract = async (
   deps: ExtractDeps,
   args: ExtractArgs,
@@ -239,17 +251,30 @@ const runExtract = async (
   }
 
   const userPrompt = buildExtractUserPrompt(windowed, existingMemories)
+  // Compose the effective system prompt outside the try/catch so a typed
+  // CodecPriorsError from malformed priors surfaces to the caller rather
+  // than being swallowed as a provider failure.
+  const systemPrompt = applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, args.priors)
+
+  if (args.signal?.aborted) throw abortError(args.signal)
 
   let raw: string
   try {
-    const resp = await deps.provider.complete({
-      messages: [{ role: 'user', content: userPrompt }],
-      system: EXTRACTION_SYSTEM_PROMPT,
-      maxTokens: EXTRACT_MAX_TOKENS,
-      temperature: EXTRACT_TEMPERATURE,
-    })
+    const resp = await deps.provider.complete(
+      {
+        messages: [{ role: 'user', content: userPrompt }],
+        system: systemPrompt,
+        maxTokens: EXTRACT_MAX_TOKENS,
+        temperature: EXTRACT_TEMPERATURE,
+      },
+      args.signal,
+    )
     raw = resp.content
   } catch (err) {
+    // Honour cancellation explicitly: a triggered AbortSignal stops the
+    // extract immediately and propagates rather than being swallowed as a
+    // generic provider failure (no persist, no cursor advance).
+    if (isAbortError(err, args.signal)) throw err
     deps.logger.warn('memory: extract provider call failed', {
       err: err instanceof Error ? err.message : String(err),
     })

--- a/sdks/ts/memory/src/memory/index.ts
+++ b/sdks/ts/memory/src/memory/index.ts
@@ -163,6 +163,7 @@ export const createMemory = (opts: MemoryOpts): Memory => {
 }
 
 export type {
+  CodecPriors,
   ConsolidateArgs,
   ConsolidationOp,
   ConsolidationPayload,
@@ -217,6 +218,14 @@ export {
   RECALL_SELECTOR_SYSTEM_PROMPT,
   REFLECTION_SYSTEM_PROMPT,
 } from './prompts.js'
+export {
+  CODEC_PRIORS_MAX_BLOCK_CHARS,
+  CODEC_PRIORS_MAX_ITEM_LENGTH,
+  CODEC_PRIORS_MAX_ITEMS_PER_LIST,
+  CodecPriorsError,
+  applyCodecPriors,
+  buildCodecPriorsBlock,
+} from './codec-priors.js'
 export {
   createContextualPrefixBuilder,
   type ContextualPrefixBuilderConfig,

--- a/sdks/ts/memory/src/memory/types.ts
+++ b/sdks/ts/memory/src/memory/types.ts
@@ -349,6 +349,25 @@ export type MemoryOpts = {
   readonly contextualPrefixBuilder?: ContextualPrefixBuilder
 }
 
+/**
+ * Codec priors are the project's canonical vocabulary, folded into the
+ * extraction prompt as SOFT known-entity hints. They mirror the codec
+ * `ontology:` frontmatter block (plain string lists) and are deliberately
+ * distinct from the typed `ResolvedOntology` used by the ontology-type
+ * extractor — codec priors carry no types, attributes, or endpoints.
+ *
+ * All three lists are optional; an absent or wholly empty value leaves
+ * extraction behaviour byte-identical to the no-priors baseline.
+ */
+export type CodecPriors = {
+  /** Canonical entity names, e.g. `['Person', 'Organisation', 'Product']`. */
+  readonly entities?: readonly string[]
+  /** Canonical relation names, e.g. `['worksAt', 'owns', 'dependsOn']`. */
+  readonly relations?: readonly string[]
+  /** Domain vocabulary / shorthand, e.g. `['sprint', 'deployment']`. */
+  readonly domainTerms?: readonly string[]
+}
+
 /** Arguments accepted by `extract`. */
 export type ExtractArgs = {
   readonly messages: readonly Message[]
@@ -356,6 +375,14 @@ export type ExtractArgs = {
   readonly scope?: Scope
   readonly sessionId?: string
   readonly sessionDate?: string
+  /**
+   * Optional codec priors that shape extraction towards the project's
+   * canonical entities, relations, and domain terms. Omitted or empty ⇒
+   * byte-identical to current behaviour.
+   */
+  readonly priors?: CodecPriors
+  /** Optional cancellation signal threaded into the extraction LLM call. */
+  readonly signal?: AbortSignal
 }
 
 /** Arguments accepted by `reflect`. */


### PR DESCRIPTION
## Summary

Engine half of the codec feature (**Option B**, decision locked). Adds an **optional `priors` input** to the memory-note extraction path so extraction reuses a project's canonical vocabulary. Backward-compatible, bounded, deduped, with Go↔TS parity. The typed-ontology `ontology.Extractor` (its `existingTypes`) is intentionally untouched — that is the other extractor lleverage is removing.

## Priors API added

Codec priors are plain string lists (the codec `ontology:` block), kept as their own simple type — **not** reusing `ResolvedOntology`.

**TypeScript** (`sdks/ts/memory/src/memory`)
- `types.ts`: new `CodecPriors` (`entities` / `relations` / `domainTerms`), plus `ExtractArgs.priors?` and `ExtractArgs.signal?` on `createMemory().extract`.
- `codec-priors.ts` (new): `buildCodecPriorsBlock`, `applyCodecPriors`, `CodecPriorsError`, bound consts. Pure, side-effect-free.
- `extract.ts` (`runExtract`): composes the effective system prompt via `applyCodecPriors(EXTRACTION_SYSTEM_PROMPT, args.priors)` (malformed → typed error before any LLM call); threads `args.signal` into `provider.complete(req, signal)`; pre-checks and propagates abort.
- `index.ts`: exports the new type and helpers.

**Go** (`go/memory`)
- `codec_priors.go` (new): `CodecPriors` struct, `ErrInvalidCodecPriors`, `buildCodecPriorsBlock`, `applyCodecPriors`. Rune-safe truncation.
- `extract.go`: new public `ExtractFromMessagesWithPriors(...)`; private `extractFromMessagesWithSession` gains a `priors *CodecPriors` param (existing callers pass `nil`); composes the system prompt and honours `ctx` cancellation before the call. Go already threaded `context.Context` to `provider.Complete`.

## Parity evidence
- Go↔TS **golden byte-for-byte parity test** on the rendered priors block: `TestBuildCodecPriorsBlock_GoldenParity` (Go) and `buildCodecPriorsBlock — Go/TS parity` (TS). Identical framing string (same typographic apostrophe), heading order, and `- item` formatting.
- Same bounds in both languages: 64 items/list, 80 chars/item, 4000-char block budget; case-insensitive dedup, first-occurrence-wins; line-break items rejected as a typed error.

## Tests (positive / negative / edge × Go + TS)
- **TS** unit `codec-priors.test.ts` (16) + integration `extract-priors.test.ts` (7): inject-into-prompt, byte-identical baseline when omitted/empty, typed error + no-provider-call on malformed, abort pre/mid-call, item caps/truncation/dedup, bounded growth, concurrent-independence. All pass.
- **Go** unit `codec_priors_test.go` + integration `extract_priors_test.go`: mirror set incl. cancelled-context honoured (no provider call), concurrent independence under `-race`. All pass.
- `bun run typecheck` clean (`tsc -b`). `cd go && go test -race -timeout 10m ./...` all `ok`; `go vet` clean. Full `bun run test`: **2074 passed**, 4 failures confined to the documented pre-existing flakes (`cli/config`, `cli/integration`, `cron`) — `cron` verified failing identically on base `develop`.

## RC 0.4.0-rc.3 prep (NOT cut — awaiting approval)
- `@jeffs-brain/memory` → `0.4.0-rc.3`; `go/cmd/memory` version → `0.4.0-rc.3`; CHANGELOG entry; `bun.lock` refreshed. `memory-postgres` unchanged (stays `0.2.0-rc.2`).
- Cut steps (do not run without approval): merge this PR → `develop`; `gh workflow run release.yml --ref develop`; verify `npm dist-tag ls @jeffs-brain/memory` shows `rc = 0.4.0-rc.3`; watch for the `workspace:*` peer-leak (ensure published `dependencies` carry no `workspace:` specifiers — verified none in `sdks/ts/memory/package.json`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional codec priors support for memory extraction—pass hints for entities, relations, and domain terms to guide LLM-based memory identification.
  * Added cancellation support for TypeScript extraction via `AbortSignal`.

* **Tests**
  * Added Go↔TypeScript golden parity test to ensure byte-for-byte matching of codec priors rendering across implementations.

* **Chores**
  * Version bumped to RC3 for both Go and TypeScript SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->