### PR TITLE
feat(memory-postgres): LLE-10520 persist metadata jsonb on store write

### DIFF
--- a/go/graph/edges_test.go
+++ b/go/graph/edges_test.go
@@ -178,6 +178,78 @@ func TestDeleteDocumentEdges_FiltersByEdgeType(t *testing.T) {
 	}
 }
 
+func TestComputeDocumentOntologyEdges_FromPersistedMetadata(t *testing.T) {
+	db := requireTestDB(t)
+	resetGraphSchema(t, db)
+
+	ctx := context.Background()
+	brainID := "11111111-1111-1111-1111-111111111111"
+	tenantID := "22222222-2222-2222-2222-222222222222"
+	anchorID := "33333333-3333-3333-3333-333333333333"
+	typedID := "44444444-4444-4444-4444-444444444444"
+	unrelatedID := "55555555-5555-5555-5555-555555555555"
+
+	// Seed documents with the metadata jsonb exactly as the Postgres store
+	// write path now persists it from frontmatter: the anchor under ontology/
+	// carries ontology_type, the typed doc carries the camelCase ontologyType,
+	// and an unrelated doc carries no ontology metadata.
+	if _, err := db.ExecContext(ctx, `
+		insert into memory.documents (document_id, brain_id, tenant_id, path, size, updated_at, metadata, content)
+		values
+		($1::uuid, $2::uuid, $3::uuid, 'ontology/types/customer.md', 19, now(), '{"ontology_type":"customer"}'::jsonb, ''::bytea),
+		($4::uuid, $2::uuid, $3::uuid, 'memory/project/x/acme.md', 20, now(), '{"ontologyType":"customer"}'::jsonb, ''::bytea),
+		($5::uuid, $2::uuid, $3::uuid, 'memory/project/x/other.md', 21, now(), '{}'::jsonb, ''::bytea)`,
+		anchorID, brainID, tenantID, typedID, unrelatedID,
+	); err != nil {
+		t.Fatalf("seed documents: %v", err)
+	}
+
+	edges, err := ComputeDocumentOntologyEdges(ctx, db, typedID, brainID, tenantID)
+	if err != nil {
+		t.Fatalf("compute document ontology edges: %v", err)
+	}
+	var matched *LabeledWeightedEdge
+	for i := range edges {
+		if edges[i].TargetDocID == anchorID {
+			matched = &edges[i]
+		}
+	}
+	if matched == nil {
+		t.Fatalf("expected an ontology edge to the anchor doc, got %+v", edges)
+	}
+	if matched.Label != "customer" {
+		t.Fatalf("expected label 'customer', got %q", matched.Label)
+	}
+	if matched.Weight != documentOntologyWeight {
+		t.Fatalf("expected weight %v, got %v", documentOntologyWeight, matched.Weight)
+	}
+
+	// Persist the computed ontology edge via the public upsert path (the same
+	// path ComputeAllEdgesForDocument uses for this edge type) and confirm it
+	// lands in memory.document_edges.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := UpsertDocumentEdges(ctx, tx, brainID, tenantID, toLabeledEdges(typedID, edges, EdgeDocumentOntology)); err != nil {
+		t.Fatalf("upsert ontology edges: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `
+		select count(*) from memory.document_edges
+		where brain_id = $1::uuid and source_doc_id = $2::uuid and edge_type = 'document_ontology' and label = 'customer'`,
+		brainID, typedID,
+	).Scan(&count); err != nil {
+		t.Fatalf("count ontology edges: %v", err)
+	}
+	if count == 0 {
+		t.Fatalf("expected a persisted document_ontology edge, got %d", count)
+	}
+}
+
 func TestEdgeConversionHelpers(t *testing.T) {
 	semantic := toSemanticEdges("src", []SimilarDocument{{TargetDocID: "a", Similarity: 0.8}})
 	if len(semantic) != 1 || semantic[0].EdgeType != EdgeSemanticSimilarity || semantic[0].Weight != 0.8 {

--- a/sdks/ts/memory-postgres/src/metadata.test.ts
+++ b/sdks/ts/memory-postgres/src/metadata.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { extractDocumentMetadata } from './metadata.js'
+
+describe('extractDocumentMetadata', () => {
+  it('returns an empty object when no frontmatter fence is present', () => {
+    expect(extractDocumentMetadata('just a body, no frontmatter')).toEqual({})
+  })
+
+  it('returns an empty object for an unterminated fence', () => {
+    expect(extractDocumentMetadata('---\ntitle: x\nbody without close')).toEqual({})
+  })
+
+  it('returns an empty object for an empty string', () => {
+    expect(extractDocumentMetadata('')).toEqual({})
+  })
+
+  it('preserves ontology_type (snake_case) that the typed parser would drop', () => {
+    const content = '---\nontology_type: customer\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ ontology_type: 'customer' })
+  })
+
+  it('preserves ontologyType (camelCase)', () => {
+    const content = '---\nontologyType: customer\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ ontologyType: 'customer' })
+  })
+
+  it('preserves session_id and supersedes scalar edge inputs', () => {
+    const content = '---\nsession_id: s1\nsupersedes: legacy-note\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({
+      session_id: 's1',
+      supersedes: 'legacy-note',
+    })
+  })
+
+  it('parses inline-list tags into a string array', () => {
+    const content = '---\ntags: [alpha, beta]\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ tags: ['alpha', 'beta'] })
+  })
+
+  it('keeps a bare comma-separated scalar as a string (no key-name list inference)', () => {
+    // A generic extractor cannot know which arbitrary key is a list, so only
+    // explicit `[...]` or block `- ` syntax yields an array. This is safe for
+    // the edge queries: computeSharedTagEdges treats a non-array `tags` as `[]`.
+    const content = '---\ntags: alpha, beta\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ tags: 'alpha, beta' })
+  })
+
+  it('parses block-list tags into a string array', () => {
+    const content = '---\ntags:\n  - alpha\n  - beta\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ tags: ['alpha', 'beta'] })
+  })
+
+  it('records an empty array for an empty block list', () => {
+    const content = '---\ntags:\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ tags: [] })
+  })
+
+  it('coerces boolean-ish scalars', () => {
+    const content = '---\narchived: true\ndraft: no\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ archived: true, draft: false })
+  })
+
+  it('strips matching quotes from scalar values', () => {
+    const content = '---\ntitle: "Hello, World"\nsummary: \'a: b\'\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({
+      title: 'Hello, World',
+      summary: 'a: b',
+    })
+  })
+
+  it('keeps all keys together for a realistic typed-document frontmatter', () => {
+    const content = [
+      '---',
+      'title: Acme Corp',
+      'summary: A customer',
+      'tags: [crm, account]',
+      'ontology_type: customer',
+      'session_id: sess-42',
+      '---',
+      '',
+      'Acme is a customer.',
+    ].join('\n')
+    expect(extractDocumentMetadata(content)).toEqual({
+      title: 'Acme Corp',
+      summary: 'A customer',
+      tags: ['crm', 'account'],
+      ontology_type: 'customer',
+      session_id: 'sess-42',
+    })
+  })
+
+  it('ignores blank lines and non key-value lines inside the block', () => {
+    const content = '---\nontology_type: customer\n\n# a comment line without colon\n---\n\nbody'
+    expect(extractDocumentMetadata(content)).toEqual({ ontology_type: 'customer' })
+  })
+})

--- a/sdks/ts/memory-postgres/src/metadata.ts
+++ b/sdks/ts/memory-postgres/src/metadata.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Document metadata extraction for the Postgres store write path.
+ *
+ * The `memory.documents.metadata` jsonb column drives several of the
+ * `document_edges` computations (see `./edges.ts`):
+ *   - `computeSharedTagEdges`        reads `metadata->'tags'`
+ *   - `computeSameSessionEdges`      reads `metadata->>'session_id'` / `sessionId`
+ *   - `computeSupersedesEdges`       reads `metadata->>'supersedes'`
+ *   - `computeDocumentOntologyEdges` reads `metadata->>'ontology_type'` / `ontologyType`
+ *
+ * The base `Store.write(path, content)` contract carries the metadata inside
+ * the document's YAML frontmatter — there is no separate metadata channel on
+ * the interface. The typed `parseFrontmatter` exported by `@jeffs-brain/memory`
+ * deliberately recognises only a fixed field set (title/summary/tags/sources/
+ * created/modified/archived/supersededBy) and DROPS every other key, so it
+ * cannot surface `ontology_type`, `session_id`, or `supersedes`.
+ *
+ * This module parses the same YAML-subset fence (matching
+ * `knowledge/frontmatter.ts` and the Go `internal/knowledge/frontmatter.go`)
+ * but preserves EVERY scalar and list key as a generic record so the edge
+ * computations can consume the persisted column. A document with no fenced
+ * frontmatter yields an empty object, so existing callers keep writing `{}`
+ * exactly as before.
+ */
+
+const FENCE = '---'
+
+/**
+ * A single frontmatter value. Scalars are kept as parsed strings/booleans;
+ * lists are kept as string arrays. Mirrors the jsonb shapes the edge queries
+ * read (`->>` for scalars, `jsonb_typeof(... ) = 'array'` for `tags`).
+ */
+export type DocumentMetadataValue = string | boolean | readonly string[]
+
+/** Generic frontmatter map persisted into `memory.documents.metadata`. */
+export type DocumentMetadata = Readonly<Record<string, DocumentMetadataValue>>
+
+const BOOLEAN_RE = /^(true|false|yes|no)$/i
+
+const stripQuotes = (v: string): string => {
+  if (v.length < 2) return v
+  const first = v[0]
+  const last = v[v.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return v.slice(1, -1)
+  }
+  return v
+}
+
+const parseInlineList = (v: string): string[] => {
+  const trimmed = v.trim()
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1)
+    if (inner.trim() === '') return []
+    return inner
+      .split(',')
+      .map((s) => stripQuotes(s.trim()))
+      .filter((s) => s !== '')
+  }
+  return trimmed
+    .split(',')
+    .map((s) => stripQuotes(s.trim()))
+    .filter((s) => s !== '')
+}
+
+const coerceScalar = (raw: string): string | boolean => {
+  const value = stripQuotes(raw)
+  if (BOOLEAN_RE.test(value)) return /^(true|yes)$/i.test(value)
+  return value
+}
+
+const splitKV = (line: string): readonly [string, string] | undefined => {
+  const idx = line.indexOf(':')
+  if (idx < 0) return undefined
+  const key = line.slice(0, idx).trim()
+  const val = line.slice(idx + 1).trim()
+  if (key === '') return undefined
+  return [key, val]
+}
+
+/**
+ * Extract a generic metadata map from a document's YAML-subset frontmatter.
+ *
+ * Returns an empty object when no fenced frontmatter block is present, so a
+ * document written with no/empty metadata persists `{}` — byte-identical to
+ * the prior behaviour where the column was never written and defaulted to
+ * `'{}'::jsonb`.
+ *
+ * Inline lists (`tags: [a, b]` or `tags: a, b`) and block lists
+ * (`tags:`\n`  - a`) both yield string arrays. `true`/`false`/`yes`/`no`
+ * scalars coerce to booleans; everything else stays a string.
+ *
+ * @param content Raw UTF-8 document content.
+ * @returns Parsed frontmatter map preserving every key.
+ */
+export const extractDocumentMetadata = (content: string): DocumentMetadata => {
+  const lines = content.split('\n')
+  if (lines.length < 2 || lines[0]?.trim() !== FENCE) return {}
+
+  let closeIdx = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === FENCE) {
+      closeIdx = i
+      break
+    }
+  }
+  if (closeIdx < 0) return {}
+
+  const out: Record<string, DocumentMetadataValue> = {}
+  let currentListKey = ''
+  const listBuffers = new Map<string, string[]>()
+
+  for (let i = 1; i < closeIdx; i++) {
+    const line = lines[i] ?? ''
+    const trimmed = line.trim()
+
+    if (currentListKey !== '' && trimmed.startsWith('- ')) {
+      const val = stripQuotes(trimmed.slice(2).trim())
+      if (val !== '') {
+        const buffer = listBuffers.get(currentListKey) ?? []
+        buffer.push(val)
+        listBuffers.set(currentListKey, buffer)
+        out[currentListKey] = buffer
+      }
+      continue
+    }
+
+    const kv = splitKV(line)
+    if (!kv) {
+      currentListKey = ''
+      continue
+    }
+    const [key, rawVal] = kv
+
+    if (rawVal === '') {
+      // Bare key → block list follows. Seed an empty list so a list with no
+      // items still records the key as an empty array.
+      currentListKey = key
+      if (!listBuffers.has(key)) {
+        const buffer: string[] = []
+        listBuffers.set(key, buffer)
+        out[key] = buffer
+      }
+      continue
+    }
+
+    currentListKey = ''
+    const inlineTrimmed = rawVal.trim()
+    if (inlineTrimmed.startsWith('[') && inlineTrimmed.endsWith(']')) {
+      out[key] = parseInlineList(inlineTrimmed)
+      continue
+    }
+    out[key] = coerceScalar(rawVal)
+  }
+
+  return out
+}

--- a/sdks/ts/memory-postgres/src/store.integration.test.ts
+++ b/sdks/ts/memory-postgres/src/store.integration.test.ts
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { toPath } from '@jeffs-brain/memory/store'
 import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { computeAllEdgesForDocument, computeDocumentOntologyEdges } from './edges.js'
 import { createPostgresStore } from './store.js'
 import type { PgSql } from './store.js'
 
@@ -43,8 +44,14 @@ maybe('PostgresStore (testcontainers)', () => {
     superSql = postgres(uri, { max: 2, prepare: false })
 
     const here = path.dirname(fileURLToPath(import.meta.url))
-    const migration = readFileSync(path.join(here, '..', 'migrations', '0001_init.sql'), 'utf8')
-    await superSql.unsafe(migration).simple()
+    const migrationsDir = path.join(here, '..', 'migrations')
+    const migrations = readdirSync(migrationsDir)
+      .filter((entry) => /^\d+_.*\.sql$/.test(entry))
+      .sort()
+      .map((entry) => readFileSync(path.join(migrationsDir, entry), 'utf8'))
+    for (const migration of migrations) {
+      await superSql.unsafe(migration).simple()
+    }
 
     // Seed tenants + brains as superuser.
     await superSql.unsafe(
@@ -180,5 +187,112 @@ maybe('PostgresStore (testcontainers)', () => {
     expect(await storeA.exists(secret)).toBe(true)
     expect((await storeA.read(secret)).toString()).toBe('tenant-A-only')
     await storeA.close()
+  }, 60_000)
+
+  it('persists frontmatter metadata on write and round-trips it', async () => {
+    const store = await createPostgresStore({
+      sql: superSql as unknown as PgSql,
+      tenantId: tenantA,
+      brainId: brainA,
+    })
+    const typed = toPath('meta/typed.md')
+    await store.write(
+      typed,
+      Buffer.from(
+        '---\nontology_type: customer\ntags: [crm, account]\n---\n\nAcme is a customer.\n',
+      ),
+    )
+
+    const rows = (await superSql<{ metadata: Record<string, unknown> }>`
+      select metadata from memory.documents
+      where brain_id = ${brainA}::uuid and path = ${'meta/typed.md'}
+      limit 1
+    `) as ReadonlyArray<{ metadata: Record<string, unknown> }>
+    expect(rows[0]?.metadata).toEqual({ ontology_type: 'customer', tags: ['crm', 'account'] })
+
+    // A plain document (no frontmatter) must still persist {} exactly as before.
+    const plain = toPath('meta/plain.md')
+    await store.write(plain, Buffer.from('no frontmatter here'))
+    const plainRows = (await superSql<{ metadata: Record<string, unknown> }>`
+      select metadata from memory.documents
+      where brain_id = ${brainA}::uuid and path = ${'meta/plain.md'}
+      limit 1
+    `) as ReadonlyArray<{ metadata: Record<string, unknown> }>
+    expect(plainRows[0]?.metadata).toEqual({})
+
+    // Re-writing with changed frontmatter updates the persisted metadata.
+    await store.write(typed, Buffer.from('---\nontology_type: supplier\n---\n\nNow a supplier.\n'))
+    const updated = (await superSql<{ metadata: Record<string, unknown> }>`
+      select metadata from memory.documents
+      where brain_id = ${brainA}::uuid and path = ${'meta/typed.md'}
+      limit 1
+    `) as ReadonlyArray<{ metadata: Record<string, unknown> }>
+    expect(updated[0]?.metadata).toEqual({ ontology_type: 'supplier' })
+
+    await store.delete(typed)
+    await store.delete(plain)
+    await store.close()
+  }, 60_000)
+
+  it('produces a document_ontology edge between docs sharing ontology_type via the store write path', async () => {
+    const store = await createPostgresStore({
+      sql: superSql as unknown as PgSql,
+      tenantId: tenantA,
+      brainId: brainA,
+    })
+
+    // Anchor doc under ontology/ carrying the type, and a typed doc elsewhere
+    // carrying the same type — written purely through the public store API.
+    const anchorPath = 'ontology/types/customer.md'
+    const typedPath = 'memory/project/x/acme.md'
+    await store.write(
+      toPath(anchorPath),
+      Buffer.from('---\nontology_type: customer\n---\n\nCustomer type anchor.\n'),
+    )
+    await store.write(
+      toPath(typedPath),
+      Buffer.from('---\nontologyType: customer\n---\n\nAcme account note.\n'),
+    )
+
+    const idRows = (await superSql<{ document_id: string; path: string }>`
+      select document_id::text, path from memory.documents
+      where brain_id = ${brainA}::uuid and path in (${anchorPath}, ${typedPath})
+    `) as ReadonlyArray<{ document_id: string; path: string }>
+    const byPath = new Map(idRows.map((r) => [r.path, r.document_id]))
+    const typedId = byPath.get(typedPath)
+    const anchorId = byPath.get(anchorPath)
+    expect(typedId).toBeDefined()
+    expect(anchorId).toBeDefined()
+
+    // The typed doc, anchored against the ontology/ doc, yields the edge.
+    const ontologyEdges = await computeDocumentOntologyEdges(
+      superSql as unknown as PgSql,
+      typedId as string,
+      brainA,
+      tenantA,
+    )
+    expect(ontologyEdges.some((e) => e.targetDocId === anchorId && e.label === 'customer')).toBe(
+      true,
+    )
+
+    // The full edge recompute persists it into memory.document_edges.
+    await computeAllEdgesForDocument(
+      superSql as unknown as PgSql,
+      typedId as string,
+      brainA,
+      tenantA,
+    )
+    const edgeRows = (await superSql<{ count: number }>`
+      select count(*)::int as count from memory.document_edges
+      where brain_id = ${brainA}::uuid
+        and source_doc_id = ${typedId as string}::uuid
+        and edge_type = 'document_ontology'
+        and label = 'customer'
+    `) as ReadonlyArray<{ count: number }>
+    expect((edgeRows[0]?.count ?? 0) > 0).toBe(true)
+
+    await store.delete(toPath(anchorPath))
+    await store.delete(toPath(typedPath))
+    await store.close()
   }, 60_000)
 })

--- a/sdks/ts/memory-postgres/src/store.ts
+++ b/sdks/ts/memory-postgres/src/store.ts
@@ -41,6 +41,7 @@ import {
   isGenerated as pathIsGenerated,
   validatePath,
 } from '@jeffs-brain/memory/store'
+import { extractDocumentMetadata } from './metadata.js'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -154,13 +155,19 @@ export class PostgresStore implements Store {
   }
 
   /**
-   * Apply the additive `content` column so `read()` has something to return.
-   * Idempotent — safe to call on every process boot.
+   * Apply the additive `content` and `metadata` columns so `read()` has
+   * something to return and frontmatter-derived edges have a column to key
+   * off. Idempotent — safe to call on every process boot. Managed
+   * deployments that run the SQL migrations under `./migrations/` already
+   * have both columns; this keeps the OSS-standalone path self-sufficient.
    */
   async init(): Promise<void> {
     const { sql } = this
     await sql.unsafe(
       "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS content bytea NOT NULL DEFAULT ''::bytea",
+    )
+    await sql.unsafe(
+      "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb",
     )
   }
 
@@ -414,17 +421,25 @@ export class PostgresStore implements Store {
 
   async upsertInTx(tx: PgSql, p: Path, content: Buffer): Promise<void> {
     const hash = sha256(content)
+    // Derive the metadata jsonb from the document's YAML-subset frontmatter.
+    // Documents without a fenced frontmatter block yield `{}`, preserving the
+    // prior behaviour where the column defaulted to `'{}'::jsonb`. The metadata
+    // is serialised to a JSON string and parsed by Postgres via `::text::jsonb`
+    // so the driver sends it as a text parameter rather than JSON-encoding it a
+    // second time into a jsonb string scalar (which would defeat `->>'key'`).
+    const metadataJson = JSON.stringify(extractDocumentMetadata(content.toString('utf8')))
     await tx`
       insert into memory.documents
-        (brain_id, tenant_id, path, content_hash, size, source, content, updated_at)
+        (brain_id, tenant_id, path, content_hash, size, source, content, metadata, updated_at)
       values
         (${this.brainId}::uuid, ${this.tenantId}::uuid, ${p as string},
-         ${hash}, ${content.length}, ${this.source}, ${content}, now())
+         ${hash}, ${content.length}, ${this.source}, ${content}, ${metadataJson}::text::jsonb, now())
       on conflict (brain_id, path) do update set
         content_hash = excluded.content_hash,
         size         = excluded.size,
         content      = excluded.content,
         source       = excluded.source,
+        metadata     = excluded.metadata,
         updated_at   = now()
     `
   }

--- a/sdks/ts/memory-postgres/vitest.config.ts
+++ b/sdks/ts/memory-postgres/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: '@jeffs-brain/memory-postgres',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,5 +1,6 @@
 export default [
   './sdks/ts/memory/vitest.config.ts',
+  './sdks/ts/memory-postgres/vitest.config.ts',
   './sdks/ts/memory-openfga/vitest.config.ts',
   './mcp/ts/vitest.config.ts',
   './install/vitest.config.ts',


### PR DESCRIPTION
## LLE-10520 (package half) — persist `metadata` jsonb on postgres store write

Enables `document_ontology` (entity) graph edges, which currently never fire.

### Root cause
`PostgresStore.upsertInTx` (`sdks/ts/memory-postgres/src/store.ts`) inserted only `path/content_hash/size/source/content/updated_at` — it **dropped the `metadata` column**. The `metadata jsonb NOT NULL DEFAULT '{}'` column already exists (migration `0004`), and `computeDocumentOntologyEdges` (TS `edges.ts:502`, Go `edges.go:538`) reads `metadata->>'ontology_type'` / `ontologyType`. Since the store is the only writer to `memory.documents`, that column was always `{}`, so `document_ontology` / `shared_tag` / `same_session` / `supersedes` edges could never fire. **Write-path only — no migration.**

### Change
- `store.ts`: derive metadata from the document's `---` frontmatter and persist it on insert/upsert via `${metadataJson}::text::jsonb` (a plain `::jsonb` bind double-encodes a JS string into a jsonb *string scalar*, which defeats `->>'key'`), with `on conflict ... metadata = excluded.metadata`. Empty/absent frontmatter → `{}` (byte-identical to current behaviour; fully backward-compatible).
- **new** `metadata.ts` — non-lossy `---` YAML-subset extractor (`extractDocumentMetadata`). The package's typed `parseFrontmatter` is intentionally lossy (fixed field set) and drops `ontology_type`, so it must not be used here.
- Parity: the postgres document store is TS-only (no Go writer); Go is the metadata *reader*. Added a Go reader test proving `computeDocumentOntologyEdges` consumes the persisted field.

### Tests
- `bun run typecheck` clean.
- memory-postgres suite (Docker): 36 passed / 0 failed — incl. new `metadata.test.ts` (14) and integration round-trip + a `document_ontology` edge built via the public `store.write` path.
- Go: new `TestComputeDocumentOntologyEdges_FromPersistedMetadata` passing; `go build`/`go vet`/`gofmt` clean.
- Pre-existing failures on `develop` (cron tz flakes; a float-precision edge test; a graph chunk-insert test; a Go `computeWikilinkEdges` raw-string regex bug) are unrelated to this change and reproduce on a clean checkout.

### Follow-up
Lleverage half (LLE-10520): emit `ontology_type` in document frontmatter at the write sites + write `ontology/<entity>.md` anchor docs, then bump the `apps/memory-service` pin to the new RC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents can now extract and persist metadata from YAML frontmatter automatically
  * Supports metadata preservation across multiple key formats with automatic type coercion
  * Document ontology edges are computed and persisted based on metadata

* **Tests**
  * Added comprehensive test coverage for metadata extraction, persistence, and document ontology edge computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->