### PR TITLE
fix(memory-postgres): LLE-10529 memoise store.init ensure-schema + lock_timeout

### DIFF
--- a/sdks/ts/memory-postgres/src/store.init.test.ts
+++ b/sdks/ts/memory-postgres/src/store.init.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_INIT_LOCK_TIMEOUT_MS,
+  PostgresStore,
+  type PgPendingQuery,
+  type PgSql,
+} from './store.js'
+
+const TENANT_ID = '11111111-1111-1111-1111-111111111111'
+const BRAIN_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+
+type Recorder = {
+  readonly ddl: string[]
+  readonly setConfig: Array<{ key: unknown; value: unknown }>
+  beginCalls: number
+}
+
+/**
+ * Build a structural {@link PgSql} fake that records every `unsafe` DDL
+ * statement and every parameterised `set_config(...)` tagged-template call.
+ * `begin` invokes the callback with a transaction-scoped fake whose calls are
+ * recorded against the same recorder, mirroring postgres.js semantics closely
+ * enough to assert on the ensure-schema path without a live database.
+ */
+const makeFakeSql = (
+  recorder: Recorder,
+  opts: { failBegin?: boolean } = {},
+): PgSql => {
+  const resolved = <T>(rows: ReadonlyArray<T>): PgPendingQuery<T> => {
+    const p = Promise.resolve(rows) as PgPendingQuery<T>
+    p.simple = async () => undefined
+    return p
+  }
+
+  const setConfigKey = /set_config\(\s*'([^']+)'/
+  const tagged = (<T>(strings: TemplateStringsArray, ...values: unknown[]): PgPendingQuery<T> => {
+    const text = strings.join('?')
+    const match = setConfigKey.exec(text)
+    if (match !== null) {
+      recorder.setConfig.push({ key: match[1], value: values[0] })
+    }
+    return resolved<T>([])
+  }) as PgSql
+
+  tagged.unsafe = <T>(sql: string): PgPendingQuery<T> => {
+    recorder.ddl.push(sql)
+    return resolved<T>([])
+  }
+
+  tagged.begin = async <T>(fn: (sql: PgSql) => Promise<T>): Promise<T> => {
+    recorder.beginCalls += 1
+    if (opts.failBegin === true) throw new Error('lock_timeout: canceling statement (55P03)')
+    return fn(tagged)
+  }
+
+  return tagged
+}
+
+const newRecorder = (): Recorder => ({ ddl: [], setConfig: [], beginCalls: 0 })
+
+const makeStore = (sql: PgSql, initLockTimeoutMs?: number): PostgresStore =>
+  new PostgresStore({ sql, tenantId: TENANT_ID, brainId: BRAIN_ID, initLockTimeoutMs })
+
+describe('PostgresStore.init ensure-schema guard', () => {
+  it('runs the additive content + metadata DDL exactly once across many init() calls', async () => {
+    const recorder = newRecorder()
+    const store = makeStore(makeFakeSql(recorder))
+
+    await store.init()
+    await store.init()
+    await store.init()
+
+    const alters = recorder.ddl.filter((s) => s.startsWith('ALTER TABLE memory.documents'))
+    expect(alters).toHaveLength(2)
+    expect(alters[0]).toContain('ADD COLUMN IF NOT EXISTS content bytea')
+    expect(alters[1]).toContain('ADD COLUMN IF NOT EXISTS metadata jsonb')
+    expect(recorder.beginCalls).toBe(1)
+  })
+
+  it('is single-flight under concurrent init() calls', async () => {
+    const recorder = newRecorder()
+    const store = makeStore(makeFakeSql(recorder))
+
+    await Promise.all([store.init(), store.init(), store.init()])
+
+    expect(recorder.beginCalls).toBe(1)
+    expect(recorder.ddl.filter((s) => s.startsWith('ALTER TABLE'))).toHaveLength(2)
+  })
+
+  it('sets a transaction-local lock_timeout on the ensure-schema path', async () => {
+    const recorder = newRecorder()
+    const store = makeStore(makeFakeSql(recorder))
+
+    await store.init()
+
+    expect(recorder.setConfig).toContainEqual({
+      key: 'lock_timeout',
+      value: `${DEFAULT_INIT_LOCK_TIMEOUT_MS}`,
+    })
+  })
+
+  it('honours a caller-supplied initLockTimeoutMs', async () => {
+    const recorder = newRecorder()
+    const store = makeStore(makeFakeSql(recorder), 1500)
+
+    await store.init()
+
+    expect(recorder.setConfig).toContainEqual({ key: 'lock_timeout', value: '1500' })
+  })
+
+  it('does not cache a failed ensure-schema so a later init() can retry', async () => {
+    const recorder = newRecorder()
+    const failing = makeFakeSql(recorder, { failBegin: true })
+    const failingStore = makeStore(failing)
+
+    await expect(failingStore.init()).rejects.toThrow(/lock_timeout/)
+    await expect(failingStore.init()).rejects.toThrow(/lock_timeout/)
+    expect(recorder.beginCalls).toBe(2)
+  })
+})

--- a/sdks/ts/memory-postgres/src/store.ts
+++ b/sdks/ts/memory-postgres/src/store.ts
@@ -84,7 +84,25 @@ export type PostgresStoreOptions = {
    * Set to false in managed deployments that provision the column up front.
    */
   readonly initContentColumn?: boolean
+  /**
+   * Maximum time, in milliseconds, the ensure-schema transaction will wait to
+   * acquire the `ACCESS EXCLUSIVE` lock its `ALTER TABLE` statements need. If
+   * the table is held by a long-running transaction the DDL fails fast with a
+   * Postgres `lock_timeout` error (SQLSTATE 55P03) instead of convoying behind
+   * it. Scoped to the ensure-schema transaction only via `SET LOCAL`; normal
+   * query transactions are unaffected. Defaults to {@link DEFAULT_INIT_LOCK_TIMEOUT_MS}.
+   */
+  readonly initLockTimeoutMs?: number
 }
+
+/**
+ * Default `lock_timeout` for the ensure-schema transaction. The columns
+ * normally already exist (provisioned by the SQL migrations under
+ * `./migrations/`), so the `ADD COLUMN IF NOT EXISTS` statements complete
+ * instantly; this bound only matters on the rare path where the table is
+ * concurrently locked, in which case failing fast is far safer than blocking.
+ */
+export const DEFAULT_INIT_LOCK_TIMEOUT_MS = 3000
 
 /**
  * Convert a glob pattern into a Postgres LIKE pattern. Unlike {@link matchGlob}
@@ -143,32 +161,68 @@ export class PostgresStore implements Store {
   readonly tenantId: string
   readonly brainId: string
   private readonly source: string
+  private readonly initLockTimeoutMs: number
   private readonly sinks = new Map<number, EventSink>()
   private nextSinkId = 0
   private closed = false
+  /**
+   * Memoised ensure-schema promise. The first `init()` call assigns it and
+   * runs the DDL exactly once; every later call returns the same settled
+   * promise without touching the table. This guarantees the `ALTER TABLE`
+   * (and the momentary `ACCESS EXCLUSIVE` lock it takes) happens at most once
+   * per store instance rather than on every operation.
+   */
+  private initPromise: Promise<void> | undefined
 
   constructor(opts: PostgresStoreOptions) {
     this.sql = opts.sql
     this.tenantId = opts.tenantId
     this.brainId = opts.brainId
     this.source = opts.source ?? 'postgres-store'
+    this.initLockTimeoutMs = opts.initLockTimeoutMs ?? DEFAULT_INIT_LOCK_TIMEOUT_MS
   }
 
   /**
    * Apply the additive `content` and `metadata` columns so `read()` has
    * something to return and frontmatter-derived edges have a column to key
-   * off. Idempotent — safe to call on every process boot. Managed
-   * deployments that run the SQL migrations under `./migrations/` already
-   * have both columns; this keeps the OSS-standalone path self-sufficient.
+   * off. Managed deployments that run the SQL migrations under
+   * `./migrations/` already have both columns; this keeps the OSS-standalone
+   * path self-sufficient.
+   *
+   * Idempotent AND memoised: the DDL executes at most once per store instance.
+   * Repeat calls return the cached promise without issuing any SQL, so a
+   * caller that constructs a store (or invokes `init()`) per request never
+   * takes a fresh `ACCESS EXCLUSIVE` lock on `memory.documents` on the hot
+   * recall path. The DDL runs inside a single transaction with a short
+   * `SET LOCAL lock_timeout`, so if the table is held by a long-running
+   * transaction it fails fast (SQLSTATE 55P03) instead of convoying behind it.
+   *
+   * The promise is memoised only once it resolves: a rejected ensure-schema
+   * (e.g. a transient `lock_timeout`) is not cached, so a later call may
+   * retry, while a successful run is never repeated.
    */
   async init(): Promise<void> {
-    const { sql } = this
-    await sql.unsafe(
-      "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS content bytea NOT NULL DEFAULT ''::bytea",
-    )
-    await sql.unsafe(
-      "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb",
-    )
+    if (this.initPromise !== undefined) return this.initPromise
+    const pending = this.ensureSchema()
+    this.initPromise = pending
+    try {
+      await pending
+    } catch (err) {
+      this.initPromise = undefined
+      throw err
+    }
+  }
+
+  private async ensureSchema(): Promise<void> {
+    await this.sql.begin(async (tx) => {
+      await tx`select set_config('lock_timeout', ${`${this.initLockTimeoutMs}`}, true)`
+      await tx.unsafe(
+        "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS content bytea NOT NULL DEFAULT ''::bytea",
+      )
+      await tx.unsafe(
+        "ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb",
+      )
+    })
   }
 
   async read(p: Path): Promise<Buffer> {


### PR DESCRIPTION
## LLE-10529 (package half) — memoise store.init ensure-schema + lock_timeout

`PostgresStore.init()` ran `ALTER TABLE memory.documents ADD COLUMN IF NOT EXISTS …` via `sql.unsafe` on **every** call (no memoisation, no `lock_timeout`), taking a momentary ACCESS EXCLUSIVE lock per recall — the convoy behind the 2026-06-10 prod outage.

### Change (`sdks/ts/memory-postgres/src/store.ts`)
- **Memoise**: `init()` runs ensure-schema at most once per store instance via a cached promise (single-flight; a rejected run is not cached so a transient lock failure can retry). Subsequent calls issue zero SQL.
- **lock_timeout**: the ensure-schema ALTERs run in one transaction with `SET LOCAL lock_timeout` (default 3s, configurable via `initLockTimeoutMs`), so blocked DDL fails fast (55P03) instead of convoying. `SET LOCAL` is tx-scoped — normal queries unaffected.
- Idempotent DDL and metadata-on-write behaviour unchanged; backward-compatible. Go unaffected (the postgres document store is TS-only; Go is the reader).

### Tests
New `store.init.test.ts`: DDL executes once across multiple `init()` calls; single-flight under concurrency; `lock_timeout` set; failed init not cached. `bun typecheck`/`build` clean; **41 pass** (incl. Docker pg17 integration).

Intended to cut as **`@jeffs-brain/memory-postgres@0.2.0-rc.4`** after review. Lleverage then bumps its pin and ensures `init()` is called once at startup (LLE-10529 lleverage).
