### PR TITLE
test(ingest/trigger): make TestQueueDepthExceeded deterministic

### DIFF
--- a/go/ingest/trigger/bus_test.go
+++ b/go/ingest/trigger/bus_test.go
@@ -132,23 +132,50 @@ func TestQueueDepthExceeded(t *testing.T) {
 
 	bus := NewBus(&BusOptions{MaxQueueDepth: 2, Logger: logger})
 
-	// Do not subscribe — events accumulate in queue.
+	// The dispatch goroutine continuously drains the event channel, so we
+	// cannot rely on unsubscribed events accumulating — dispatch would empty
+	// the buffer before backpressure can trigger, making the assertion flaky.
+	//
+	// Instead, pin the dispatch loop with a blocking handler. dispatch calls
+	// handlers synchronously, so once it pulls the first event the handler
+	// parks on inHandler/release and the loop stops consuming. Subsequent
+	// publishes then fill the buffered channel (capacity 2) until the queue
+	// overflows and the backpressure warning is emitted deterministically.
+	inHandler := make(chan struct{})
+	release := make(chan struct{})
+	var handlerEntered sync.Once
+	bus.Subscribe(func(_ IngestTriggerEvent) error {
+		handlerEntered.Do(func() { close(inHandler) })
+		<-release
+		return nil
+	})
+
+	// First event is consumed by dispatch and parks the handler.
 	if err := bus.Publish(validEvent("q1")); err != nil {
 		t.Fatalf("publish q1: %v", err)
 	}
+	<-inHandler // dispatch is now blocked; the buffer will no longer drain.
+
+	// Fill the buffered channel to capacity (MaxQueueDepth: 2).
 	if err := bus.Publish(validEvent("q2")); err != nil {
 		t.Fatalf("publish q2: %v", err)
 	}
-	// Third publish should trigger backpressure (drop oldest).
 	if err := bus.Publish(validEvent("q3")); err != nil {
 		t.Fatalf("publish q3: %v", err)
 	}
-
-	bus.Close()
+	// Channel is now full; this publish must trigger backpressure (drop oldest)
+	// and emit the warning synchronously inside Publish.
+	if err := bus.Publish(validEvent("q4")); err != nil {
+		t.Fatalf("publish q4: %v", err)
+	}
 
 	if got := warnings.Load(); got < 1 {
 		t.Fatalf("expected at least 1 warning, got %d", got)
 	}
+
+	// Release the parked handler and let the bus drain and close cleanly.
+	close(release)
+	bus.Close()
 }
 
 func TestMalformedEventRejected(t *testing.T) {


### PR DESCRIPTION
## Make TestQueueDepthExceeded deterministic

`go/ingest/trigger/bus_test.go` `TestQueueDepthExceeded` was flaky on `ubuntu-latest` ("expected at least 1 warning, got 0"), reddening develop CI. Unrelated to any product change (it failed on a commit that touched only package.json + CHANGELOG; identical Go passed on the prior commit).

### Root cause
The test published q1/q2/q3 with `MaxQueueDepth:2` and **no subscriber**, expecting the buffer to fill — but the background `dispatch` goroutine drains the buffer near-instantly when there's no subscriber, so q3 found free space → no drop-oldest → no warning. Slower Linux scheduling surfaced it.

### Fix
Subscribe a handler that blocks on a `release` channel (signalling entry via `inHandler`). Because `deliverToAll` runs handlers synchronously inside the dispatch goroutine, dispatch parks on q1 and stops draining; q2/q3 fill the cap-2 buffer and q4 overflows → the drop-oldest warning fires synchronously inside `Publish(q4)` and is asserted immediately. No `time.Sleep`; no production change.

### Verification
`go test -race -run TestQueueDepthExceeded -count=20 ./ingest/trigger/...` and the whole package `-count=20` both green; `go build`/`vet`/`gofmt` clean; full `go test ./...` (32 packages) green.
