### PR TITLE
fix(memory-postgres): bound the query embedding by the request signal (rc.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### memory-postgres 0.2.0-rc.5
+
+#### Fixed
+
+- Thread the caller's `AbortSignal` through the Postgres retrieve path to the
+  query-embedding call. `PostgresRetrievalRequest` now accepts an optional
+  `signal`, which `createPostgresRetriever().retrieve` forwards to
+  `embedder.embed([query], signal)`. Previously the query embedding ran with no
+  deadline, so a degraded embeddings service could keep a `/ask` or `/search`
+  request in flight past the intended request deadline (a bounded but
+  unintentionally slow request). With the signal supplied, an aborted deadline
+  (e.g. `AbortSignal.any([request-close, AbortSignal.timeout(...)])`) cancels
+  the in-flight embed and retrieval degrades to lexical via the existing
+  fallback, rather than blocking. Omitting `signal` is byte-identical to the
+  previous behaviour. The Go retriever already threaded its `context.Context`
+  to `Embedder.Embed`; a mirrored parity test now guards that behaviour.
+  (LLE-10559) (TypeScript, Go)
+
 ### memory-postgres 0.2.0-rc.4
 
 #### Fixed

--- a/go/retrieval/retrieval_test.go
+++ b/go/retrieval/retrieval_test.go
@@ -1823,3 +1823,74 @@ func (f rerankerFn) Rerank(ctx context.Context, query string, chunks []Retrieved
 }
 
 func (f rerankerFn) Name() string { return "test-reranker" }
+
+// ctxObservingEmbedder records the context handed to Embed and honours
+// cancellation: an already-cancelled context returns promptly with the
+// context error instead of running the embed to completion. It is the Go
+// mirror of the TypeScript memory-postgres signal-threading tests, proving
+// the caller's deadline reaches the embed network call on the retrieve path.
+type ctxObservingEmbedder struct {
+	dims     int
+	gotErr   error
+	canceled bool
+	ran      bool
+}
+
+func (e *ctxObservingEmbedder) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if err := ctx.Err(); err != nil {
+		e.canceled = true
+		e.gotErr = err
+		return nil, err
+	}
+	e.ran = true
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = make([]float32, e.dims)
+	}
+	return out, nil
+}
+
+func (e *ctxObservingEmbedder) Dimensions() int { return e.dims }
+
+func (e *ctxObservingEmbedder) Close() error { return nil }
+
+// TestRetrieve_CancelledContext_AbortsEmbed proves the caller's cancelled
+// context is threaded down to embedder.Embed on the vector leg: the embed sees
+// the cancellation, returns promptly, and the retrieve degrades to BM25 rather
+// than running the embed to completion. Without ctx threading the embedder
+// would not observe the cancellation.
+func TestRetrieve_CancelledContext_AbortsEmbed(t *testing.T) {
+	t.Parallel()
+	src := newFakeSource(newTestCorpus())
+	embedder := &ctxObservingEmbedder{dims: src.embedDim}
+	r, err := New(Config{Source: src, Embedder: embedder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := r.Retrieve(ctx, Request{
+		Query: "invoice",
+		Mode:  ModeHybrid,
+	})
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	if !embedder.canceled {
+		t.Fatalf("embed did not observe the cancelled context; threading is broken")
+	}
+	if embedder.ran {
+		t.Fatalf("embed ran to completion despite a cancelled context")
+	}
+	if !errors.Is(embedder.gotErr, context.Canceled) {
+		t.Fatalf("embed got %v, want context.Canceled", embedder.gotErr)
+	}
+	if resp.Trace.EmbedderUsed {
+		t.Fatalf("embedder should not be marked used after a cancelled embed")
+	}
+	if resp.Trace.VectorSkipReason != "vector_error" {
+		t.Fatalf("vector skip reason = %q, want vector_error", resp.Trace.VectorSkipReason)
+	}
+}

--- a/sdks/ts/memory-postgres/package.json
+++ b/sdks/ts/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-postgres",
-  "version": "0.2.0-rc.4",
+  "version": "0.2.0-rc.5",
   "description": "Postgres and pgvector adapter for @jeffs-brain/memory: tsvector BM25, halfvec cosine, and RRF hybrid retrieval.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",

--- a/sdks/ts/memory-postgres/src/retrieval.test.ts
+++ b/sdks/ts/memory-postgres/src/retrieval.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Embedder } from '@jeffs-brain/memory/llm'
+import { describe, expect, it } from 'vitest'
+import {
+  type PostgresRetriever,
+  type PostgresSearchLike,
+  createPostgresRetriever,
+} from './retrieval.js'
+import type { PgSql } from './store.js'
+
+/**
+ * Unit coverage for the query-embedding deadline. `createPostgresRetriever`
+ * accepts an injected embedder and search index, so these tests exercise the
+ * full retrieve -> embed call chain without a database. They prove the
+ * caller-supplied `AbortSignal` is threaded down to `embedder.embed`, so a
+ * degraded embeddings service cannot run past the request deadline.
+ */
+
+const lexicalOnlyIndex = (): PostgresSearchLike => ({
+  searchBM25: async () => [],
+  hasEmbeddings: async () => true,
+  searchVector: async () => [],
+  getChunk: async () => undefined,
+})
+
+const buildRetriever = (input: {
+  readonly embedder: Embedder
+  readonly index?: PostgresSearchLike
+}): PostgresRetriever =>
+  createPostgresRetriever({
+    // The pg client is never touched: the injected index short-circuits all DB
+    // access and the injected embedder replaces the network embed call.
+    pg: {} as unknown as PgSql,
+    tenantId: 'tenant-test',
+    brainId: 'brain-test',
+    env: {},
+    indexFactory: () => input.index ?? lexicalOnlyIndex(),
+    embedderFactory: () => input.embedder,
+  })
+
+describe('createPostgresRetriever query-embedding deadline', () => {
+  it('threads the request signal down to embedder.embed', async () => {
+    let received: AbortSignal | undefined
+    const embedder: Embedder = {
+      name: () => 'spy',
+      model: () => 'spy',
+      dimension: () => 0,
+      embed: async (_texts, signal) => {
+        received = signal
+        return [[0.1, 0.2, 0.3]]
+      },
+    }
+    const controller = new AbortController()
+    const retriever = buildRetriever({ embedder })
+
+    await retriever.retrieve({
+      query: 'invoice processing',
+      limit: 5,
+      mode: 'semantic',
+      signal: controller.signal,
+    })
+
+    expect(received).toBe(controller.signal)
+  })
+
+  it('aborts the in-flight embed promptly when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    let resolved = false
+    const embedder: Embedder = {
+      name: () => 'honours-signal',
+      model: () => 'honours-signal',
+      dimension: () => 0,
+      // A signal-honouring embedder (TEI/OpenAI both forward the signal to
+      // fetch) rejects immediately when the signal is already aborted, rather
+      // than running the network round-trip to completion.
+      embed: async (_texts, signal) => {
+        if (signal?.aborted === true) {
+          throw new DOMException('aborted', 'AbortError')
+        }
+        await new Promise((r) => setTimeout(r, 10_000))
+        resolved = true
+        return [[0.1, 0.2, 0.3]]
+      },
+    }
+    const retriever = buildRetriever({ embedder })
+
+    const response = await retriever.retrieve({
+      query: 'invoice processing',
+      limit: 5,
+      mode: 'semantic',
+      signal: controller.signal,
+    })
+
+    // The aborted embed degrades gracefully to lexical (matching the existing
+    // catch-and-fall-back behaviour) and never runs the 10s embed to
+    // completion. Without the threading the embedder would not see the aborted
+    // signal and would hang for the full timeout.
+    expect(resolved).toBe(false)
+    expect(response.trace.fellBackToLexical).toBe(true)
+    expect(response.trace.effectiveMode).toBe('lexical')
+  })
+
+  it('omitting the signal leaves embed behaviour unchanged (backwards compatible)', async () => {
+    let receivedArgCount = -1
+    const embedder: Embedder = {
+      name: () => 'spy',
+      model: () => 'spy',
+      dimension: () => 0,
+      embed: async (_texts, signal) => {
+        receivedArgCount = signal === undefined ? 1 : 2
+        return [[0.1, 0.2, 0.3]]
+      },
+    }
+    const retriever = buildRetriever({ embedder })
+
+    await retriever.retrieve({
+      query: 'invoice processing',
+      limit: 5,
+      mode: 'semantic',
+    })
+
+    expect(receivedArgCount).toBe(1)
+  })
+})

--- a/sdks/ts/memory-postgres/src/retrieval.ts
+++ b/sdks/ts/memory-postgres/src/retrieval.ts
@@ -120,6 +120,14 @@ export type PostgresRetrievalRequest = {
   readonly candidateLimit?: number
   readonly rerankTopN?: number
   readonly documentIdAllowlist?: ReadonlySet<string>
+  /**
+   * Optional caller deadline. When supplied it is forwarded to the query
+   * embedding call so that an aborted signal (e.g. a request close or an
+   * `AbortSignal.timeout`) cancels the in-flight embed rather than letting a
+   * degraded embeddings service run past the intended request deadline. When
+   * omitted, behaviour is unchanged.
+   */
+  readonly signal?: AbortSignal
 }
 
 export type PostgresSearchLike = {
@@ -456,7 +464,7 @@ export const createPostgresRetriever = (
         try {
           if (embedderFactory === undefined) throw new Error('embedder not configured')
           const embedder = embedderFactory(opts.env)
-          const vectors = await embedder.embed([req.query])
+          const vectors = await embedder.embed([req.query], req.signal)
           const first = vectors[0]
           if (first !== undefined && first.length > 0) {
             embedding = first


### PR DESCRIPTION
## Summary

The Postgres retriever called `embedder.embed([query])` with **no signal**, so on `/ask` and `/search` a degraded embeddings service could keep a request in flight past the caller's intended deadline (a slow request, not a zombie — surfaced by an lleverage memory-service scalability audit, LLE-10559).

This threads an optional `AbortSignal` from `PostgresRetrievalRequest` down to `embedder.embed`. The `Embedder.embed(texts, signal?)` interface and the TEI/OpenAI implementations **already accept and forward** a signal, so the change is confined to `memory-postgres`; `@jeffs-brain/memory` is unchanged.

## Go parity

The Go retriever already propagates `context.Context` through to `Embedder.Embed`, so a cancelled/deadline context already aborts the embed — **no Go code change**, only a parity test (`TestRetrieve_CancelledContext_AbortsEmbed`).

## Changes

- TS: `PostgresRetrievalRequest` gains `readonly signal?: AbortSignal`; the retrieve embed call passes `req.signal`. **Backward-compatible** — omitting the signal is byte-identical to before.
- TS test (new): threads the signal to `embed`; aborts the in-flight embed promptly when the signal is already aborted; omitting the signal leaves behaviour unchanged. Proven to fail without the threading.
- Go test (new): cancelled-context aborts the embed (parity). Proven to fail without the propagation.
- Version: `memory-postgres` `0.2.0-rc.4 → 0.2.0-rc.5`; `@jeffs-brain/memory` stays `0.4.0-rc.3` (surface unchanged). CHANGELOG updated.

## Tests

- `bun run typecheck` (tsc -b) — 0 errors
- `bun run build` — 0 errors
- `bun run test sdks/ts/memory-postgres` — 7 files / 44 tests pass (incl. real-Postgres integration + the new test)
- `go test -race ./retrieval/` — ok
- Go golden/parity tests — ok

Note: the full `bun run test` has 4 pre-existing flaky failures in `@jeffs-brain/memory` (`cron.test.ts` timezone ×2; `cli/integration.test.ts` git-sync timeout ×2) — unrelated to these files.

Release (after merge): `gh workflow run release.yml --ref develop`, verify the `rc` dist-tag resolves `memory-postgres@0.2.0-rc.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retriever now accepts an optional abort signal parameter to enable request cancellation with fallback to alternative search methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->