### PR TITLE
feat(memory): opt-in OKF frontmatter profile (backwards-compatible)

### DIFF
--- a/sdks/ts/memory/src/memory/consolidate.ts
+++ b/sdks/ts/memory/src/memory/consolidate.ts
@@ -15,7 +15,12 @@ import type { Logger, Provider } from '../llm/index.js'
 import { ErrNotFound } from '../store/errors.js'
 import type { Batch, FileInfo, ListOpts, Store } from '../store/index.js'
 import { type Path, lastSegment } from '../store/path.js'
-import { type Frontmatter, buildFrontmatter, parseFrontmatter } from './frontmatter.js'
+import {
+  type Frontmatter,
+  type FrontmatterProfile,
+  buildFrontmatter,
+  parseFrontmatter,
+} from './frontmatter.js'
 import { scopeIndex, scopePrefix } from './paths.js'
 import { fireConsolidationEnd, fireConsolidationStart } from './plugins.js'
 import { DEDUPLICATION_SYSTEM_PROMPT } from './prompts.js'
@@ -63,6 +68,7 @@ export type ConsolidateDeps = {
   readonly plugins: readonly Plugin[]
   readonly defaultScope: Scope
   readonly defaultActorId: string
+  readonly frontmatterProfile?: FrontmatterProfile
 }
 
 export const createConsolidate = (deps: ConsolidateDeps) => {
@@ -154,6 +160,7 @@ export const createConsolidate = (deps: ConsolidateDeps) => {
           prefix,
           indexPath,
           now,
+          profile: deps.frontmatterProfile,
         })
         ops.push(...maintenance.ops)
         errors.push(...maintenance.errors)
@@ -292,6 +299,7 @@ const runMaintenancePass = async (
     readonly prefix: Path
     readonly indexPath: Path
     readonly now: Date
+    readonly profile?: FrontmatterProfile | undefined
   },
 ): Promise<{ readonly ops: readonly ConsolidationOp[]; readonly errors: readonly string[] }> => {
   const ops: ConsolidationOp[] = []
@@ -299,7 +307,7 @@ const runMaintenancePass = async (
   const notes = await listNotes(batch, input.prefix, errors)
 
   for (const note of notes) {
-    const rewrite = rewriteNote(note, input.now)
+    const rewrite = rewriteNote(note, input.now, input.profile)
     if (!rewrite.changed) continue
     await batch.write(note.path, Buffer.from(rewrite.content, 'utf8'))
     ops.push({ kind: 'rewrite', path: note.path })
@@ -361,6 +369,7 @@ const listNotes = async (
 const rewriteNote = (
   note: NoteRecord,
   now: Date,
+  profile?: FrontmatterProfile,
 ): { readonly changed: boolean; readonly content: string } => {
   const originalTags = normaliseTags(note.frontmatter.tags)
   let nextTags = [...originalTags]
@@ -413,13 +422,18 @@ const rewriteNote = (
       ...(nextTags.length > 0 ? { tags: nextTags } : {}),
     },
     note.body,
+    profile,
   )
 
   return { changed: content !== note.content, content }
 }
 
-const buildNoteContent = (frontmatter: Frontmatter, body: string): string => {
-  const built = buildFrontmatter(frontmatter)
+const buildNoteContent = (
+  frontmatter: Frontmatter,
+  body: string,
+  profile?: FrontmatterProfile,
+): string => {
+  const built = buildFrontmatter(frontmatter, { profile })
   const trimmedBody = body.trim()
   return trimmedBody === '' ? `${built}\n` : `${built}\n${trimmedBody}\n`
 }

--- a/sdks/ts/memory/src/memory/episodes.ts
+++ b/sdks/ts/memory/src/memory/episodes.ts
@@ -2,7 +2,7 @@
 
 import { type Logger, type Message, noopLogger } from '../llm/index.js'
 import { type Path, type Store, joinPath, toPath } from '../store/index.js'
-import { buildFrontmatter, parseFrontmatter } from './frontmatter.js'
+import { type FrontmatterProfile, buildFrontmatter, parseFrontmatter } from './frontmatter.js'
 import { ensureMarkdown } from './paths.js'
 import type { Heuristic, ReflectionResult, Scope } from './types.js'
 
@@ -109,6 +109,7 @@ export type EpisodeRecorderDeps = {
   readonly defaultScope: Scope
   readonly defaultActorId: string
   readonly config?: Partial<EpisodeRecorderConfig>
+  readonly frontmatterProfile?: FrontmatterProfile
 }
 
 export type EpisodeRecorder = {
@@ -315,6 +316,7 @@ export const createEpisodeRecorder = (deps: EpisodeRecorderDeps): EpisodeRecorde
         outcome: args.reflection.outcome,
         signals: gate.signals,
         payload,
+        ...(deps.frontmatterProfile !== undefined ? { profile: deps.frontmatterProfile } : {}),
         ...(startedAt !== undefined ? { startedAt } : {}),
         ...(endedAt !== undefined ? { endedAt } : {}),
       })
@@ -398,38 +400,42 @@ const buildEpisodeFile = (args: {
   readonly endedAt?: string
   readonly signals: EpisodeSignals
   readonly payload: StoredEpisodePayload
+  readonly profile?: FrontmatterProfile
 }): string => {
-  const fm = buildFrontmatter({
-    name: args.name,
-    description: args.summary,
-    type: 'episode',
-    scope: args.scope,
-    created: args.created,
-    modified: args.modified,
-    source: 'episode',
-    session_id: args.sessionId,
-    session_date: args.sessionDate,
-    observed_on: args.observedOn,
-    tags: args.tags,
-    extra: {
-      actor_id: args.actorId,
-      outcome: args.outcome,
-      should_record_episode: 'true',
-      message_count: String(args.signals.messageCount),
-      substantive_message_count: String(args.signals.substantiveMessageCount),
-      user_message_count: String(args.signals.userMessageCount),
-      assistant_message_count: String(args.signals.assistantMessageCount),
-      tool_message_count: String(args.signals.toolMessageCount),
-      tool_call_count: String(args.signals.toolCallCount),
-      write_signal: boolString(args.signals.writeSignal),
-      edit_signal: boolString(args.signals.editSignal),
-      tool_signal: boolString(args.signals.toolSignal),
-      ...(args.startedAt !== undefined ? { started_at: args.startedAt } : {}),
-      ...(args.endedAt !== undefined ? { ended_at: args.endedAt } : {}),
-      heuristic_count: String(args.payload.heuristics.length),
-      open_question_count: String(args.payload.open_questions.length),
+  const fm = buildFrontmatter(
+    {
+      name: args.name,
+      description: args.summary,
+      type: 'episode',
+      scope: args.scope,
+      created: args.created,
+      modified: args.modified,
+      source: 'episode',
+      session_id: args.sessionId,
+      session_date: args.sessionDate,
+      observed_on: args.observedOn,
+      tags: args.tags,
+      extra: {
+        actor_id: args.actorId,
+        outcome: args.outcome,
+        should_record_episode: 'true',
+        message_count: String(args.signals.messageCount),
+        substantive_message_count: String(args.signals.substantiveMessageCount),
+        user_message_count: String(args.signals.userMessageCount),
+        assistant_message_count: String(args.signals.assistantMessageCount),
+        tool_message_count: String(args.signals.toolMessageCount),
+        tool_call_count: String(args.signals.toolCallCount),
+        write_signal: boolString(args.signals.writeSignal),
+        edit_signal: boolString(args.signals.editSignal),
+        tool_signal: boolString(args.signals.toolSignal),
+        ...(args.startedAt !== undefined ? { started_at: args.startedAt } : {}),
+        ...(args.endedAt !== undefined ? { ended_at: args.endedAt } : {}),
+        heuristic_count: String(args.payload.heuristics.length),
+        open_question_count: String(args.payload.open_questions.length),
+      },
     },
-  })
+    { profile: args.profile },
+  )
 
   const body: string[] = [
     `# ${args.name}`,

--- a/sdks/ts/memory/src/memory/extract.ts
+++ b/sdks/ts/memory/src/memory/extract.ts
@@ -13,7 +13,7 @@ import type { Logger, Message, Provider } from '../llm/index.js'
 import { expandTemporal } from '../query/temporal.js'
 import type { Store } from '../store/index.js'
 import { lastSegment } from '../store/path.js'
-import { buildFrontmatter } from './frontmatter.js'
+import { type FrontmatterProfile, buildFrontmatter } from './frontmatter.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { ensureMarkdown, scopeIndex, scopePrefix, scopeTopic } from './paths.js'
 import { fireExtractionEnd, fireExtractionStart } from './plugins.js'
@@ -176,6 +176,7 @@ export type ExtractDeps = {
   readonly minMessages: number
   readonly maxRecent: number
   readonly contextualPrefixBuilder?: ContextualPrefixBuilder
+  readonly frontmatterProfile?: FrontmatterProfile
 }
 
 type ExtractRunOptions = {
@@ -290,7 +291,7 @@ const runExtract = async (
 
   if (opts.persist && extracted.length > 0) {
     try {
-      await persistExtractions(deps.store, actorId, extracted)
+      await persistExtractions(deps.store, actorId, extracted, deps.frontmatterProfile)
     } catch (err) {
       deps.logger.warn('memory: extract persist failed', {
         err: err instanceof Error ? err.message : String(err),
@@ -586,6 +587,7 @@ const persistExtractions = async (
   store: Store,
   actorId: string,
   extracted: readonly ExtractedMemory[],
+  profile?: FrontmatterProfile,
 ): Promise<void> => {
   const indexEntriesByScope = new Map<Scope, string[]>()
   type Pending = { path: import('../store/path.js').Path; body: Buffer }
@@ -595,7 +597,7 @@ const persistExtractions = async (
     if (!em.filename || !em.content) continue
     const filename = ensureMarkdown(em.filename)
     const path = scopeTopic(em.scope, actorId, filename)
-    const body = buildTopicFile(em)
+    const body = buildTopicFile(em, profile)
     writes.push({ path, body })
     if (em.indexEntry) {
       const arr = indexEntriesByScope.get(em.scope) ?? []
@@ -709,25 +711,28 @@ const appendIndexEntries = async (
   await batch.write(indexPath, Buffer.from(`${content}\n`, 'utf8'))
 }
 
-const buildTopicFile = (em: ExtractedMemory): Buffer => {
+const buildTopicFile = (em: ExtractedMemory, profile?: FrontmatterProfile): Buffer => {
   const now = new Date().toISOString()
   const modified = em.modifiedOverride ?? now
   const created = em.modifiedOverride ?? now
-  const fm = buildFrontmatter({
-    extra: {},
-    ...(em.name ? { name: em.name } : {}),
-    ...(em.description ? { description: em.description } : {}),
-    ...(em.type ? { type: em.type } : {}),
-    scope: em.scope,
-    ...(em.action === 'create' ? { created } : {}),
-    modified,
-    source: 'session',
-    ...(em.supersedes ? { supersedes: em.supersedes } : {}),
-    ...(em.sessionId ? { session_id: em.sessionId } : {}),
-    ...(em.observedOn ? { observed_on: em.observedOn } : {}),
-    ...(em.sessionDate ? { session_date: em.sessionDate } : {}),
-    ...(em.tags && em.tags.length > 0 ? { tags: em.tags } : {}),
-  })
+  const fm = buildFrontmatter(
+    {
+      extra: {},
+      ...(em.name ? { name: em.name } : {}),
+      ...(em.description ? { description: em.description } : {}),
+      ...(em.type ? { type: em.type } : {}),
+      scope: em.scope,
+      ...(em.action === 'create' ? { created } : {}),
+      modified,
+      source: 'session',
+      ...(em.supersedes ? { supersedes: em.supersedes } : {}),
+      ...(em.sessionId ? { session_id: em.sessionId } : {}),
+      ...(em.observedOn ? { observed_on: em.observedOn } : {}),
+      ...(em.sessionDate ? { session_date: em.sessionDate } : {}),
+      ...(em.tags && em.tags.length > 0 ? { tags: em.tags } : {}),
+    },
+    { profile },
+  )
   const prefix = em.contextPrefix?.trim()
   const body = prefix ? `${CONTEXTUAL_PREFIX_MARKER}${prefix}\n\n${em.content}` : em.content
   return Buffer.from(`${fm}\n${body}\n`, 'utf8')

--- a/sdks/ts/memory/src/memory/frontmatter.test.ts
+++ b/sdks/ts/memory/src/memory/frontmatter.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import { type Frontmatter, buildFrontmatter, parseFrontmatter } from './frontmatter.js'
+
+const sample = (): Frontmatter => ({
+  name: 'Run the test suite',
+  description: 'Always run the project suite, never the package manager default.',
+  type: 'project',
+  scope: 'global',
+  created: '2026-01-01T00:00:00.000Z',
+  modified: '2026-02-01T00:00:00.000Z',
+  source: 'session',
+  session_id: 'sess-123',
+  tags: ['testing', 'ci'],
+  extra: {},
+})
+
+describe('buildFrontmatter — default profile', () => {
+  it('is unchanged by an explicit default profile (byte-for-byte)', () => {
+    const fm = sample()
+    expect(buildFrontmatter(fm, { profile: 'default' })).toBe(buildFrontmatter(fm))
+  })
+
+  it('emits the native key set, not OKF keys', () => {
+    const out = buildFrontmatter(sample())
+    expect(out).toContain('name: Run the test suite')
+    expect(out).toContain('modified: 2026-02-01T00:00:00.000Z')
+    expect(out).toContain('created: 2026-01-01T00:00:00.000Z')
+    expect(out).not.toContain('title:')
+    expect(out).not.toContain('timestamp:')
+  })
+})
+
+describe('buildFrontmatter — okf profile', () => {
+  it('emits OKF-shaped frontmatter (type/title/description/tags/timestamp)', () => {
+    const out = buildFrontmatter(sample(), { profile: 'okf' })
+    expect(out).toContain('type: project')
+    expect(out).toContain('title: Run the test suite')
+    expect(out).toContain(
+      'description: Always run the project suite, never the package manager default.',
+    )
+    expect(out).toContain('tags: [testing, ci]')
+    // timestamp tracks `modified` (the recency signal recall ranks on).
+    expect(out).toContain('timestamp: 2026-02-01T00:00:00.000Z')
+    // OKF uses `title`/`timestamp` in place of the native `name`/`modified` keys.
+    expect(out).not.toMatch(/^name:/m)
+    expect(out).not.toMatch(/^modified:/m)
+  })
+
+  it('orders OKF core fields before the preserved extension keys', () => {
+    const out = buildFrontmatter(sample(), { profile: 'okf' })
+    expect(out.indexOf('type:')).toBeLessThan(out.indexOf('scope:'))
+    expect(out.indexOf('timestamp:')).toBeLessThan(out.indexOf('source:'))
+  })
+
+  it('falls back to `created` for the timestamp when `modified` is absent', () => {
+    const out = buildFrontmatter(
+      { name: 'x', type: 'note', created: '2026-01-01T00:00:00.000Z', extra: {} },
+      { profile: 'okf' },
+    )
+    expect(out).toContain('timestamp: 2026-01-01T00:00:00.000Z')
+  })
+
+  it('preserves arbitrary extension keys (e.g. episode metadata)', () => {
+    const out = buildFrontmatter(
+      {
+        name: 'Episode',
+        type: 'episode',
+        modified: 't',
+        extra: { actor_id: 'tom', outcome: 'success' },
+      },
+      { profile: 'okf' },
+    )
+    expect(out).toContain('actor_id: tom')
+    expect(out).toContain('outcome: success')
+  })
+})
+
+describe('parseFrontmatter — OKF reader tolerance', () => {
+  it('reads a hand-authored OKF note (title→name, timestamp→modified)', () => {
+    const note = [
+      '---',
+      'type: reference',
+      'title: API base URL',
+      'description: The production API base URL.',
+      'tags: [api, ops]',
+      'timestamp: 2026-03-03T00:00:00.000Z',
+      '---',
+      '',
+      'The base URL is https://api.example.com.',
+    ].join('\n')
+    const { frontmatter, body } = parseFrontmatter(note)
+    expect(frontmatter.name).toBe('API base URL')
+    expect(frontmatter.modified).toBe('2026-03-03T00:00:00.000Z')
+    expect(frontmatter.type).toBe('reference')
+    expect(frontmatter.description).toBe('The production API base URL.')
+    expect(frontmatter.tags).toEqual(['api', 'ops'])
+    expect(body).toBe('The base URL is https://api.example.com.')
+  })
+
+  it('lets a native key win when both it and its OKF alias are present (either order)', () => {
+    const aliasFirst = [
+      '---',
+      'title: Alias',
+      'name: Canonical',
+      'timestamp: 2026-01-01T00:00:00.000Z',
+      'modified: 2026-05-05T00:00:00.000Z',
+      '---',
+      '',
+      'x',
+    ].join('\n')
+    const nativeFirst = [
+      '---',
+      'name: Canonical',
+      'title: Alias',
+      'modified: 2026-05-05T00:00:00.000Z',
+      'timestamp: 2026-01-01T00:00:00.000Z',
+      '---',
+      '',
+      'x',
+    ].join('\n')
+    for (const raw of [aliasFirst, nativeFirst]) {
+      const { frontmatter } = parseFrontmatter(raw)
+      expect(frontmatter.name).toBe('Canonical')
+      expect(frontmatter.modified).toBe('2026-05-05T00:00:00.000Z')
+    }
+  })
+})
+
+describe('round-trip + cross-format equivalence', () => {
+  it('round-trips an OKF-written note back to equivalent frontmatter', () => {
+    const fm = sample()
+    const { frontmatter: parsed } = parseFrontmatter(
+      `${buildFrontmatter(fm, { profile: 'okf' })}\nbody`,
+    )
+    expect(parsed.name).toBe(fm.name)
+    expect(parsed.description).toBe(fm.description)
+    expect(parsed.type).toBe(fm.type)
+    expect(parsed.scope).toBe(fm.scope)
+    expect(parsed.source).toBe(fm.source)
+    expect(parsed.session_id).toBe(fm.session_id)
+    expect(parsed.created).toBe(fm.created)
+    expect(parsed.modified).toBe(fm.modified)
+    expect(parsed.tags).toEqual(fm.tags)
+  })
+
+  it('parses default and OKF renderings of the same note to identical logical fields', () => {
+    const fm = sample()
+    const fromDefault = parseFrontmatter(`${buildFrontmatter(fm)}\nbody`).frontmatter
+    const fromOkf = parseFrontmatter(
+      `${buildFrontmatter(fm, { profile: 'okf' })}\nbody`,
+    ).frontmatter
+    const keys = [
+      'name',
+      'description',
+      'type',
+      'scope',
+      'source',
+      'session_id',
+      'created',
+      'modified',
+    ] as const
+    for (const key of keys) expect(fromOkf[key]).toBe(fromDefault[key])
+    expect(fromOkf.tags).toEqual(fromDefault.tags)
+  })
+})

--- a/sdks/ts/memory/src/memory/frontmatter.ts
+++ b/sdks/ts/memory/src/memory/frontmatter.ts
@@ -5,6 +5,11 @@
  * memory writer: `key: value` scalars plus a `tags:` list in either inline
  * (`[a, b]`) or block (`- a\n- b`) form. Unknown keys land in `extra` so
  * callers can preserve round-trip fidelity when rewriting.
+ *
+ * The parser also tolerates the [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+ * key aliases (`title`→`name`, `timestamp`→`modified`), so brains written by
+ * {@link buildFrontmatter} under the `okf` profile read back identically and a
+ * brain may freely mix both formats. See {@link FrontmatterProfile}.
  */
 
 export type Frontmatter = {
@@ -24,6 +29,23 @@ export type Frontmatter = {
   observed_on?: string
   extra: Record<string, string>
 }
+
+/**
+ * Serialisation profile for {@link buildFrontmatter}.
+ *
+ * - `default` — the native field set (`name`/`created`/`modified`/…). This is
+ *   what every existing brain on disk uses and stays the default, so output is
+ *   byte-for-byte unchanged unless a profile is explicitly selected.
+ * - `okf` — emits [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+ *   shaped frontmatter (`type`/`title`/`description`/`tags`/`timestamp`) for
+ *   interoperability with OKF tooling. Native-only fields (`scope`, `source`,
+ *   `session_id`, …) are preserved as OKF extension keys so a brain round-trips
+ *   losslessly through the profile.
+ *
+ * Reads are profile-agnostic — {@link parseFrontmatter} understands both key
+ * sets — so a brain may mix formats and switching profiles needs no migration.
+ */
+export type FrontmatterProfile = 'default' | 'okf'
 
 export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; body: string } => {
   const lines = content.split('\n')
@@ -45,6 +67,9 @@ export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; b
   const fm: Frontmatter = { extra: {} }
   const tags: string[] = []
   let currentListKey = ''
+  // OKF aliases captured separately so the native keys win when both are present.
+  let titleAlias: string | undefined
+  let timestampAlias: string | undefined
 
   for (let i = 1; i < closeIdx; i++) {
     const line = lines[i] ?? ''
@@ -118,6 +143,13 @@ export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; b
       case 'observed_on':
         fm.observed_on = val
         break
+      // OKF profile aliases — resolved after the loop so an explicit native key wins.
+      case 'title':
+        titleAlias = val
+        break
+      case 'timestamp':
+        timestampAlias = val
+        break
       case 'tags': {
         // Inline [a, b, c] form.
         if (val.startsWith('[') && val.endsWith(']')) {
@@ -140,6 +172,9 @@ export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; b
   }
 
   if (tags.length > 0) fm.tags = tags
+  // OKF: `title`→name, `timestamp`→modified. Native keys, if also present, win.
+  if (fm.name === undefined && titleAlias !== undefined) fm.name = titleAlias
+  if (fm.modified === undefined && timestampAlias !== undefined) fm.modified = timestampAlias
 
   const body = lines
     .slice(closeIdx + 1)
@@ -148,7 +183,16 @@ export const parseFrontmatter = (content: string): { frontmatter: Frontmatter; b
   return { frontmatter: fm, body }
 }
 
-export const buildFrontmatter = (fm: Frontmatter): string => {
+/**
+ * Serialise frontmatter. The default profile is unchanged from prior releases
+ * (byte-for-byte); pass `{ profile: 'okf' }` to emit Open Knowledge Format
+ * shaped frontmatter instead. See {@link FrontmatterProfile}.
+ */
+export const buildFrontmatter = (
+  fm: Frontmatter,
+  opts: { readonly profile?: FrontmatterProfile | undefined } = {},
+): string => {
+  if (opts.profile === 'okf') return buildOkfFrontmatter(fm)
   const out: string[] = ['---']
   if (fm.name) out.push(`name: ${fm.name}`)
   if (fm.description) out.push(`description: ${fm.description}`)
@@ -164,6 +208,40 @@ export const buildFrontmatter = (fm: Frontmatter): string => {
   if (fm.session_date) out.push(`session_date: ${fm.session_date}`)
   if (fm.observed_on) out.push(`observed_on: ${fm.observed_on}`)
   if (fm.tags && fm.tags.length > 0) out.push(`tags: [${fm.tags.join(', ')}]`)
+  for (const [k, v] of Object.entries(fm.extra ?? {})) out.push(`${k}: ${v}`)
+  out.push('---', '')
+  return out.join('\n')
+}
+
+/**
+ * Open Knowledge Format projection of {@link Frontmatter}. OKF core fields come
+ * first (`type`, `title`, `description`, `tags`, `timestamp`); the native-only
+ * fields follow as OKF extension keys (OKF permits additional keys) so the note
+ * round-trips back to an equivalent Frontmatter via {@link parseFrontmatter}.
+ *
+ * `timestamp` is sourced from `modified` (the recency signal recall ranks on),
+ * falling back to `created`; `created` is still emitted as an extension key so
+ * the original creation time survives the round-trip.
+ */
+const buildOkfFrontmatter = (fm: Frontmatter): string => {
+  const out: string[] = ['---']
+  // OKF core.
+  if (fm.type) out.push(`type: ${fm.type}`)
+  if (fm.name) out.push(`title: ${fm.name}`)
+  if (fm.description) out.push(`description: ${fm.description}`)
+  if (fm.tags && fm.tags.length > 0) out.push(`tags: [${fm.tags.join(', ')}]`)
+  const timestamp = fm.modified ?? fm.created
+  if (timestamp) out.push(`timestamp: ${timestamp}`)
+  // Native fields preserved as OKF extension keys for lossless round-trips.
+  if (fm.created) out.push(`created: ${fm.created}`)
+  if (fm.confidence) out.push(`confidence: ${fm.confidence}`)
+  if (fm.source) out.push(`source: ${fm.source}`)
+  if (fm.supersedes) out.push(`supersedes: ${fm.supersedes}`)
+  if (fm.superseded_by) out.push(`superseded_by: ${fm.superseded_by}`)
+  if (fm.scope) out.push(`scope: ${fm.scope}`)
+  if (fm.session_id) out.push(`session_id: ${fm.session_id}`)
+  if (fm.session_date) out.push(`session_date: ${fm.session_date}`)
+  if (fm.observed_on) out.push(`observed_on: ${fm.observed_on}`)
   for (const [k, v] of Object.entries(fm.extra ?? {})) out.push(`${k}: ${v}`)
   out.push('---', '')
   return out.join('\n')

--- a/sdks/ts/memory/src/memory/index.ts
+++ b/sdks/ts/memory/src/memory/index.ts
@@ -50,6 +50,9 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     ...(opts.contextualPrefixBuilder !== undefined
       ? { contextualPrefixBuilder: opts.contextualPrefixBuilder }
       : {}),
+    ...(opts.frontmatterProfile !== undefined
+      ? { frontmatterProfile: opts.frontmatterProfile }
+      : {}),
   })
   const previewExtract = createPreviewExtract({
     store: opts.store,
@@ -64,6 +67,9 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     ...(opts.contextualPrefixBuilder !== undefined
       ? { contextualPrefixBuilder: opts.contextualPrefixBuilder }
       : {}),
+    ...(opts.frontmatterProfile !== undefined
+      ? { frontmatterProfile: opts.frontmatterProfile }
+      : {}),
   })
 
   const reflect = createReflect({
@@ -73,6 +79,9 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     plugins,
     defaultScope: opts.scope,
     defaultActorId: opts.actorId,
+    ...(opts.frontmatterProfile !== undefined
+      ? { frontmatterProfile: opts.frontmatterProfile }
+      : {}),
   })
 
   const consolidate = createConsolidate({
@@ -82,6 +91,9 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     plugins,
     defaultScope: opts.scope,
     defaultActorId: opts.actorId,
+    ...(opts.frontmatterProfile !== undefined
+      ? { frontmatterProfile: opts.frontmatterProfile }
+      : {}),
   })
 
   const contextualise = createContextualise({
@@ -94,6 +106,9 @@ export const createMemory = (opts: MemoryOpts): Memory => {
     logger,
     defaultScope: opts.scope,
     defaultActorId: opts.actorId,
+    ...(opts.frontmatterProfile !== undefined
+      ? { frontmatterProfile: opts.frontmatterProfile }
+      : {}),
   })
   const proceduralStore = createStoreBackedProceduralStore(opts.store)
 
@@ -229,6 +244,8 @@ export {
   scopePrefix,
   scopeTopic,
 } from './paths.js'
+
+export type { FrontmatterProfile } from './frontmatter.js'
 
 export { StoreBackedCursorStore, createStoreBackedCursorStore } from './cursor.js'
 export {

--- a/sdks/ts/memory/src/memory/okf-profile.test.ts
+++ b/sdks/ts/memory/src/memory/okf-profile.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest'
+import type {
+  CompletionRequest,
+  CompletionResponse,
+  Message,
+  Provider,
+  StructuredRequest,
+} from '../llm/index.js'
+import { createMemStore } from '../store/memstore.js'
+import { createStoreBackedCursorStore } from './cursor.js'
+import { parseFrontmatter } from './frontmatter.js'
+import { createMemory } from './index.js'
+import { scopeTopic } from './paths.js'
+
+const stubProvider = (content: string): Provider => ({
+  name: () => 'stub',
+  modelName: () => 'stub-model',
+  async *stream() {
+    yield { type: 'done', stopReason: 'end_turn' as const }
+  },
+  complete: async (_req: CompletionRequest): Promise<CompletionResponse> => ({
+    content,
+    toolCalls: [],
+    usage: { inputTokens: 0, outputTokens: 0 },
+    stopReason: 'end_turn',
+  }),
+  supportsStructuredDecoding: () => false,
+  structured: async (_req: StructuredRequest) => content,
+})
+
+const conversation = (n: number): Message[] => {
+  const out: Message[] = []
+  for (let i = 0; i < n; i++)
+    out.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `msg ${i}` })
+  return out
+}
+
+const extraction = JSON.stringify({
+  memories: [
+    {
+      action: 'create',
+      filename: 'feedback-testing.md',
+      name: 'Feedback on testing',
+      description: 'User prefers integration tests',
+      type: 'feedback',
+      scope: 'global',
+      content: 'Prefer integration tests over snapshots.',
+      index_entry: '- feedback-testing.md: testing preference',
+    },
+  ],
+})
+
+describe('frontmatterProfile threads through createMemory → extract', () => {
+  it('writes OKF-shaped notes when the okf profile is selected', async () => {
+    const store = createMemStore()
+    const mem = createMemory({
+      store,
+      provider: stubProvider(extraction),
+      cursorStore: createStoreBackedCursorStore(store),
+      scope: 'project',
+      actorId: 'tenant-a',
+      frontmatterProfile: 'okf',
+    })
+
+    await mem.extract({ messages: conversation(8) })
+
+    const note = (
+      await store.read(scopeTopic('global', 'tenant-a', 'feedback-testing.md'))
+    ).toString('utf8')
+    // OKF keys present; native name/modified keys replaced by title/timestamp.
+    expect(note).toContain('title: Feedback on testing')
+    expect(note).toMatch(/^timestamp:/m)
+    expect(note).not.toMatch(/^name:/m)
+    expect(note).not.toMatch(/^modified:/m)
+    // Body still follows the frontmatter.
+    expect(note).toContain('Prefer integration tests over snapshots.')
+
+    // And it reads back to the right logical fields.
+    const { frontmatter } = parseFrontmatter(note)
+    expect(frontmatter.name).toBe('Feedback on testing')
+    expect(frontmatter.type).toBe('feedback')
+    expect(frontmatter.modified).toBeDefined()
+  })
+
+  it('writes native-format notes by default (no profile set)', async () => {
+    const store = createMemStore()
+    const mem = createMemory({
+      store,
+      provider: stubProvider(extraction),
+      cursorStore: createStoreBackedCursorStore(store),
+      scope: 'project',
+      actorId: 'tenant-a',
+    })
+
+    await mem.extract({ messages: conversation(8) })
+
+    const note = (
+      await store.read(scopeTopic('global', 'tenant-a', 'feedback-testing.md'))
+    ).toString('utf8')
+    expect(note).toMatch(/^name: Feedback on testing$/m)
+    expect(note).not.toContain('title:')
+    expect(note).not.toMatch(/^timestamp:/m)
+  })
+})

--- a/sdks/ts/memory/src/memory/reflect.ts
+++ b/sdks/ts/memory/src/memory/reflect.ts
@@ -10,7 +10,7 @@
 
 import type { Logger, Message, Provider } from '../llm/index.js'
 import type { Store } from '../store/index.js'
-import { buildFrontmatter } from './frontmatter.js'
+import { type FrontmatterProfile, buildFrontmatter } from './frontmatter.js'
 import { parseFrontmatter } from './frontmatter.js'
 import { reflectionPath, scopeIndex, scopeTopic } from './paths.js'
 import { fireReflectionEnd, fireReflectionStart } from './plugins.js'
@@ -30,6 +30,7 @@ export type ReflectDeps = {
   readonly plugins: readonly Plugin[]
   readonly defaultScope: Scope
   readonly defaultActorId: string
+  readonly frontmatterProfile?: FrontmatterProfile
 }
 
 export const createReflect = (deps: ReflectDeps) => {
@@ -67,7 +68,7 @@ export const createReflect = (deps: ReflectDeps) => {
     }
 
     const path = reflectionPath(args.sessionId)
-    const fileContent = buildReflectionFile(parsed, args.sessionId, scope)
+    const fileContent = buildReflectionFile(parsed, args.sessionId, scope, deps.frontmatterProfile)
 
     try {
       await deps.store.batch({ reason: 'reflect' }, async (b) => {
@@ -76,6 +77,7 @@ export const createReflect = (deps: ReflectDeps) => {
           actorId,
           sessionId: args.sessionId,
           heuristics: parsed.heuristics,
+          profile: deps.frontmatterProfile,
         })
       })
     } catch (err) {
@@ -194,19 +196,27 @@ const buildReflectionPrompt = (messages: readonly Message[]): string => {
   return parts.join('\n')
 }
 
-const buildReflectionFile = (r: ParsedReflection, sessionId: string, scope: Scope): string => {
+const buildReflectionFile = (
+  r: ParsedReflection,
+  sessionId: string,
+  scope: Scope,
+  profile?: FrontmatterProfile,
+): string => {
   const now = new Date().toISOString()
-  const fm = buildFrontmatter({
-    extra: {
-      should_record_episode: r.shouldRecordEpisode ? 'true' : 'false',
+  const fm = buildFrontmatter(
+    {
+      extra: {
+        should_record_episode: r.shouldRecordEpisode ? 'true' : 'false',
+      },
+      type: 'reflection',
+      scope,
+      created: now,
+      modified: now,
+      source: 'reflection',
+      session_id: sessionId,
     },
-    type: 'reflection',
-    scope,
-    created: now,
-    modified: now,
-    source: 'reflection',
-    session_id: sessionId,
-  })
+    { profile },
+  )
   const body: string[] = []
   body.push(`# Session ${sessionId}`)
   body.push('')
@@ -239,6 +249,7 @@ const persistHeuristicsInBatch = async (
     readonly actorId: string
     readonly sessionId: string
     readonly heuristics: readonly Heuristic[]
+    readonly profile?: FrontmatterProfile | undefined
   },
 ): Promise<void> => {
   if (input.heuristics.length === 0) return
@@ -264,6 +275,7 @@ const persistHeuristicsInBatch = async (
           sessionId: input.sessionId,
           created: parsedExisting?.created,
           now,
+          profile: input.profile,
         }),
         'utf8',
       ),
@@ -317,23 +329,27 @@ const buildHeuristicFile = (input: {
   readonly sessionId: string
   readonly created?: string | undefined
   readonly now: string
+  readonly profile?: FrontmatterProfile | undefined
 }): string => {
   const { heuristic } = input
-  const fm = buildFrontmatter({
-    extra: {},
-    name: heuristic.antiPattern
-      ? `Anti-pattern: ${heuristic.rule}`
-      : `Heuristic: ${heuristic.rule}`,
-    description: heuristicDescription(heuristic),
-    type: heuristic.scope === 'project' ? 'project' : 'feedback',
-    scope: heuristic.scope,
-    created: input.created ?? input.now,
-    modified: input.now,
-    confidence: heuristic.confidence,
-    source: 'reflection',
-    session_id: input.sessionId,
-    tags: heuristicTags(heuristic),
-  })
+  const fm = buildFrontmatter(
+    {
+      extra: {},
+      name: heuristic.antiPattern
+        ? `Anti-pattern: ${heuristic.rule}`
+        : `Heuristic: ${heuristic.rule}`,
+      description: heuristicDescription(heuristic),
+      type: heuristic.scope === 'project' ? 'project' : 'feedback',
+      scope: heuristic.scope,
+      created: input.created ?? input.now,
+      modified: input.now,
+      confidence: heuristic.confidence,
+      source: 'reflection',
+      session_id: input.sessionId,
+      tags: heuristicTags(heuristic),
+    },
+    { profile: input.profile },
+  )
   const body = heuristic.antiPattern
     ? [
         `Anti-pattern: ${heuristic.rule}`,

--- a/sdks/ts/memory/src/memory/types.ts
+++ b/sdks/ts/memory/src/memory/types.ts
@@ -19,6 +19,7 @@ import type {
   EpisodeRecordArgs,
   RecordEpisodeResult,
 } from './episodes.js'
+import type { FrontmatterProfile } from './frontmatter.js'
 import type {
   DetectAndPersistProceduralRecordsArgs,
   ListProceduralRecordsArgs,
@@ -317,6 +318,13 @@ export type MemoryOpts = {
   readonly extractMaxRecent?: number
   /** Optional live contextualiser for extracted facts. */
   readonly contextualPrefixBuilder?: ContextualPrefixBuilder
+  /**
+   * Frontmatter serialisation profile for notes this instance writes. Defaults
+   * to `default` (the native field set; existing brains are unaffected). Set to
+   * `okf` to emit Open Knowledge Format shaped frontmatter. Reads tolerate both
+   * formats regardless of this setting, so no migration is needed to switch.
+   */
+  readonly frontmatterProfile?: FrontmatterProfile
 }
 
 /** Arguments accepted by `extract`. */

--- a/spec/STORAGE.md
+++ b/spec/STORAGE.md
@@ -215,3 +215,65 @@ const store = await createGitStore({
 ```
 
 Language SDKs. Go and Python SDKs MUST expose the same two-type shape (`GitSignPayload` with a single `payload: string` field; `GitSignFn` taking the payload and returning a future-of-string). The callback MUST receive the pre-hashed commit object verbatim and MUST return the detached armored signature. Implementations MUST invoke the callback at every batch commit and the init commit, and MUST NOT invoke it for tags or pushes in v1.0.
+
+## Note frontmatter profiles
+
+Memory notes are markdown files that open with a YAML frontmatter block. The
+canonical field set (the **`default` profile**) is:
+
+```
+---
+name: <concept title>
+description: <one-line summary>
+type: <user | feedback | project | reference | reflection | episode>
+scope: <global | project | agent>
+created: <RFC3339>
+modified: <RFC3339>
+source: <session | reflection | episode | …>
+session_id: <id>
+tags: [a, b]
+---
+```
+
+The writer also supports an opt-in **`okf` profile** that serialises the same
+note as [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+frontmatter for interoperability with OKF tooling, mapping the core fields and
+preserving everything else as OKF extension keys:
+
+| Native field | OKF profile |
+|---|---|
+| `name` | `title` |
+| `modified` (else `created`) | `timestamp` |
+| `type`, `description`, `tags` | unchanged (OKF core) |
+| `created`, `scope`, `source`, `session_id`, `confidence`, … | retained as OKF extension keys |
+
+```
+---
+type: project
+title: <concept title>
+description: <one-line summary>
+tags: [a, b]
+timestamp: <RFC3339>
+created: <RFC3339>
+scope: global
+source: session
+session_id: <id>
+---
+```
+
+Rules implementations MUST follow:
+
+- The profile is a **write-time** choice. `default` is the default and its
+  output is byte-for-byte unchanged from prior releases; existing brains are
+  never rewritten on read.
+- **Readers MUST be profile-agnostic.** The frontmatter parser MUST accept both
+  key sets — treating `title` as an alias of `name` and `timestamp` as an alias
+  of `modified` — so a brain may freely mix formats and switching profiles needs
+  no migration. When a note carries both a native key and its alias, the native
+  key wins.
+- The `okf` projection MUST round-trip: parsing an `okf`-written note MUST yield
+  a frontmatter equivalent to the source (the SDK preserves `created` and the
+  native-only fields as extension keys for this reason).
+
+The TypeScript reference is `sdks/ts/memory/src/memory/frontmatter.ts`; the
+profile is selected per `Memory` instance via `MemoryOpts.frontmatterProfile`.


### PR DESCRIPTION
## Summary

Adds an **opt-in Open Knowledge Format (OKF) profile** for memory note frontmatter, plus **backwards-compatible reads** of OKF-shaped notes. The goal is interoperability with [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) tooling without changing the on-disk format anyone already has.

The change lives almost entirely at one seam — `src/memory/frontmatter.ts`, the single serialiser/parser used by extract, recall, reflect, consolidate and episodes — so the surface area is small and the blast radius is contained.

## Convert existing brains, or stay backwards-compatible?

**Backwards-compatible, no forced conversion.** Concretely:

1. **`default` stays the default and is byte-for-byte unchanged.** Existing brains are never rewritten on read or upgrade. (`buildFrontmatter(fm)` === `buildFrontmatter(fm, { profile: 'default' })`, asserted in tests.)
2. **Readers are profile-agnostic.** `parseFrontmatter` now also understands the OKF aliases (`title`→`name`, `timestamp`→`modified`). A brain can therefore *mix* `default` and `okf` notes and everything still recalls — so switching a deployment to `okf` needs **no migration**, and rolling back is equally free.
3. **The profile is a write-time choice**, selected per `Memory` instance via `MemoryOpts.frontmatterProfile` (default `'default'`).

This is deliberately the smallest, lowest-risk thing that delivers OKF interop: a one-way migration or a format flip would be a breaking change for every existing brain and every other SDK reader, whereas reader-tolerance + an opt-in writer is additive and reversible. A bulk reformatter can always be layered on later as a separate utility, but nothing here requires one.

## What it does

`buildFrontmatter(fm, { profile: 'okf' })` projects the canonical frontmatter onto OKF's shape:

| Native field | OKF profile |
|---|---|
| `name` | `title` |
| `modified` (else `created`) | `timestamp` |
| `type`, `description`, `tags` | unchanged (OKF core) |
| `created`, `scope`, `source`, `session_id`, `confidence`, … | retained as OKF **extension keys** |

```yaml
---
type: project
title: Run the test suite
description: Always run the project suite.
tags: [testing, ci]
timestamp: 2026-02-01T00:00:00.000Z
created: 2026-01-01T00:00:00.000Z
scope: global
source: session
session_id: sess-123
---
```

The native-only fields are kept as OKF extension keys (OKF permits additional keys) specifically so the projection **round-trips losslessly**: parsing an `okf`-written note yields a frontmatter equivalent to the source. `timestamp` is sourced from `modified` (the recency signal recall ranks on), falling back to `created`.

**On the `type` vocabulary:** the projection is *structural* — it keeps the memory's own type values (`project`, `feedback`, `reflection`, …) rather than remapping them to a fixed OKF vocabulary, since OKF allows domain-specific types and a lossy remap would break recall and round-tripping. Happy to add a vocabulary mapping table if you'd prefer one.

## Implementation notes

- `MemoryOpts.frontmatterProfile?: FrontmatterProfile` is threaded to every note writer (extract / reflect / consolidate / episodes) via their existing deps; default `undefined` → `default` profile, so all current call sites are unaffected.
- When a note carries **both** a native key and its OKF alias, the native key wins (resolved after the parse loop, order-independent).
- `FrontmatterProfile` is exported from the package root. The serialiser/parser stay internal (`Frontmatter`/`parseFrontmatter` already collide with the `knowledge` module's same-named exports, so I kept the public surface to just the new type).

## Tests & spec

- `src/memory/frontmatter.test.ts` — default-unchanged regression guard, OKF shape + ordering, `created`-fallback timestamp, extension-key preservation, reader tolerance, native-wins precedence (both orders), OKF round-trip, and cross-format equivalence (a note rendered both ways parses to identical logical fields).
- `src/memory/okf-profile.test.ts` — end-to-end: `createMemory({ frontmatterProfile: 'okf' })` → `extract` writes OKF-shaped notes; default writes native.
- `spec/STORAGE.md` — documents both profiles, the mapping, and the reader-tolerance rule (incl. the requirement for other-language SDKs).

`bun run typecheck` clean; `bun run test` green (653 passed, 1 pre-existing skip).
