### PR TITLE
chore(release): v1.0.0 lockstep across all packages

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,4 +3,3 @@ reviews:
     enabled: true
     base_branches:
       - main
-      - develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.14
       - name: Install
         run: bun install --frozen-lockfile
       - name: Typecheck

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: '20'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.14
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/eval-smoke.yml
+++ b/.github/workflows/eval-smoke.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '20'
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.8
+          bun-version: 1.3.14
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.8'
+          bun-version: '1.3.14'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-### memory 0.4.0-rc.4
+Nothing yet.
+
+## [1.0.0] - 2026-08-04
+
+First stable major release. Every published package moves to 1.0.0 in
+lockstep: `@jeffs-brain/memory`, `@jeffs-brain/memory-pi`,
+`@jeffs-brain/memory-postgres`, `@jeffs-brain/memory-openfga`,
+`@jeffs-brain/memory-mcp`, `@jeffs-brain/install`, and the Go module
+(tagged `go/v1.0.0`). The `rc` npm channel is retired; `latest` points at
+1.0.0 for all packages. Development moves to trunk-based flow on `main`;
+the long-running `develop` branch is retired.
+
+### Publishing
+
+#### Fixed
+
+- Cross-package dependency ranges are now concrete (`^1.0.0`) instead of
+  `workspace:*`. `npm publish` does not rewrite workspace specifiers, so
+  `memory-postgres@0.2.0-rc.6` and `memory-mcp@0.1.0` shipped with a
+  literal `workspace:*` peer range on `@jeffs-brain/memory` that npm
+  consumers cannot resolve. The same defect was fixed by hand for
+  `memory-pi` 0.2.1; concrete ranges remove the bug class.
+- The MCP servers now report their real version. The TypeScript server
+  advertised `0.0.1` regardless of package version, and the Go
+  `memory-mcp` did the same.
+
+### memory
 
 #### Added
 
@@ -23,7 +49,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   treated as graph edges; broken links are tolerated. No I/O, no DDL. (#80)
   (TypeScript)
 
-### memory-postgres 0.2.0-rc.6
+### memory-postgres
 
 #### Added
 
@@ -45,8 +71,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   already satisfies the table CHECK, so no schema change is required. (#80)
   (TypeScript)
 
-### memory-postgres 0.2.0-rc.5
-
 #### Fixed
 
 - Thread the caller's `AbortSignal` through the Postgres retrieve path to the
@@ -62,10 +86,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   previous behaviour. The Go retriever already threaded its `context.Context`
   to `Embedder.Embed`; a mirrored parity test now guards that behaviour.
   (LLE-10559) (TypeScript, Go)
-
-### memory-postgres 0.2.0-rc.4
-
-#### Fixed
 
 - Memoise `PostgresStore.init()` ensure-schema so the additive-column DDL runs
   at most once per store instance. `init()` is now single-flight: the first call
@@ -87,10 +107,6 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   the ensure-schema transaction only; normal query transactions are unaffected.
   (#77, LLE-10529) (TypeScript)
 
-### memory-postgres 0.2.0-rc.3
-
-#### Fixed
-
 - Persist the `metadata` jsonb column on document write. `PostgresStore`
   previously inserted only path/content_hash/size/source/content/updated_at and
   dropped `metadata`, so the column stayed `{}` and the metadata-keyed graph
@@ -105,7 +121,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   A Go reader test pins that `computeDocumentOntologyEdges` consumes the
   persisted field. (#76, LLE-10520) (TypeScript)
 
-### memory (Go + TypeScript) — codec extraction priors
+### memory: codec extraction priors (Go + TypeScript)
 
 #### Added
 
@@ -129,7 +145,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   call and is honoured before and during the call; the Go path already
   honoured `context.Context` cancellation. (TypeScript)
 
-### memory (Go) 0.3.1
+### memory (Go)
+
+Shipped early as `go/v0.3.1` on 2026-05-30.
 
 #### Added
 
@@ -145,9 +163,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   articles under the brain and surface them through hybrid retrieval
   with no host-side index workaround. (Go)
 
-### memory-pi 0.2.2
+### memory-pi
 
-#### Added
+The 0.2.x line shipped incrementally to npm from the development branch;
+notable entries are consolidated below. Versions 0.2.3 through 0.2.7
+shipped without changelog entries.
+
+#### memory-pi 0.2.2: Added
 
 - `vectorExtensionPath` config option (also `MEMORY_PI_VECTOR_EXTENSION_PATH`
   env var) that overrides the path to sqlite-vec's loadable extension.
@@ -157,9 +179,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   the virtual fs, so the host must copy the native extension next to
   the executable and point memory-pi at it. (TS)
 
-### memory-pi 0.2.1
-
-#### Fixed
+#### memory-pi 0.2.1: Fixed
 
 - Replace `"@jeffs-brain/memory": "workspace:*"` in the published tarball
   with `"^0.3.0"` so consumers installing via `npm` / `bun add` outside
@@ -168,9 +188,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `pnpm publish`), so the 0.2.0 tarball was effectively uninstallable
   outside this repo. (TS)
 
-### memory-pi 0.2.0
-
-#### Added
+#### memory-pi 0.2.0: Added
 
 - `flatLayout` configuration option on `createMemoryExtension`. When
   `true`, the extension treats `brainRoot` as the brain directly and
@@ -192,7 +210,7 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `MEMORY_PI_SEARCH_INDEX_PATH`, `MEMORY_PI_BRAIN_ROOT`,
   `MEMORY_PI_BRAIN_ID` for ops-friendly configuration. (TS)
 
-#### Changed
+#### memory-pi 0.2.0: Changed
 
 - `resolveBrainPaths(root, brainId)` now accepts an optional third
   argument `{ flat?: boolean; searchIndexPath?: string }`. Existing
@@ -301,7 +319,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Go and Python SDKs are in the pipeline. See `go/` and `sdks/py/` README files.
 - Platform integration (multi-tenant backend) is private and unpublished.
 
-[Unreleased]: https://github.com/jeffs-brain/memory/compare/v0.4.0-rc.1...HEAD
+[Unreleased]: https://github.com/jeffs-brain/memory/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/jeffs-brain/memory/compare/v0.4.0-rc.1...v1.0.0
 [0.4.0-rc.1]: https://github.com/jeffs-brain/memory/compare/v0.3.0...v0.4.0-rc.1
 [0.3.0]: https://github.com/jeffs-brain/memory/compare/go/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/jeffs-brain/memory/compare/go/v0.2.2...go/v0.2.3

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Local-first, hosted-optional. Apache-2.0.
 
 | Language   | Package                        | Version | Install                                |
 | ---------- | ------------------------------ | ------- | -------------------------------------- |
-| TypeScript | `@jeffs-brain/memory`          | 0.2.0   | `npm i -g @jeffs-brain/memory`         |
-| TypeScript | `@jeffs-brain/memory-postgres` | 0.1.0   | `npm i @jeffs-brain/memory-postgres`   |
-| TypeScript | `@jeffs-brain/memory-openfga`  | 0.1.0   | `npm i @jeffs-brain/memory-openfga`    |
-| TypeScript | `@jeffs-brain/memory-mcp`      | 0.1.0   | `npx -y @jeffs-brain/memory-mcp`       |
-| TypeScript | `@jeffs-brain/install`         | 0.1.0   | `npx @jeffs-brain/install`             |
-| Go         | `github.com/jeffs-brain/memory/go` | 0.2.3   | `go install github.com/jeffs-brain/memory/go/cmd/memory@v0.2.3` |
-| Go         | `cmd/memory-mcp`               | 0.2.3   | `go install github.com/jeffs-brain/memory/go/cmd/memory-mcp@v0.2.3` |
+| TypeScript | `@jeffs-brain/memory`          | 1.0.0   | `npm i -g @jeffs-brain/memory`         |
+| TypeScript | `@jeffs-brain/memory-postgres` | 1.0.0   | `npm i @jeffs-brain/memory-postgres`   |
+| TypeScript | `@jeffs-brain/memory-openfga`  | 1.0.0   | `npm i @jeffs-brain/memory-openfga`    |
+| TypeScript | `@jeffs-brain/memory-mcp`      | 1.0.0   | `npx -y @jeffs-brain/memory-mcp`       |
+| TypeScript | `@jeffs-brain/install`         | 1.0.0   | `npx @jeffs-brain/install`             |
+| Go         | `github.com/jeffs-brain/memory/go` | 1.0.0   | `go install github.com/jeffs-brain/memory/go/cmd/memory@v1.0.0` |
+| Go         | `cmd/memory-mcp`               | 1.0.0   | `go install github.com/jeffs-brain/memory/go/cmd/memory-mcp@v1.0.0` |
 | Python     | `jeffs-brain-memory`           | 0.0.1 (pre-publish) | `pip install jeffs-brain-memory` or `uv add jeffs-brain-memory` |
 | Python     | `jeffs-brain-memory-mcp`       | 0.1.0   | `uvx jeffs-brain-memory-mcp`           |
 
@@ -136,7 +136,7 @@ Full walkthrough: [docs.jeffsbrain.com/getting-started/typescript/](https://docs
 ### Go
 
 ```bash
-go install github.com/jeffs-brain/memory/go/cmd/memory@v0.2.3
+go install github.com/jeffs-brain/memory/go/cmd/memory@v1.0.0
 memory version
 memory serve --addr 127.0.0.1:18841
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "install": {
       "name": "@jeffs-brain/install",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "bin": {
         "jeffs-brain-install": "./dist/index.js",
       },
@@ -29,7 +29,7 @@
     },
     "mcp/ts": {
       "name": "@jeffs-brain/memory-mcp",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "bin": {
         "memory-mcp": "./dist/index.js",
       },
@@ -38,16 +38,16 @@
         "zod": "^3.23.0",
       },
       "devDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
         "vitest": "^2.1.8",
       },
       "peerDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
       },
     },
     "sdks/ts/memory": {
       "name": "@jeffs-brain/memory",
-      "version": "0.4.0-rc.3",
+      "version": "1.0.0",
       "bin": {
         "memory": "./dist/cli.js",
       },
@@ -71,18 +71,18 @@
     },
     "sdks/ts/memory-openfga": {
       "name": "@jeffs-brain/memory-openfga",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "devDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
         "vitest": "^2.1.8",
       },
       "peerDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
       },
     },
     "sdks/ts/memory-pi": {
       "name": "@jeffs-brain/memory-pi",
-      "version": "0.2.7",
+      "version": "1.0.0",
       "dependencies": {
         "@jeffs-brain/memory": "workspace:*",
         "zod": "^3",
@@ -101,19 +101,19 @@
     },
     "sdks/ts/memory-postgres": {
       "name": "@jeffs-brain/memory-postgres",
-      "version": "0.2.0-rc.5",
+      "version": "1.0.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
         "postgres": "^3.4.9",
       },
       "devDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
         "@testcontainers/postgresql": "^11.14.0",
         "testcontainers": "^11.14.0",
         "vitest": "^2.1.8",
       },
       "peerDependencies": {
-        "@jeffs-brain/memory": "workspace:*",
+        "@jeffs-brain/memory": "^1.0.0",
       },
     },
   },

--- a/docs/src/content/docs/getting-started/go.mdx
+++ b/docs/src/content/docs/getting-started/go.mdx
@@ -8,7 +8,7 @@ sidebar:
 ## Install
 
 ```bash
-go install github.com/jeffs-brain/memory/go/cmd/memory@v0.2.3
+go install github.com/jeffs-brain/memory/go/cmd/memory@v1.0.0
 ```
 
 The binary is named `memory` and lives under `$GOPATH/bin` (usually `~/go/bin`). Ensure that's on your `PATH`.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,7 +33,7 @@ Cross-SDK eval parity today is the shared daemon surface in three scenarios: `as
   </TabItem>
   <TabItem label="Go">
     ```bash
-    go install github.com/jeffs-brain/memory/go/cmd/memory@v0.2.3
+    go install github.com/jeffs-brain/memory/go/cmd/memory@v1.0.0
     memory version
     memory serve --addr 127.0.0.1:18841
     ```
@@ -80,9 +80,9 @@ That registers a stdio MCP server with Claude Code. The same package works with 
 
 | Language   | Package                            | Status                                      |
 | ---------- | ---------------------------------- | ------------------------------------------- |
-| TypeScript | `@jeffs-brain/memory`              | v0.2.0                                      |
-| TypeScript | `@jeffs-brain/memory-mcp`          | v0.1.0                                      |
-| TypeScript | `@jeffs-brain/memory-postgres`     | v0.1.0                                      |
-| TypeScript | `@jeffs-brain/memory-openfga`      | v0.1.0                                      |
-| Go         | `github.com/jeffs-brain/memory/go` | v0.2.3: daemon, MCP wrapper, native LME runner |
+| TypeScript | `@jeffs-brain/memory`              | v1.0.0                                      |
+| TypeScript | `@jeffs-brain/memory-mcp`          | v1.0.0                                      |
+| TypeScript | `@jeffs-brain/memory-postgres`     | v1.0.0                                      |
+| TypeScript | `@jeffs-brain/memory-openfga`      | v1.0.0                                      |
+| Go         | `github.com/jeffs-brain/memory/go` | v1.0.0: daemon, MCP wrapper, native LME runner |
 | Python     | `jeffs-brain-memory`               | v0.0.1 (pre-publish): CLI, daemon, shared eval scenarios |

--- a/go/cmd/memory-mcp/main.go
+++ b/go/cmd/memory-mcp/main.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	serverName    = "@jeffs-brain/memory-mcp"
-	serverVersion = "0.0.1"
+	serverVersion = "1.0.0"
 )
 
 func main() {

--- a/go/cmd/memory/version.go
+++ b/go/cmd/memory/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 // version is the released Go CLI version.
-const version = "0.4.0-rc.3"
+const version = "1.0.0"
 
 func versionCmd() *cobra.Command {
 	return &cobra.Command{

--- a/install/package.json
+++ b/install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/install",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "One-shot npx orchestrator that wires the @jeffs-brain/memory-mcp server into Claude Code, Claude Desktop, Cursor, Windsurf, and Zed configs.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",

--- a/mcp/ts/package.json
+++ b/mcp/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-mcp",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Model Context Protocol stdio server for @jeffs-brain/memory, exposing eleven memory tools with zero-config local and hosted modes.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",
@@ -56,10 +56,10 @@
     "zod": "^3.23.0"
   },
   "peerDependencies": {
-    "@jeffs-brain/memory": "workspace:*"
+    "@jeffs-brain/memory": "^1.0.0"
   },
   "devDependencies": {
-    "@jeffs-brain/memory": "workspace:*",
+    "@jeffs-brain/memory": "^1.0.0",
     "vitest": "^2.1.8"
   }
 }

--- a/mcp/ts/src/server.ts
+++ b/mcp/ts/src/server.ts
@@ -16,7 +16,7 @@ import { type Tool, type ToolResult, tools } from './tools/index.js'
 import type { ToolContext } from './tools/types.js'
 
 export const SERVER_NAME = '@jeffs-brain/memory-mcp'
-export const SERVER_VERSION = '0.0.1'
+export const SERVER_VERSION = '1.0.0'
 
 type ToolRegistry = ReadonlyMap<string, Tool>
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "workspaces": ["sdks/ts/*", "mcp/ts", "install"],
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.14",
   "scripts": {
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc -b",

--- a/scripts/publish-if-needed.sh
+++ b/scripts/publish-if-needed.sh
@@ -23,7 +23,8 @@ if [[ "$local_version" == *-* ]]; then
 fi
 
 # Provenance requires the tag to be on the default branch (main).
-# RC candidates are tagged on develop, so we skip provenance for prereleases.
+# Prerelease tags may sit on short-lived branches, so provenance is skipped
+# for any version containing a prerelease suffix.
 provenance_flag="--provenance"
 if [[ "$local_version" == *-* ]]; then
   provenance_flag=""

--- a/sdks/ts/memory-openfga/package.json
+++ b/sdks/ts/memory-openfga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-openfga",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "OpenFGA authorisation adapter for @jeffs-brain/memory, implementing the AccessControlProvider contract over plain fetch.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",
@@ -39,10 +39,10 @@
     "prepublishOnly": "bun run typecheck && bun run test && bun run build"
   },
   "peerDependencies": {
-    "@jeffs-brain/memory": "workspace:*"
+    "@jeffs-brain/memory": "^1.0.0"
   },
   "devDependencies": {
-    "@jeffs-brain/memory": "workspace:*",
+    "@jeffs-brain/memory": "^1.0.0",
     "vitest": "^2.1.8"
   }
 }

--- a/sdks/ts/memory-pi/package.json
+++ b/sdks/ts/memory-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-pi",
-  "version": "0.2.7",
+  "version": "1.0.0",
   "description": "Pi extension for the @jeffs-brain/memory pipeline. Recall, extract, reflect, consolidate on every pi session via four lifecycle hooks plus 11 memory_* tools.",
   "license": "Apache-2.0",
   "type": "module",
@@ -39,7 +39,7 @@
     "typebox": "^1"
   },
   "dependencies": {
-    "@jeffs-brain/memory": "workspace:*",
+    "@jeffs-brain/memory": "^1.0.0",
     "zod": "^3"
   },
   "devDependencies": {

--- a/sdks/ts/memory-postgres/package.json
+++ b/sdks/ts/memory-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory-postgres",
-  "version": "0.2.0-rc.6",
+  "version": "1.0.0",
   "description": "Postgres and pgvector adapter for @jeffs-brain/memory: tsvector BM25, halfvec cosine, and RRF hybrid retrieval.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",
@@ -59,10 +59,10 @@
     "postgres": "^3.4.9"
   },
   "peerDependencies": {
-    "@jeffs-brain/memory": "workspace:*"
+    "@jeffs-brain/memory": "^1.0.0"
   },
   "devDependencies": {
-    "@jeffs-brain/memory": "workspace:*",
+    "@jeffs-brain/memory": "^1.0.0",
     "@testcontainers/postgresql": "^11.14.0",
     "testcontainers": "^11.14.0",
     "vitest": "^2.1.8"

--- a/sdks/ts/memory/package.json
+++ b/sdks/ts/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jeffs-brain/memory",
-  "version": "0.4.0-rc.4",
+  "version": "1.0.0",
   "description": "Local-first memory and hybrid retrieval library for LLM agents with pluggable stores, BM25 plus vector search, and a four-stage memory pipeline.",
   "license": "Apache-2.0",
   "author": "Alex J <alex@lleverage.ai>",


### PR DESCRIPTION
First stable major release. All npm packages and the Go module move to 1.0.0 in lockstep.

## Changes
- Version bumps: memory 0.4.0-rc.4 -> 1.0.0, memory-postgres 0.2.0-rc.6 -> 1.0.0, memory-pi 0.2.7 -> 1.0.0, memory-openfga / memory-mcp / install 0.1.0 -> 1.0.0, Go CLI 0.4.0-rc.3 -> 1.0.0.
- Publishing fix: cross-package ranges are concrete (^1.0.0) instead of workspace:*. npm publish does not rewrite workspace specifiers, so memory-postgres@0.2.0-rc.6 and memory-mcp@0.1.0 shipped unresolvable peer ranges (same defect fixed by hand for memory-pi 0.2.1).
- MCP servers (TS and Go) now report their real version instead of 0.0.1.
- CHANGELOG consolidated: rc-era entries fold into a 1.0.0 section, go/v0.3.1 marked as shipped.
- README + docs site version tables and install snippets updated.
- coderabbit base branches drop develop (trunk-based on main after this lands).
- bun.lock refreshed (also corrects a stale 0.4.0-rc.3 workspace entry).

## Validation
- bun typecheck, test, build green locally (two pre-existing environment-only failures: TZ-dependent cron tests pass under TZ=UTC, ffmpeg-version-dependent video integration tests; neither touched by this diff).
- go build ./... green, go test ./cmd/memory ./cmd/memory-mcp green, memory version prints 1.0.0 (matches the release gate for v1.0.0 and go/v1.0.0 tags).

## After merge
Tag v1.0.0 and go/v1.0.0 on main; the release workflow publishes all six npm packages and cuts the GitHub releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Released version 1.0.0 across the SDK, CLI, MCP server, and integration packages.
  * Updated package references to use the stable 1.0.0 release.

* **Documentation**
  * Updated installation instructions, SDK version matrices, and quick-start examples to reference 1.0.0.
  * Added consolidated 1.0.0 release notes covering recent features and fixes.

* **Maintenance**
  * Updated release and review configuration for the stable release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->